### PR TITLE
feat: consolidate builder agents into Secretary with hiring/install/h…

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -351,6 +351,20 @@ Agent completes work
 | Task `review` unhandled | > 12h | Report to human |
 | Task `assigned` not started | > 4h | Remind Agent -> reassign |
 
+### 4.7 Agent Lifecycle & Sourcing
+
+Agents can be sourced from three paths:
+
+| Source | Tool | Flow |
+|--------|------|------|
+| **Built-in template** | `team_hire_agent` | Browse `team_list_templates` → hire → onboard |
+| **Builder artifact** | `builder_install` | Custom-created or Hub-downloaded package in `~/.markus/builder-artifacts/` → install → onboard |
+| **Markus Hub** | `hub_install` | Search `hub_search` → download + install in one step → onboard |
+
+The **Secretary** agent is the sole default agent (builder agents have been removed). The Secretary holds all building skills (`agent-building`, `team-building`, `skill-building`) and hub tools (`hub_search`, `hub_install`). All managers (including Secretary) have hiring tools (`team_hire_agent`, `team_list_templates`, `builder_install`, `builder_list`).
+
+The `BuilderService` (`packages/org-manager/src/builder-service.ts`) encapsulates artifact install/list logic, used by both the HTTP API and agent tools.
+
 ---
 
 ## 5. Database Schema

--- a/docs/PROMPT-ENGINEERING.md
+++ b/docs/PROMPT-ENGINEERING.md
@@ -92,6 +92,7 @@ Contains:
 - Manager info (for workers)
 - Colleague list (name, role, type, status, skills)
 - Human team members
+- **Manager Responsibilities** (for managers): Routing, Coordination, Reporting, Cross-team, Escalation, Hiring
 
 #### Task Board (§19)
 Source: `opts.assignedTasks`.  
@@ -308,7 +309,7 @@ The heartbeat prompt is assembled inline (not via `buildSystemPrompt`) and inclu
 8. When `background_exec` sessions have finished since the last turn, a `## Background Processes Completed` section is included so the model sees completion summaries on the next heartbeat
 9. Conditional actions (failed bg processes, blocked tasks, completed dependencies, patterns)
 
-Tool whitelist: `task_list`, `task_update`, `task_get`, `task_note`, `task_create`, `file_read`, `file_edit`, `agent_send_message`, `requirement_propose`, `requirement_list`, `memory_save`, `memory_search`, `memory_update_longterm`, `discover_tools`, `notify_user`, `request_user_chat`. Managers additionally get: `task_board_health`, `task_cleanup_duplicates`, `task_assign`, `team_status`, `deliverable_create`, `deliverable_search`.
+Tool whitelist: `task_list`, `task_update`, `task_get`, `task_note`, `task_create`, `file_read`, `file_edit`, `agent_send_message`, `requirement_propose`, `requirement_list`, `memory_save`, `memory_search`, `memory_update_longterm`, `discover_tools`, `notify_user`, `request_user_chat`. Managers additionally get: `task_board_health`, `task_cleanup_duplicates`, `task_assign`, `team_status`, `deliverable_create`, `deliverable_search`, `team_hire_agent`, `team_list_templates`, `builder_install`, `builder_list`. Secretary (with building skills) additionally gets: `hub_search`, `hub_install`.
 
 Agent-to-user communication:
 | Situation | Tool | Example |
@@ -400,12 +401,13 @@ This ensures that modern models with large output windows are not artificially c
 `ToolSelector.selectTools()` determines which tools appear in each LLM call:
 
 1. **Always-on tools**: Core set always included (e.g., `memory_save`, `memory_search`, `file_read`, `file_write`, `task_create`, `task_list`, `spawn_subagent`, `spawn_subagents`, etc.)
-2. **Manager-only tools**: Added when `isManager=true` (e.g., `task_assign`, `team_status`)
-3. **Task-execution tools**: Added when `isTaskExecution=true` (e.g., `task_submit_review`, `subtask_create`)
-4. **Recently used tools**: Tools used in recent calls are re-included to maintain continuity
-5. **Activated tools**: Tools the agent explicitly activated via `discover_tools`
-6. **Skill-provided tools**: MCP tools from activated skills
-7. **`discover_tools` meta-tool**: Always present, enabling agents to list/activate/install skills at runtime
+2. **Manager-only tools**: Added when `isManager=true` (e.g., `task_assign`, `team_status`, `team_hire_agent`, `team_list_templates`, `builder_install`, `builder_list`)
+3. **Hub tools**: Added for agents with building skills — Secretary only (e.g., `hub_search`, `hub_install`)
+4. **Task-execution tools**: Added when `isTaskExecution=true` (e.g., `task_submit_review`, `subtask_create`)
+5. **Recently used tools**: Tools used in recent calls are re-included to maintain continuity
+6. **Activated tools**: Tools the agent explicitly activated via `discover_tools`
+7. **Skill-provided tools**: MCP tools from activated skills
+8. **`discover_tools` meta-tool**: Always present, enabling agents to list/activate/install skills at runtime
 
 ---
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -463,8 +463,18 @@ async function startServer(config: ReturnType<typeof loadConfig>, values: Record
   // Seed default team + Secretary agent (runs for both DB and in-memory mode)
   await orgService.seedDefaultTeam(firstOrgId, 'default');
 
-  // Ensure builder agents exist (idempotent — skips if already created)
-  await orgService.seedBuilderAgents(firstOrgId, skillRegistry);
+  // Register builder context providers on agents with building skills (e.g. Secretary)
+  orgService.registerBuilderContextProviders(skillRegistry);
+
+  // Wire BuilderService and HubClient into AgentManager for hire/install/hub tools
+  const builderService = apiServer.getBuilderService();
+  if (builderService) {
+    agentManager.setBuilderService(builderService);
+  }
+  const hubClient = apiServer.getHubClient();
+  if (hubClient) {
+    agentManager.setHubClient(hubClient);
+  }
 
   // Wire skill search/install callbacks so agents can discover and install remote skills
   agentManager.setSkillSearcher(async (query) => searchRegistries(query));

--- a/packages/core/src/agent-manager.ts
+++ b/packages/core/src/agent-manager.ts
@@ -21,6 +21,7 @@ import { createBuiltinTools } from './tools/builtin.js';
 import { MCPClientManager } from './tools/mcp-client.js';
 import { BrowserSessionManager } from './tools/browser-session.js';
 import { createManagerTools } from './tools/manager.js';
+import { createHubTools } from './tools/hub-tools.js';
 import { createA2ATools, type A2AContext } from './tools/a2a.js';
 import { createStructuredA2ATools } from './tools/a2a-structured.js';
 import { createAgentTaskTools, type AgentTaskContext } from './tools/task-tools.js';
@@ -320,6 +321,8 @@ export class AgentManager {
   private delegationManager: DelegationManager;
   private _maxToolIterations = Infinity;
   private templateRegistry?: TemplateRegistry;
+  private builderService?: { listArtifacts: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>; installArtifact: (type: 'agent' | 'team' | 'skill', name: string) => Promise<{ type: string; installed: unknown }> };
+  private hubClient?: { search: (opts?: { type?: string; query?: string }) => Promise<Array<{ id: string; name: string; type: string; description: string; author: string; version?: string; downloads?: number }>>; downloadAndInstall: (itemId: string) => Promise<{ type: string; installed: unknown }> };
   private groupChatHandlers?: {
     sendGroupMessage: (
       channelKey: string,
@@ -1080,9 +1083,44 @@ export class AgentManager {
         getTaskBoardHealth: this.taskService?.getTaskBoardHealth
           ? (orgId: string) => this.taskService!.getTaskBoardHealth!(orgId)
           : undefined,
+        hireFromTemplate: this.templateRegistry
+          ? async (templateId: string, name: string, skills?: string[]) => {
+              const newAgent = await this.createAgentFromTemplate({
+                templateId,
+                name,
+                orgId: config.orgId ?? 'default',
+                teamId: config.teamId,
+                overrides: skills ? { skills } : undefined,
+              });
+              await this.startAgent(newAgent.id);
+              return { id: newAgent.id, name: newAgent.config.name, role: newAgent.role.name };
+            }
+          : undefined,
+        listTemplates: this.templateRegistry
+          ? () => this.templateRegistry!.list().map(t => ({
+              id: t.id, name: t.name, description: t.description, roleId: t.roleId, category: t.category ?? 'general',
+            }))
+          : undefined,
+        installArtifact: this.builderService
+          ? (type: 'agent' | 'team' | 'skill', name: string) => this.builderService!.installArtifact(type, name)
+          : undefined,
+        listArtifacts: this.builderService
+          ? (type?: 'agent' | 'team' | 'skill') => this.builderService!.listArtifacts(type)
+          : undefined,
       });
       for (const tool of managerTools) {
         agent.registerTool(tool);
+      }
+
+      // Hub tools for agents with building skills (Secretary)
+      const BUILDING_SKILLS = new Set(['agent-building', 'team-building', 'skill-building']);
+      const hasBuilderSkill = config.skills?.some((s: string) => BUILDING_SKILLS.has(s));
+      if (hasBuilderSkill && this.hubClient) {
+        const hubTools = createHubTools({
+          searchHub: (opts) => this.hubClient!.search(opts),
+          downloadAndInstall: (itemId) => this.hubClient!.downloadAndInstall(itemId),
+        });
+        for (const tool of hubTools) agent.registerTool(tool);
       }
     }
 
@@ -1631,8 +1669,42 @@ export class AgentManager {
         getTaskBoardHealth: this.taskService?.getTaskBoardHealth
           ? (orgId: string) => this.taskService!.getTaskBoardHealth!(orgId)
           : undefined,
+        hireFromTemplate: this.templateRegistry
+          ? async (templateId: string, name: string, skills?: string[]) => {
+              const newAgent = await this.createAgentFromTemplate({
+                templateId,
+                name,
+                orgId: config.orgId ?? 'default',
+                teamId: config.teamId,
+                overrides: skills ? { skills } : undefined,
+              });
+              await this.startAgent(newAgent.id);
+              return { id: newAgent.id, name: newAgent.config.name, role: newAgent.role.name };
+            }
+          : undefined,
+        listTemplates: this.templateRegistry
+          ? () => this.templateRegistry!.list().map(t => ({
+              id: t.id, name: t.name, description: t.description, roleId: t.roleId, category: t.category ?? 'general',
+            }))
+          : undefined,
+        installArtifact: this.builderService
+          ? (type: 'agent' | 'team' | 'skill', name: string) => this.builderService!.installArtifact(type, name)
+          : undefined,
+        listArtifacts: this.builderService
+          ? (type?: 'agent' | 'team' | 'skill') => this.builderService!.listArtifacts(type)
+          : undefined,
       });
       for (const tool of managerTools) agent.registerTool(tool);
+
+      const BUILDING_SKILLS_R = new Set(['agent-building', 'team-building', 'skill-building']);
+      const hasBuilderSkillR = config.skills?.some((s: string) => BUILDING_SKILLS_R.has(s));
+      if (hasBuilderSkillR && this.hubClient) {
+        const hubTools = createHubTools({
+          searchHub: (opts) => this.hubClient!.search(opts),
+          downloadAndInstall: (itemId) => this.hubClient!.downloadAndInstall(itemId),
+        });
+        for (const tool of hubTools) agent.registerTool(tool);
+      }
     }
 
     if (this.agentAuditCallback) {
@@ -1931,6 +2003,14 @@ export class AgentManager {
 
   getTemplateRegistry(): TemplateRegistry | undefined {
     return this.templateRegistry;
+  }
+
+  setBuilderService(service: { listArtifacts: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>; installArtifact: (type: 'agent' | 'team' | 'skill', name: string) => Promise<{ type: string; installed: unknown }> }): void {
+    this.builderService = service;
+  }
+
+  setHubClient(client: { search: (opts?: { type?: string; query?: string }) => Promise<Array<{ id: string; name: string; type: string; description: string; author: string; version?: string; downloads?: number }>>; downloadAndInstall: (itemId: string) => Promise<{ type: string; installed: unknown }> }): void {
+    this.hubClient = client;
   }
 
   setGroupChatHandlers(handlers: {

--- a/packages/core/src/context-engine.ts
+++ b/packages/core/src/context-engine.ts
@@ -720,6 +720,7 @@ export class ContextEngine {
         lines.push('3. **Reporting** — Report your team\'s progress to human stakeholders');
         lines.push('4. **Cross-team** — Coordinate with other team managers via `agent_send_message` when work crosses team boundaries');
         lines.push('5. **Escalation** — Escalate issues that require human decision to the Owner');
+        lines.push('6. **Hiring** — Use `team_list_templates` + `team_hire_agent` to recruit agents; use `builder_install` to deploy custom-built or Hub-sourced artifacts');
       }
     } else {
       lines.push(`- Name: ${opts.agentName}`);

--- a/packages/core/src/tools/hub-tools.ts
+++ b/packages/core/src/tools/hub-tools.ts
@@ -1,0 +1,66 @@
+import type { AgentToolHandler } from '../agent.js';
+
+export interface HubToolsContext {
+  searchHub: (opts?: { type?: string; query?: string }) => Promise<Array<{ id: string; name: string; type: string; description: string; author: string; version?: string; downloads?: number }>>;
+  downloadAndInstall: (itemId: string) => Promise<{ type: string; installed: unknown }>;
+}
+
+export function createHubTools(ctx: HubToolsContext): AgentToolHandler[] {
+  return [
+    {
+      name: 'hub_search',
+      description: 'Search Markus Hub for community-published agents, teams, and skills. Returns a list of available items with descriptions and popularity.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          type: {
+            type: 'string',
+            enum: ['agent', 'team', 'skill'],
+            description: 'Filter by item type (optional)',
+          },
+          query: {
+            type: 'string',
+            description: 'Search query (optional)',
+          },
+        },
+      },
+      async execute(args: Record<string, unknown>): Promise<string> {
+        try {
+          const items = await ctx.searchHub({
+            type: args['type'] as string | undefined,
+            query: args['query'] as string | undefined,
+          });
+          return JSON.stringify({ items, count: items.length });
+        } catch (error) {
+          return JSON.stringify({ status: 'error', error: String(error) });
+        }
+      },
+    },
+    {
+      name: 'hub_install',
+      description: 'Download an item from Markus Hub and install it. Combines download, save as artifact, and install into a single step. For agents/teams: remember to onboard the new agent(s) after installation.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          item_id: { type: 'string', description: 'Hub item ID (from hub_search results)' },
+        },
+        required: ['item_id'],
+      },
+      async execute(args: Record<string, unknown>): Promise<string> {
+        try {
+          const result = await ctx.downloadAndInstall(args['item_id'] as string);
+          const isAgentOrTeam = result.type === 'agent' || result.type === 'team';
+          return JSON.stringify({
+            status: 'success',
+            ...result,
+            ...(isAgentOrTeam ? {
+              next_steps: 'Downloaded and installed from Hub. Next: onboard new agent(s) with project context via agent_send_message, then assign initial tasks via task_create.',
+            } : {}),
+          });
+        } catch (error) {
+          return JSON.stringify({ status: 'error', error: String(error) });
+        }
+      },
+    },
+  ];
+}

--- a/packages/core/src/tools/index.ts
+++ b/packages/core/src/tools/index.ts
@@ -15,3 +15,4 @@ export { createAgentTaskTools, type AgentTaskContext } from './task-tools.js';
 export { createMemoryTools, type AgentMemoryContext } from './memory.js';
 export { createSubagentTool, createParallelSubagentTool, runSubagentLoop, type SubagentContext, type SubagentProgressCallback } from './subagent.js';
 export { createSettingsTools, type SettingsToolsContext } from './settings.js';
+export { createHubTools, type HubToolsContext } from './hub-tools.js';

--- a/packages/core/src/tools/manager.ts
+++ b/packages/core/src/tools/manager.ts
@@ -10,6 +10,10 @@ export interface ManagerToolsContext {
   findDuplicateTasks?: (orgId: string) => Array<{ group: string; tasks: Array<{ id: string; title: string; status: string; createdAt: string }> }>;
   cleanupDuplicateTasks?: (orgId: string) => { cancelledIds: string[]; count: number };
   getTaskBoardHealth?: (orgId: string) => Record<string, unknown>;
+  hireFromTemplate?: (templateId: string, name: string, skills?: string[]) => Promise<{ id: string; name: string; role: string }>;
+  listTemplates?: () => Array<{ id: string; name: string; description: string; roleId: string; category: string }>;
+  installArtifact?: (type: 'agent' | 'team' | 'skill', name: string) => Promise<{ type: string; installed: unknown }>;
+  listArtifacts?: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>;
 }
 
 export function createManagerTools(ctx: ManagerToolsContext): AgentToolHandler[] {
@@ -138,6 +142,131 @@ export function createManagerTools(ctx: ManagerToolsContext): AgentToolHandler[]
               try {
                 const health = ctx.getTaskBoardHealth!(args['org_id'] as string);
                 return JSON.stringify({ status: 'success', ...health });
+              } catch (error) {
+                return JSON.stringify({ status: 'error', error: String(error) });
+              }
+            },
+          } as AgentToolHandler,
+        ]
+      : []),
+
+    ...(ctx.listTemplates
+      ? [
+          {
+            name: 'team_list_templates',
+            description: 'List available agent templates that can be hired. Each template has a role, description, and category.',
+            inputSchema: {
+              type: 'object',
+              properties: {},
+            },
+            async execute(): Promise<string> {
+              try {
+                const templates = ctx.listTemplates!();
+                return JSON.stringify({ templates, count: templates.length });
+              } catch (error) {
+                return JSON.stringify({ status: 'error', error: String(error) });
+              }
+            },
+          } as AgentToolHandler,
+        ]
+      : []),
+
+    ...(ctx.hireFromTemplate
+      ? [
+          {
+            name: 'team_hire_agent',
+            description: 'Hire a new agent from a template and add them to your team. After hiring, onboard the agent: send a welcome message with project context via agent_send_message, then assign initial tasks via task_create.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                template_id: { type: 'string', description: 'Template ID (from team_list_templates)' },
+                name: { type: 'string', description: 'Display name for the new agent' },
+                skills: {
+                  type: 'array',
+                  items: { type: 'string' },
+                  description: 'Optional skill IDs to assign',
+                },
+              },
+              required: ['template_id', 'name'],
+            },
+            async execute(args: Record<string, unknown>): Promise<string> {
+              try {
+                const result = await ctx.hireFromTemplate!(
+                  args['template_id'] as string,
+                  args['name'] as string,
+                  args['skills'] as string[] | undefined,
+                );
+                return JSON.stringify({
+                  status: 'success',
+                  agent: result,
+                  next_steps: 'Agent created and started. Next: onboard them with project context via agent_send_message, then assign initial tasks via task_create.',
+                });
+              } catch (error) {
+                return JSON.stringify({ status: 'error', error: String(error) });
+              }
+            },
+          } as AgentToolHandler,
+        ]
+      : []),
+
+    ...(ctx.listArtifacts
+      ? [
+          {
+            name: 'builder_list',
+            description: 'List builder artifacts (custom-created or Hub-downloaded agent/team/skill packages). These can be installed with builder_install.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: ['agent', 'team', 'skill'],
+                  description: 'Filter by artifact type (optional)',
+                },
+              },
+            },
+            async execute(args: Record<string, unknown>): Promise<string> {
+              try {
+                const artifacts = ctx.listArtifacts!(args['type'] as 'agent' | 'team' | 'skill' | undefined);
+                return JSON.stringify({ artifacts, count: artifacts.length });
+              } catch (error) {
+                return JSON.stringify({ status: 'error', error: String(error) });
+              }
+            },
+          } as AgentToolHandler,
+        ]
+      : []),
+
+    ...(ctx.installArtifact
+      ? [
+          {
+            name: 'builder_install',
+            description: 'Install a builder artifact — deploys an agent, team, or skill package into the live organization. For agents/teams: after installation, onboard with project context and assign initial tasks.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                type: {
+                  type: 'string',
+                  enum: ['agent', 'team', 'skill'],
+                  description: 'Artifact type',
+                },
+                name: { type: 'string', description: 'Artifact name (from builder_list)' },
+              },
+              required: ['type', 'name'],
+            },
+            async execute(args: Record<string, unknown>): Promise<string> {
+              try {
+                const result = await ctx.installArtifact!(
+                  args['type'] as 'agent' | 'team' | 'skill',
+                  args['name'] as string,
+                );
+                const isAgentOrTeam = result.type === 'agent' || result.type === 'team';
+                return JSON.stringify({
+                  status: 'success',
+                  ...result,
+                  ...(isAgentOrTeam ? {
+                    next_steps: 'Installed successfully. Next: onboard new agent(s) with project context via agent_send_message, then assign initial tasks via task_create.',
+                  } : {}),
+                });
               } catch (error) {
                 return JSON.stringify({ status: 'error', error: String(error) });
               }

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -1,9 +1,9 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { join, resolve, dirname } from 'node:path';
-import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync, copyFileSync, rmSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync, rmSync, statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { execSync } from 'node:child_process';
-import { createLogger, generateId, saveConfig, getTextContent, stripInternalBlocks, extractThinkBlocks, APP_VERSION, buildManifest, readManifest, manifestFilename, validateManifest, type TaskStatus, type TaskPriority, type TaskSortField, type SortOrder, type PackageType, type RequirementStatus } from '@markus/shared';
+import { createLogger, generateId, saveConfig, getTextContent, stripInternalBlocks, extractThinkBlocks, APP_VERSION, buildManifest, manifestFilename, type TaskStatus, type TaskPriority, type TaskSortField, type SortOrder, type PackageType, type RequirementStatus } from '@markus/shared';
 import {
   GatewayError,
   WorkflowEngine,
@@ -11,7 +11,6 @@ import {
   createDefaultTemplateRegistry,
   generateHandbook,
   GatewaySyncHandler,
-  readSkillInstructions,
   type TeamTemplateRegistry,
   type AgentToolHandler,
   type ExternalAgentGateway,
@@ -27,7 +26,6 @@ import {
   discoverSkillsInDir,
   WELL_KNOWN_SKILL_DIRS,
   type AgentManager,
-  type SkillCategory,
 } from '@markus/core';
 import type { ChannelMsg } from '@markus/storage';
 import { OrganizationService } from './org-service.js';

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -28,7 +28,7 @@ import {
   type AgentManager,
 } from '@markus/core';
 import type { ChannelMsg } from '@markus/storage';
-import { OrganizationService } from './org-service.js';
+import type { OrganizationService } from './org-service.js';
 import { BuilderService } from './builder-service.js';
 import type { TaskService } from './task-service.js';
 import type { HITLService } from './hitl-service.js';

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -31,6 +31,7 @@ import {
 } from '@markus/core';
 import type { ChannelMsg } from '@markus/storage';
 import { OrganizationService } from './org-service.js';
+import { BuilderService } from './builder-service.js';
 import type { TaskService } from './task-service.js';
 import type { HITLService } from './hitl-service.js';
 import type { BillingService } from './billing-service.js';
@@ -188,6 +189,7 @@ export class APIServer {
   private reviewService?: ReviewService;
   private registryCache?: Map<string, { data: unknown; ts: number }>;
   private templateRegistry?: TemplateRegistry;
+  private builderService?: BuilderService;
   private workflowEngine?: WorkflowEngine;
   private teamTemplateRegistry: TeamTemplateRegistry;
   private customGroupChats: Array<{
@@ -290,6 +292,85 @@ export class APIServer {
 
   setSkillRegistry(registry: SkillRegistry): void {
     this.skillRegistry = registry;
+    this.builderService = new BuilderService(
+      this.orgService,
+      registry,
+      (msg) => this.ws?.broadcast(msg as Parameters<WSBroadcaster['broadcast']>[0]),
+    );
+  }
+
+  getBuilderService(): BuilderService | undefined {
+    return this.builderService;
+  }
+
+  /**
+   * Returns a hub client that agents can use to search and install from Markus Hub.
+   * Reads the hub token from ~/.markus/hub-token on each call.
+   */
+  getHubClient(): {
+    search: (opts?: { type?: string; query?: string }) => Promise<Array<{ id: string; name: string; type: string; description: string; author: string; version?: string; downloads?: number }>>;
+    downloadAndInstall: (itemId: string) => Promise<{ type: string; installed: unknown }>;
+  } | undefined {
+    if (!this.builderService) return undefined;
+    const self = this;
+    return {
+      search: async (opts) => {
+        const hubUrl = self.hubUrl;
+        const token = self.readHubToken();
+        const params = new URLSearchParams();
+        if (opts?.type) params.set('type', opts.type);
+        if (opts?.query) params.set('q', opts.query);
+        const qs = params.toString();
+        const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+        if (token) headers['Authorization'] = `Bearer ${token}`;
+        const res = await fetch(`${hubUrl}/api/items${qs ? `?${qs}` : ''}`, { headers });
+        if (!res.ok) throw new Error(`Hub search failed: ${res.status}`);
+        const data = await res.json() as { items?: Array<Record<string, unknown>> };
+        return (data.items ?? []).map((item: Record<string, unknown>) => ({
+          id: item.id as string,
+          name: item.name as string,
+          type: (item.itemType ?? item.type ?? 'agent') as string,
+          description: (item.description ?? '') as string,
+          author: ((item.author as Record<string, unknown>)?.displayName ?? (item.author as Record<string, unknown>)?.username ?? '') as string,
+          version: item.version as string | undefined,
+          downloads: item.downloadCount as number | undefined,
+        }));
+      },
+      downloadAndInstall: async (itemId) => {
+        const hubUrl = self.hubUrl;
+        const token = self.readHubToken();
+        if (!token) throw new Error('Hub token not configured. Please login to Markus Hub first.');
+        const headers: Record<string, string> = { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` };
+        const res = await fetch(`${hubUrl}/api/items/${itemId}/download`, { method: 'POST', headers });
+        if (!res.ok) throw new Error(`Hub download failed: ${res.status}`);
+        const data = await res.json() as { name: string; itemType: string; files?: Record<string, string>; config?: unknown; description?: string };
+        const name = data.name;
+        const slug = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+        const mode = (data.itemType === 'team' ? 'team' : data.itemType === 'skill' ? 'skill' : 'agent') as 'agent' | 'team' | 'skill';
+        const typeDir = mode === 'agent' ? 'agents' : mode === 'team' ? 'teams' : 'skills';
+        const artDir = join(homedir(), '.markus', 'builder-artifacts', typeDir, slug);
+        mkdirSync(artDir, { recursive: true });
+        if (data.files && Object.keys(data.files).length > 0) {
+          for (const [fname, content] of Object.entries(data.files)) {
+            const filePath = join(artDir, fname);
+            mkdirSync(dirname(filePath), { recursive: true });
+            writeFileSync(filePath, content, 'utf-8');
+          }
+        } else if (data.config) {
+          writeFileSync(join(artDir, 'manifest.json'), JSON.stringify(data.config, null, 2), 'utf-8');
+        }
+        return self.builderService!.installArtifact(mode, slug);
+      },
+    };
+  }
+
+  private readHubToken(): string | undefined {
+    try {
+      const tokenPath = join(homedir(), '.markus', 'hub-token');
+      return existsSync(tokenPath) ? readFileSync(tokenPath, 'utf-8').trim() : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   setBillingService(service: BillingService): void {
@@ -2717,7 +2798,7 @@ export class APIServer {
           }
           // When a building skill is added, register builder dynamic context so the
           // agent can see available skills/roles, just like the seeded builder agents.
-          if (OrganizationService.BUILDING_SKILLS.has(skillName)) {
+          if (['agent-building', 'team-building', 'skill-building'].includes(skillName)) {
             agent.addDynamicContextProvider(
               () => this.orgService.buildBuilderDynamicContext(this.skillRegistry),
               'builder-context'
@@ -3786,27 +3867,9 @@ export class APIServer {
     // GET /api/builder/artifacts — scan all builder artifacts
     if (path === '/api/builder/artifacts' && req.method === 'GET') {
       try {
-        const baseDir = join(homedir(), '.markus', 'builder-artifacts');
-        const types = ['agents', 'teams', 'skills'] as const;
-        const artifacts: Array<{ type: string; name: string; meta: Record<string, unknown>; path: string; updatedAt: string }> = [];
-        const fsHelper = { existsSync, readFileSync: (p: string, _enc: 'utf-8') => readFileSync(p, 'utf-8'), join };
-
-        for (const typeDir of types) {
-          const dir = join(baseDir, typeDir);
-          if (!existsSync(dir)) continue;
-          for (const entry of readdirSync(dir, { withFileTypes: true })) {
-            if (!entry.isDirectory()) continue;
-            const artDir = join(dir, entry.name);
-            const type = (typeDir === 'agents' ? 'agent' : typeDir === 'teams' ? 'team' : 'skill') as PackageType;
-            const manifest = readManifest(artDir, type, fsHelper);
-            const meta: Record<string, unknown> = manifest ? { ...manifest } : { name: entry.name };
-            let updatedAt = new Date().toISOString();
-            try { updatedAt = statSync(artDir).mtime.toISOString(); } catch { /* ignore */ }
-            artifacts.push({ type, name: entry.name, meta, path: artDir, updatedAt });
-          }
-        }
-
-        artifacts.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+        const artifacts = this.builderService
+          ? this.builderService.listArtifacts()
+          : [];
         this.json(res, 200, { artifacts });
       } catch (err) {
         this.json(res, 500, { error: `Scan failed: ${String(err)}` });
@@ -4067,165 +4130,20 @@ export class APIServer {
         const rawType = installMatch[1]!;
         const name = decodeURIComponent(installMatch[2]!);
         const typeDir = rawType.endsWith('s') ? rawType : rawType + 's';
-        const type = typeDir === 'agents' ? 'agent' : typeDir === 'teams' ? 'team' : 'skill';
-        const artDir = join(homedir(), '.markus', 'builder-artifacts', typeDir, name);
+        const type = (typeDir === 'agents' ? 'agent' : typeDir === 'teams' ? 'team' : 'skill') as 'agent' | 'team' | 'skill';
 
-        if (!existsSync(artDir)) {
-          this.json(res, 404, { error: 'Artifact not found' });
+        if (!this.builderService) {
+          this.json(res, 500, { error: 'BuilderService not initialized' });
           return;
         }
 
         try {
-          const fsHelper = { existsSync, readFileSync: (p: string, _enc: 'utf-8') => readFileSync(p, 'utf-8'), join };
-          const installType = type as PackageType;
-          const manifest = readManifest(artDir, installType, fsHelper);
-          if (!manifest) {
-            this.json(res, 400, { error: `No ${manifestFilename(installType)} found in artifact package` });
-            return;
-          }
-
-          const validationErrors = validateManifest(manifest);
-          if (validationErrors.length > 0) {
-            this.json(res, 400, { error: `Invalid manifest: ${validationErrors.join('; ')}` });
-            return;
-          }
-
-          const mfName = manifestFilename(installType);
-
-          if (type === 'agent') {
-            const agentManager = this.orgService.getAgentManager();
-            const agentName = manifest.displayName ?? manifest.name ?? name;
-            const knownRoles = this.orgService.listAvailableRoles();
-            const requestedRole = manifest.agent?.roleName ?? 'developer';
-            const roleName = knownRoles.includes(requestedRole) ? requestedRole : 'developer';
-            const skills = manifest.dependencies?.skills ?? [];
-            const agentRole = manifest.agent?.agentRole ?? 'worker';
-
-            const agent = await this.orgService.hireAgent({
-              name: agentName,
-              roleName,
-              orgId: 'default',
-              agentRole,
-              skills,
-            });
-
-            const agentRoleDir = join(agentManager.getDataDir(), agent.id, 'role');
-            mkdirSync(agentRoleDir, { recursive: true });
-            for (const fname of readdirSync(artDir)) {
-              if (fname === mfName) continue;
-              const srcFile = join(artDir, fname);
-              if (statSync(srcFile).isFile()) {
-                copyFileSync(srcFile, join(agentRoleDir, fname));
-              }
-            }
-            writeFileSync(join(agentRoleDir, '.role-origin.json'), JSON.stringify({ customRole: true, source: 'builder-artifact', artifact: name, artifactType: 'agent' }));
-            agent.reloadRole();
-            await agentManager.startAgent(agent.id);
-
-            this.json(res, 201, { type: 'agent', agent: { id: agent.id, name: agent.config.name, role: agent.role.name, status: agent.getState().status } });
-
-          } else if (type === 'team') {
-            const agentManager = this.orgService.getAgentManager();
-            const teamName = manifest.displayName ?? manifest.name ?? name;
-            const team = await this.orgService.createTeam('default', teamName, manifest.description ?? '');
-            this.ws?.broadcast({
-              type: 'chat:group_created',
-              payload: { chatId: `group:${team.id}`, name: teamName, creatorId: '', creatorName: '' },
-              timestamp: new Date().toISOString(),
-            });
-
-            const announcementPath = join(artDir, 'ANNOUNCEMENT.md');
-            const normsPath = join(artDir, 'NORMS.md');
-            const announcements = existsSync(announcementPath) ? readFileSync(announcementPath, 'utf-8') : '';
-            const norms = existsSync(normsPath) ? readFileSync(normsPath, 'utf-8') : '';
-            this.orgService.ensureTeamDataDir(team.id, announcements, norms);
-
-            const members = manifest.team?.members ?? [];
-            const knownRoles = this.orgService.listAvailableRoles();
-            const createdAgents: Array<{ id: string; name: string; role: string }> = [];
-
-            for (const member of members) {
-              const count = member.count ?? 1;
-              const memberRole = member.role ?? 'worker';
-              const memberName = member.name ?? 'Agent';
-              const roleName = knownRoles.includes(member.roleName) ? member.roleName : 'developer';
-              const memberSkills = member.skills ?? [];
-              const memberSlug = memberName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
-              const memberFilesDir = join(artDir, 'members', memberSlug);
-
-              for (let i = 0; i < count; i++) {
-                const displayName = count > 1 ? `${memberName} ${i + 1}` : memberName;
-                const agent = await this.orgService.hireAgent({
-                  name: displayName,
-                  roleName,
-                  orgId: 'default',
-                  teamId: team.id,
-                  agentRole: memberRole,
-                  skills: memberSkills.length > 0 ? memberSkills : undefined,
-                });
-
-                const agentRoleDir = join(agentManager.getDataDir(), agent.id, 'role');
-                mkdirSync(agentRoleDir, { recursive: true });
-                if (existsSync(memberFilesDir)) {
-                  for (const fname of readdirSync(memberFilesDir)) {
-                    const srcFile = join(memberFilesDir, fname);
-                    if (statSync(srcFile).isFile()) {
-                      copyFileSync(srcFile, join(agentRoleDir, fname));
-                    }
-                  }
-                  agent.reloadRole();
-                }
-                writeFileSync(join(agentRoleDir, '.role-origin.json'), JSON.stringify({ customRole: true, source: 'builder-artifact', artifact: name, artifactType: 'team' }));
-
-                if (memberRole === 'manager') {
-                  await this.orgService.updateTeam(team.id, { managerId: agent.id, managerType: 'agent' });
-                }
-                await agentManager.startAgent(agent.id);
-                createdAgents.push({ id: agent.id, name: agent.config.name, role: agent.role.name });
-              }
-            }
-
-            this.json(res, 201, { type: 'team', team: { id: team.id, name: teamName }, agents: createdAgents });
-
-          } else if (type === 'skill') {
-            const skillDir = join(homedir(), '.markus', 'skills', name);
-            mkdirSync(skillDir, { recursive: true });
-            for (const fname of readdirSync(artDir)) {
-              const srcFile = join(artDir, fname);
-              if (statSync(srcFile).isFile()) {
-                copyFileSync(srcFile, join(skillDir, fname));
-              }
-            }
-
-            if (this.skillRegistry) {
-              try {
-                const skillFile = manifest.skill?.skillFile ?? 'SKILL.md';
-                const instrPath = join(skillDir, skillFile);
-                const instructions = existsSync(instrPath) ? readFileSync(instrPath, 'utf-8').replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '').trim() : undefined;
-                this.skillRegistry.register({
-                  manifest: {
-                    name: manifest.name,
-                    version: manifest.version,
-                    description: manifest.description,
-                    author: manifest.author ?? '',
-                    category: (manifest.category ?? 'custom') as SkillCategory,
-                    tags: manifest.tags,
-                    instructions,
-                    requiredPermissions: manifest.skill?.requiredPermissions,
-                    mcpServers: manifest.skill?.mcpServers,
-                    sourcePath: skillDir,
-                    source: 'builder',
-                  },
-                });
-              } catch (regErr) {
-                log.warn('Failed to register skill into runtime registry', { error: String(regErr) });
-              }
-            }
-
-            this.json(res, 201, { type: 'skill', skill: { name, path: skillDir, status: 'registered' } });
-          }
+          const result = await this.builderService.installArtifact(type, name);
+          this.json(res, 201, result);
         } catch (err) {
-          this.json(res, 500, { error: `Install failed: ${String(err)}` });
+          const msg = String(err instanceof Error ? err.message : err);
+          const status = msg.includes('not found') ? 404 : msg.includes('Invalid manifest') || msg.includes('No ') ? 400 : 500;
+          this.json(res, status, { error: msg });
         }
         return;
       }

--- a/packages/org-manager/src/builder-service.ts
+++ b/packages/org-manager/src/builder-service.ts
@@ -1,0 +1,290 @@
+import { join } from 'node:path';
+import { readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync, copyFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import {
+  createLogger,
+  readManifest,
+  manifestFilename,
+  validateManifest,
+  type PackageType,
+  type MarkusPackageManifest,
+} from '@markus/shared';
+import {
+  discoverSkillsInDir,
+  WELL_KNOWN_SKILL_DIRS,
+  type SkillCategory,
+  type SkillRegistry,
+} from '@markus/core';
+import type { OrganizationService } from './org-service.js';
+
+const log = createLogger('builder-service');
+
+export interface ArtifactInfo {
+  type: string;
+  name: string;
+  description?: string;
+  meta: Record<string, unknown>;
+  path: string;
+  updatedAt: string;
+}
+
+export interface InstallResult {
+  type: string;
+  installed: unknown;
+}
+
+export interface WSBroadcastFn {
+  (msg: { type: string; payload: unknown; timestamp: string }): void;
+}
+
+const FS_HELPER = {
+  existsSync,
+  readFileSync: (p: string, _enc: 'utf-8') => readFileSync(p, 'utf-8'),
+  join,
+};
+
+export class BuilderService {
+  constructor(
+    private orgService: OrganizationService,
+    private skillRegistry?: SkillRegistry,
+    private wsBroadcast?: WSBroadcastFn,
+  ) {}
+
+  private get baseDir(): string {
+    return join(homedir(), '.markus', 'builder-artifacts');
+  }
+
+  listArtifacts(type?: 'agent' | 'team' | 'skill'): ArtifactInfo[] {
+    const types = type
+      ? [type === 'agent' ? 'agents' : type === 'team' ? 'teams' : 'skills'] as const
+      : (['agents', 'teams', 'skills'] as const);
+    const artifacts: ArtifactInfo[] = [];
+
+    for (const typeDir of types) {
+      const dir = join(this.baseDir, typeDir);
+      if (!existsSync(dir)) continue;
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) continue;
+        const artDir = join(dir, entry.name);
+        const artType = (typeDir === 'agents' ? 'agent' : typeDir === 'teams' ? 'team' : 'skill') as PackageType;
+        const manifest = readManifest(artDir, artType, FS_HELPER);
+        const meta: Record<string, unknown> = manifest ? { ...manifest } : { name: entry.name };
+        let updatedAt = new Date().toISOString();
+        try { updatedAt = statSync(artDir).mtime.toISOString(); } catch { /* ignore */ }
+        artifacts.push({
+          type: artType,
+          name: entry.name,
+          description: (manifest?.description as string) ?? undefined,
+          meta,
+          path: artDir,
+          updatedAt,
+        });
+      }
+    }
+
+    artifacts.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return artifacts;
+  }
+
+  async installArtifact(type: 'agent' | 'team' | 'skill', name: string): Promise<InstallResult> {
+    const typeDir = type === 'agent' ? 'agents' : type === 'team' ? 'teams' : 'skills';
+    const artDir = join(this.baseDir, typeDir, name);
+
+    if (!existsSync(artDir)) {
+      throw new Error(`Artifact not found: ${type}/${name}`);
+    }
+
+    const installType = type as PackageType;
+    const manifest = readManifest(artDir, installType, FS_HELPER);
+    if (!manifest) {
+      throw new Error(`No ${manifestFilename(installType)} found in artifact package`);
+    }
+
+    const validationErrors = validateManifest(manifest);
+    if (validationErrors.length > 0) {
+      throw new Error(`Invalid manifest: ${validationErrors.join('; ')}`);
+    }
+
+    const mfName = manifestFilename(installType);
+
+    if (type === 'agent') {
+      return this.installAgent(artDir, manifest, mfName, name);
+    } else if (type === 'team') {
+      return this.installTeam(artDir, manifest, mfName, name);
+    } else {
+      return this.installSkill(artDir, manifest, name);
+    }
+  }
+
+  private async installAgent(
+    artDir: string,
+    manifest: MarkusPackageManifest,
+    mfName: string,
+    artifactName: string,
+  ): Promise<InstallResult> {
+    const agentManager = this.orgService.getAgentManager();
+    const agentName = manifest.displayName ?? manifest.name ?? artifactName;
+    const knownRoles = this.orgService.listAvailableRoles();
+    const requestedRole = manifest.agent?.roleName ?? 'developer';
+    const roleName = knownRoles.includes(requestedRole) ? requestedRole : 'developer';
+    const skills = manifest.dependencies?.skills ?? [];
+    const agentRole = (manifest.agent?.agentRole ?? 'worker') as 'worker' | 'manager';
+
+    const agent = await this.orgService.hireAgent({
+      name: agentName,
+      roleName,
+      orgId: 'default',
+      agentRole,
+      skills,
+    });
+
+    const agentRoleDir = join(agentManager.getDataDir(), agent.id, 'role');
+    mkdirSync(agentRoleDir, { recursive: true });
+    for (const fname of readdirSync(artDir)) {
+      if (fname === mfName) continue;
+      const srcFile = join(artDir, fname);
+      if (statSync(srcFile).isFile()) {
+        copyFileSync(srcFile, join(agentRoleDir, fname));
+      }
+    }
+    writeFileSync(
+      join(agentRoleDir, '.role-origin.json'),
+      JSON.stringify({ customRole: true, source: 'builder-artifact', artifact: artifactName, artifactType: 'agent' }),
+    );
+    agent.reloadRole();
+    await agentManager.startAgent(agent.id);
+
+    return {
+      type: 'agent',
+      installed: {
+        id: agent.id,
+        name: agent.config.name,
+        role: agent.role.name,
+        status: agent.getState().status,
+      },
+    };
+  }
+
+  private async installTeam(
+    artDir: string,
+    manifest: MarkusPackageManifest,
+    mfName: string,
+    artifactName: string,
+  ): Promise<InstallResult> {
+    const agentManager = this.orgService.getAgentManager();
+    const teamName = manifest.displayName ?? manifest.name ?? artifactName;
+    const team = await this.orgService.createTeam('default', teamName, manifest.description ?? '');
+
+    this.wsBroadcast?.({
+      type: 'chat:group_created',
+      payload: { chatId: `group:${team.id}`, name: teamName, creatorId: '', creatorName: '' },
+      timestamp: new Date().toISOString(),
+    });
+
+    const announcementPath = join(artDir, 'ANNOUNCEMENT.md');
+    const normsPath = join(artDir, 'NORMS.md');
+    const announcements = existsSync(announcementPath) ? readFileSync(announcementPath, 'utf-8') : '';
+    const norms = existsSync(normsPath) ? readFileSync(normsPath, 'utf-8') : '';
+    this.orgService.ensureTeamDataDir(team.id, announcements, norms);
+
+    const members = manifest.team?.members ?? [];
+    const knownRoles = this.orgService.listAvailableRoles();
+    const createdAgents: Array<{ id: string; name: string; role: string }> = [];
+
+    for (const member of members) {
+      const count = member.count ?? 1;
+      const memberRole = (member.role ?? 'worker') as 'worker' | 'manager';
+      const memberName = member.name ?? 'Agent';
+      const roleName = knownRoles.includes(member.roleName) ? member.roleName : 'developer';
+      const memberSkills = member.skills ?? [];
+      const memberSlug = memberName.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      const memberFilesDir = join(artDir, 'members', memberSlug);
+
+      for (let i = 0; i < count; i++) {
+        const displayName = count > 1 ? `${memberName} ${i + 1}` : memberName;
+        const agent = await this.orgService.hireAgent({
+          name: displayName,
+          roleName,
+          orgId: 'default',
+          teamId: team.id,
+          agentRole: memberRole,
+          skills: memberSkills.length > 0 ? memberSkills : undefined,
+        });
+
+        const agentRoleDir = join(agentManager.getDataDir(), agent.id, 'role');
+        mkdirSync(agentRoleDir, { recursive: true });
+        if (existsSync(memberFilesDir)) {
+          for (const fname of readdirSync(memberFilesDir)) {
+            const srcFile = join(memberFilesDir, fname);
+            if (statSync(srcFile).isFile()) {
+              copyFileSync(srcFile, join(agentRoleDir, fname));
+            }
+          }
+          agent.reloadRole();
+        }
+        writeFileSync(
+          join(agentRoleDir, '.role-origin.json'),
+          JSON.stringify({ customRole: true, source: 'builder-artifact', artifact: artifactName, artifactType: 'team' }),
+        );
+
+        if (memberRole === 'manager') {
+          await this.orgService.updateTeam(team.id, { managerId: agent.id, managerType: 'agent' });
+        }
+        await agentManager.startAgent(agent.id);
+        createdAgents.push({ id: agent.id, name: agent.config.name, role: agent.role.name });
+      }
+    }
+
+    return {
+      type: 'team',
+      installed: { team: { id: team.id, name: teamName }, agents: createdAgents },
+    };
+  }
+
+  private async installSkill(
+    artDir: string,
+    manifest: MarkusPackageManifest,
+    artifactName: string,
+  ): Promise<InstallResult> {
+    const skillDir = join(homedir(), '.markus', 'skills', artifactName);
+    mkdirSync(skillDir, { recursive: true });
+    for (const fname of readdirSync(artDir)) {
+      const srcFile = join(artDir, fname);
+      if (statSync(srcFile).isFile()) {
+        copyFileSync(srcFile, join(skillDir, fname));
+      }
+    }
+
+    if (this.skillRegistry) {
+      try {
+        const skillFile = manifest.skill?.skillFile ?? 'SKILL.md';
+        const instrPath = join(skillDir, skillFile);
+        const instructions = existsSync(instrPath)
+          ? readFileSync(instrPath, 'utf-8').replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '').trim()
+          : undefined;
+        this.skillRegistry.register({
+          manifest: {
+            name: manifest.name,
+            version: manifest.version,
+            description: manifest.description,
+            author: manifest.author ?? '',
+            category: (manifest.category ?? 'custom') as SkillCategory,
+            tags: manifest.tags,
+            instructions,
+            requiredPermissions: manifest.skill?.requiredPermissions,
+            mcpServers: manifest.skill?.mcpServers,
+            sourcePath: skillDir,
+            source: 'builder',
+          },
+        });
+      } catch (regErr) {
+        log.warn('Failed to register skill into runtime registry', { error: String(regErr) });
+      }
+    }
+
+    return {
+      type: 'skill',
+      installed: { name: artifactName, path: skillDir, status: 'registered' },
+    };
+  }
+}

--- a/packages/org-manager/src/index.ts
+++ b/packages/org-manager/src/index.ts
@@ -20,3 +20,4 @@ export { StaleDetector } from './stale-detector.js';
 export { ScheduledTaskRunner } from './scheduled-task-runner.js';
 export { initStorage, type StorageBridge } from './storage-bridge.js';
 export { searchRegistries, installSkill, type SkillSearchResult, type SkillInstallRequest, type SkillInstallResult } from './skill-service.js';
+export { BuilderService, type ArtifactInfo, type InstallResult } from './builder-service.js';

--- a/packages/org-manager/src/org-service.ts
+++ b/packages/org-manager/src/org-service.ts
@@ -870,13 +870,14 @@ export class OrganizationService {
         this.addMemberToTeam(team.id, ownerUserId, 'human');
       }
 
-      // Hire a Secretary agent as manager of this team
+      // Hire a Secretary agent as manager of this team, with all building skills
       const secretary = await this.hireAgent({
         name: 'Secretary',
         roleName: 'secretary',
         orgId,
         teamId: team.id,
         agentRole: 'manager',
+        skills: ['agent-building', 'team-building', 'skill-building'],
       });
 
       // Set the secretary as the team manager
@@ -894,64 +895,20 @@ export class OrganizationService {
     }
   }
 
-  /**
-   * Ensure the three built-in builder agents exist (Agent Father, Team Factory, Skill Architect).
-   * Safe to call on every startup — skips agents that already exist.
-   * Also registers dynamic context providers so builder agents can see available skills/roles at runtime.
-   */
-  static readonly BUILDING_SKILLS = new Set(['agent-building', 'team-building', 'skill-building']);
-
-  async seedBuilderAgents(orgId: string, skillRegistry?: SkillRegistry): Promise<void> {
-    const builderConfigs = [
-      { name: 'Agent Father', roleName: 'agent-father', skills: ['agent-building'] },
-      { name: 'Team Factory', roleName: 'team-factory', skills: ['team-building'] },
-      { name: 'Skill Architect', roleName: 'skill-architect', skills: ['skill-building'] },
-    ] as const;
-
-    const teams = this.listTeams(orgId);
-    if (teams.length === 0) return;
-    const defaultTeamId = teams[0]!.id;
-
-    const existingAgents = this.agentManager.listAgents();
-    for (const cfg of builderConfigs) {
-      const alreadyExists = existingAgents.some(
-        a => a.name === cfg.name || a.role === cfg.name
-      );
-      if (alreadyExists) continue;
-
-      try {
-        await this.hireAgent({
-          name: cfg.name,
-          roleName: cfg.roleName,
-          orgId,
-          teamId: defaultTeamId,
-          agentRole: 'worker',
-          heartbeatIntervalMs: 0,
-          skills: [...cfg.skills],
-        });
-        log.info(`Seeded builder agent: ${cfg.name}`);
-      } catch (err) {
-        log.warn(`Failed to seed builder agent: ${cfg.name}`, { error: String(err) });
-      }
-    }
-
-    this.registerBuilderContextProviders(skillRegistry);
-  }
+  private static readonly BUILDING_SKILLS = new Set(['agent-building', 'team-building', 'skill-building']);
 
   /**
-   * Register dynamic context providers on all builder agents (and any agent
-   * with a building skill) so they see the live list of available skills/roles.
+   * Register dynamic context providers on any agent with a building skill
+   * so they see the live list of available skills/roles at runtime.
    */
   registerBuilderContextProviders(skillRegistry?: SkillRegistry): void {
-    const builderNames = new Set(['Agent Father', 'Team Factory', 'Skill Architect']);
     const allAgents = this.agentManager.listAgents();
 
     for (const info of allAgents) {
       try {
         const agent = this.agentManager.getAgent(info.id);
-        const isBuilder = builderNames.has(info.name) ||
-          agent.config.skills.some(s => OrganizationService.BUILDING_SKILLS.has(s));
-        if (!isBuilder) continue;
+        const hasBuilderSkill = agent.config.skills.some(s => OrganizationService.BUILDING_SKILLS.has(s));
+        if (!hasBuilderSkill) continue;
         agent.addDynamicContextProvider(() => this.buildBuilderDynamicContext(skillRegistry), 'builder-context');
       } catch {
         log.warn(`Could not register dynamic context for builder: ${info.name}`);

--- a/packages/web-ui/src/pages/AgentBuilder.tsx
+++ b/packages/web-ui/src/pages/AgentBuilder.tsx
@@ -11,51 +11,48 @@ function shortenPath(p: string): string {
   return idx >= 0 ? '~/' + p.slice(idx) : p;
 }
 
-const BUILDERS = [
+const BUILDER_PROMPTS = [
   {
-    roleId: 'agent-father',
-    roleName: 'Agent Father',
     icon: '✦',
     color: 'from-brand-500 to-purple-600',
     borderColor: 'border-brand-500/30 hover:border-brand-400/50',
     bgColor: 'bg-brand-500/10',
-    desc: 'AI Agent Architect',
-    detail: 'Design and create powerful AI agents through natural conversation. Describe the agent you need and Agent Father will configure it with the right role, skills, tools, and system prompt.',
+    title: 'Hire an Agent',
+    desc: 'Hire from templates, create custom agents, or find specialists on Markus Hub',
     examples: [
-      'A senior full-stack developer who specializes in React and Node.js',
-      'A DevOps engineer for CI/CD pipeline management',
-      'A code reviewer who enforces best practices',
+      'Hire a senior React developer',
+      'Create a custom code reviewer',
+      'Find a DevOps specialist on Hub',
     ],
+    prompt: 'I need to hire an agent: ',
   },
   {
-    roleId: 'team-factory',
-    roleName: 'Team Factory',
     icon: '◈',
     color: 'from-blue-500 to-blue-600',
     borderColor: 'border-blue-500/30 hover:border-blue-400/50',
     bgColor: 'bg-blue-500/10',
-    desc: 'AI Team Composer',
-    detail: 'Compose optimal agent teams for any project. Describe your goal and Team Factory will design the lineup with the right mix of managers, developers, reviewers, and specialists.',
+    title: 'Build a Team',
+    desc: 'Compose an optimal team for your project or deploy a team template',
     examples: [
-      'A web development team with PM, developers, and QA',
-      'A content team for a tech blog',
+      'A web dev team with PM, devs, and QA',
       'A data engineering squad',
+      'A content creation team',
     ],
+    prompt: 'I need to build a team for: ',
   },
   {
-    roleId: 'skill-architect',
-    roleName: 'Skill Architect',
     icon: '⬡',
     color: 'from-green-500 to-green-600',
     borderColor: 'border-green-500/30 hover:border-green-400/50',
     bgColor: 'bg-green-500/10',
-    desc: 'AI Skill Designer',
-    detail: 'Create new agent skills and tool definitions. Describe the capability you want and Skill Architect will design the complete skill manifest with tools, schemas, and permissions.',
+    title: 'Create a Skill',
+    desc: 'Design new capabilities that agents can learn and use',
     examples: [
-      'A skill that analyzes Git repos and generates changelogs',
-      'A web scraping skill for extracting structured data',
-      'A database migration tool with rollback support',
+      'A Git changelog generator',
+      'A web scraping skill',
+      'A database migration tool',
     ],
+    prompt: 'I need a skill that: ',
   },
 ];
 
@@ -116,8 +113,6 @@ export function AgentBuilder() {
   const [hubDeleteTarget, setHubDeleteTarget] = useState<{ key: string; name: string } | null>(null);
   const [copiedKey, setCopiedKey] = useState<string | null>(null);
 
-  const builderNames = new Set(BUILDERS.map(b => b.roleName));
-
   const loadAll = useCallback(() => {
     setLoading(true);
     Promise.all([
@@ -170,12 +165,12 @@ export function AgentBuilder() {
     return () => window.removeEventListener('markus:navigate', onNav);
   }, [loadAll]);
 
-  const navigateToBuilder = (_roleId: string, roleName: string) => {
-    const builderAgent = agents.find(a => a.role === roleName || a.name === roleName);
-    if (builderAgent) {
-      navBus.navigate(PAGE.TEAM, { agentId: builderAgent.id });
+  const navigateToSecretary = (prompt: string) => {
+    const secretary = agents.find(a => a.role === 'Secretary' || a.name === 'Secretary');
+    if (secretary) {
+      navBus.navigate(PAGE.TEAM, { agentId: secretary.id, prefillMessage: prompt });
     } else {
-      navBus.navigate(PAGE.TEAM);
+      navBus.navigate(PAGE.TEAM, { prefillMessage: prompt });
     }
   };
 
@@ -287,20 +282,20 @@ export function AgentBuilder() {
   return (
     <div className="flex-1 overflow-y-auto">
       <div className={`max-w-4xl ${isMobile ? 'px-4 py-5' : 'px-6 py-10'}`}>
-        {/* Builder cards */}
+        {/* Builder prompts → navigate to Secretary */}
         <div className="mb-10">
           <h1 className="text-2xl font-bold text-fg-primary">Builder</h1>
           <p className="text-sm text-fg-tertiary mt-2">
-            Create agents, teams, and skills through AI-powered conversations.
-            Choose a builder to get started.
+            Hire agents, build teams, and create skills. Your Secretary handles the entire process
+            — from sourcing to onboarding.
           </p>
         </div>
 
         <div className="grid gap-5">
-          {BUILDERS.map(b => (
+          {BUILDER_PROMPTS.map(b => (
             <button
-              key={b.roleId}
-              onClick={() => navigateToBuilder(b.roleId, b.roleName)}
+              key={b.title}
+              onClick={() => navigateToSecretary(b.prompt)}
               className={`group text-left w-full rounded-xl border ${b.borderColor} bg-surface-secondary/60 ${isMobile ? 'p-4' : 'p-6'} transition-all hover:bg-surface-secondary/80 hover:shadow-lg`}
             >
               <div className={`flex items-start ${isMobile ? 'gap-3' : 'gap-5'}`}>
@@ -310,17 +305,14 @@ export function AgentBuilder() {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
                     <h3 className={`${isMobile ? 'text-base' : 'text-lg'} font-semibold bg-gradient-to-r ${b.color} bg-clip-text text-transparent`}>
-                      {b.roleName}
+                      {b.title}
                     </h3>
-                    <span className="text-[10px] text-fg-tertiary font-medium uppercase tracking-wider">{b.desc}</span>
-                    {agents.find(a => a.role === b.roleName || a.name === b.roleName) && (
-                      <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" title="Agent online" />
-                    )}
                   </div>
-                  <p className="text-sm text-fg-secondary leading-relaxed">{b.detail}</p>
+                  <p className="text-sm text-fg-secondary leading-relaxed">{b.desc}</p>
                   <div className="mt-3 flex flex-wrap gap-2">
                     {b.examples.map((ex, i) => (
-                      <span key={i} className="text-[11px] text-fg-tertiary bg-surface-elevated/60 rounded-full px-3 py-1 border border-border-default">
+                      <span key={i} className="text-[11px] text-fg-tertiary bg-surface-elevated/60 rounded-full px-3 py-1 border border-border-default cursor-pointer hover:bg-surface-elevated/80 hover:text-fg-secondary transition-colors"
+                        onClick={(e) => { e.stopPropagation(); navigateToSecretary(b.prompt + ex); }}>
                         &ldquo;{ex}&rdquo;
                       </span>
                     ))}
@@ -333,12 +325,6 @@ export function AgentBuilder() {
             </button>
           ))}
         </div>
-
-        {agents.length > 0 && !agents.some(a => BUILDERS.some(b => a.role === b.roleName || a.name === b.roleName)) && (
-          <div className="mt-8 p-4 rounded-lg border border-amber-500/30 bg-amber-500/10 text-amber-600 text-xs">
-            Builder agents have not been created yet. They will be automatically seeded on next server restart.
-          </div>
-        )}
 
         {/* Artifact management section */}
         <div className="mt-14 mb-4">

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -721,6 +721,10 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
         if (detail.params?.selectAgent) {
           handleViewProfile(detail.params.selectAgent);
         }
+        if (detail.params?.prefillMessage) {
+          setInput(detail.params.prefillMessage);
+          setTimeout(() => textareaRef.current?.focus(), 100);
+        }
         if (detail.params?.openHire === 'true') {
           // handled by ChatTeamSidebar via nav events
         }

--- a/templates/roles/secretary/HEARTBEAT.md
+++ b/templates/roles/secretary/HEARTBEAT.md
@@ -8,6 +8,12 @@
 - Check for tasks in `pending` — approve or reject promptly so work is not stalled.
 - **Failed task recovery**: Check `task_list` for tasks assigned to you with status `failed`. If found, retry by calling `task_update(status: "in_progress")` with a note — this auto-restarts execution.
 
+## New-Hire & Artifact Monitoring
+
+- Check `team_status` for recently hired agents that are idle, stuck, or in error — proactively send guidance or assign work via `task_create`.
+- For new hires in their first few heartbeats: review their task output quality. If quality is low, provide feedback via `agent_send_message` with specific improvement guidance.
+- Check `builder_list` for artifacts that haven't been installed yet — consider if any should be deployed.
+
 ## Correction & Learning Capture
 
 Scan your recent interactions for correction signals (inspired by OpenClaw's Reflect skill):

--- a/templates/roles/secretary/ROLE.md
+++ b/templates/roles/secretary/ROLE.md
@@ -31,11 +31,39 @@ You are a **protected system agent** — you cannot be deleted. You persist acro
 - Answer questions about team status, ongoing tasks, and agent capabilities
 - Maintain context across conversations to provide continuity
 
-### 5. Agent Management Support
-- Help the owner hire agents by suggesting suitable roles
-- When asked, brief new agents on their responsibilities and team context
-- Flag underperforming agents and recommend remediation
-- Coordinate onboarding of new team members
+### 5. Organization Building & Talent Management
+
+You are the primary builder and talent manager. You have building skills (agent-building, team-building, skill-building) and access to hiring/installation tools. **Hiring is a process, not a command** — creating the agent is step 1; onboarding is what makes them productive.
+
+#### Hiring Workflow (the complete process)
+
+1. **Assess need**: Understand what role/skills are required. Check existing team (`team_list`, `team_status`) to avoid redundancy.
+2. **Source the right agent**: Browse builtin templates (`team_list_templates`), search Markus Hub (`hub_search`), or design a custom agent using your building skills.
+3. **Create**: `team_hire_agent` (from template), `hub_install` (from Hub), or building skill + `builder_install` (custom artifact).
+4. **Onboard/Train** — Critical step:
+   - Send a welcome message (`agent_send_message`) with: who you are, team context, current project status, key conventions
+   - Share relevant project info: active repositories, current requirements, coding standards
+   - Point them to team norms and announcements
+   - If the team has existing patterns or past decisions, share context from `memory_search`
+5. **Assign initial work**: Create tasks (`task_create`) immediately so the new agent has concrete deliverables. Start with a well-scoped task to evaluate quality.
+6. **Monitor early performance**: During subsequent heartbeats, pay attention to new hires — are they producing quality work? Do they need guidance? Correct early and record lessons.
+
+#### Custom Creation (using building skills)
+
+- Design artifacts under `~/.markus/builder-artifacts/` using your building skills (agent-building, team-building, skill-building)
+- Use `builder_install` to deploy as a live entity
+- Then follow the onboarding steps above
+
+#### Hub Sourcing
+
+- `hub_search` to find community agents/teams/skills on Markus Hub
+- `hub_install` to download and deploy in one step
+- Onboard as above
+
+#### Skill Management
+
+- Use `builder_list` to see available artifacts, `builder_install` to deploy skills
+- Recommend or install skills for team members based on their responsibilities
 
 ---
 


### PR DESCRIPTION
…ub tools

Remove the 3 dedicated builder agents (Agent Father, Team Factory, Skill Architect) and consolidate all building capabilities into the Secretary. Secretary now holds all 3 building skills and serves as the sole default agent for organization building and talent management.

- Extract BuilderService from api-server.ts for programmatic artifact install/list, reused by both HTTP API and agent tools
- Add 4 manager tools: team_hire_agent, team_list_templates, builder_install, builder_list (available to all managers)
- Add 2 hub tools: hub_search, hub_install (Secretary-only, for sourcing from Markus Hub)
- Wire all new tool callbacks in agent-manager.ts (create + restore)
- Expand Secretary ROLE.md with 6-step hiring workflow including onboarding/training guidance
- Add new-hire monitoring to Secretary HEARTBEAT.md
- Add "Hiring" as Manager Responsibility 6 in context-engine.ts
- Redesign Builder page: replace builder agent cards with preset prompts that navigate to Secretary chat with prefillMessage
- Support prefillMessage navigation param in Team.tsx
- Update ARCHITECTURE.md (agent lifecycle) and PROMPT-ENGINEERING.md

Made-with: Cursor