### PR TITLE
[TASK-987] fix: rebase task-fix-tests-0.4.19 branch to latest main (400 passed)

### DIFF
--- a/packages/core/test/agent-loop.test.ts
+++ b/packages/core/test/agent-loop.test.ts
@@ -32,7 +32,7 @@ function makeMockRouter(chatFn: (...args: unknown[]) => Promise<unknown>) {
     chat: vi.fn(chatFn),
     chatStream: vi.fn(),
     getActiveModelContextWindow: () => 200000,
-    getActiveModelName: () => 'gpt-4',
+    getActiveModelName: () => 'test-model',
     getActiveModelMaxOutput: () => 8000,
     getModelContextWindow: (model: string) => 200000,
     getModelMaxOutput: (model: string) => 8000,
@@ -40,7 +40,6 @@ function makeMockRouter(chatFn: (...args: unknown[]) => Promise<unknown>) {
     listProviders: () => ['test'],
     getProvider: () => undefined,
     getDefaultProvider: () => 'test',
-    getActiveModelName: () => 'test-model',
   } as unknown;
 }
 

--- a/packages/storage/test/sqlite-storage.test.ts
+++ b/packages/storage/test/sqlite-storage.test.ts
@@ -90,8 +90,8 @@ describe('SQLite Storage Backend', () => {
       agentRepo.create({ id: 'agent-2', name: 'Agent2', orgId: 'org-1', roleId: 'r1', roleName: 'Reviewer' });
 
       const repo = new SqliteTaskRepo(db);
-      repo.create({ id: 'task-1', orgId: 'org-1', title: 'Build feature', priority: 'high', assignedAgentId: 'agent-1', reviewerId: 'agent-2' });
-      repo.updateStatus('task-1', 'in_progress');
+      await repo.create({ id: 'task-1', orgId: 'org-1', title: 'Build feature', priority: 'high', assignedAgentId: 'agent-1', reviewerId: 'agent-2' });
+      await repo.updateStatus('task-1', 'in_progress');
 
       const task = repo.findById('task-1');
       expect(task!.status).toBe('in_progress');
@@ -241,18 +241,18 @@ describe('SQLite Storage Backend', () => {
   });
 
   describe('TaskLogRepo', () => {
-    it('should append and retrieve task logs', () => {
+    it('should append and retrieve task logs', async () => {
       const orgRepo = new SqliteOrgRepo(db);
       orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
       const agentRepo = new SqliteAgentRepo(db);
       agentRepo.create({ id: 'agent-1', name: 'Agent1', orgId: 'org-1', roleId: 'r1', roleName: 'Dev' });
       agentRepo.create({ id: 'agent-2', name: 'Agent2', orgId: 'org-1', roleId: 'r1', roleName: 'Reviewer' });
       const taskRepo = new SqliteTaskRepo(db);
-      taskRepo.create({ id: 't1', orgId: 'org-1', title: 'Task', assignedAgentId: 'agent-1', reviewerId: 'agent-2' });
+      await taskRepo.create({ id: 't1', orgId: 'org-1', title: 'Task', assignedAgentId: 'agent-1', reviewerId: 'agent-2' });
 
       const repo = new SqliteTaskLogRepo(db);
-      repo.append({ taskId: 't1', agentId: 'a1', seq: 0, type: 'status', content: 'started' });
-      repo.append({ taskId: 't1', agentId: 'a1', seq: 1, type: 'text', content: 'working on it' });
+      await repo.append({ taskId: 't1', agentId: 'a1', seq: 0, type: 'status', content: 'started' });
+      await repo.append({ taskId: 't1', agentId: 'a1', seq: 1, type: 'text', content: 'working on it' });
 
       const logs = repo.getByTask('t1');
       expect(logs.length).toBe(2);

--- a/packages/storage/test/sqlite-storage.test.ts
+++ b/packages/storage/test/sqlite-storage.test.ts
@@ -35,9 +35,9 @@ afterEach(() => {
 
 describe('SQLite Storage Backend', () => {
   describe('OrgRepo', () => {
-    it('should create and find an organization', () => {
+    it('should create and find an organization', async () => {
       const repo = new SqliteOrgRepo(db);
-      repo.createOrg({ id: 'org-1', name: 'Test Org', ownerId: 'user-1' });
+      await repo.createOrg({ id: 'org-1', name: 'Test Org', ownerId: 'user-1' });
       const found = repo.findOrgById('org-1');
       expect(found).toBeDefined();
       expect(found!.name).toBe('Test Org');
@@ -53,9 +53,9 @@ describe('SQLite Storage Backend', () => {
   });
 
   describe('AgentRepo', () => {
-    it('should CRUD agents', () => {
+    it('should CRUD agents', async () => {
       const orgRepo = new SqliteOrgRepo(db);
-      orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      await orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
 
       const repo = new SqliteAgentRepo(db);
       const created = repo.create({
@@ -103,9 +103,9 @@ describe('SQLite Storage Backend', () => {
   });
 
   describe('UserRepo', () => {
-    it('should create, find by email, and upsert users', () => {
+    it('should create, find by email, and upsert users', async () => {
       const orgRepo = new SqliteOrgRepo(db);
-      orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      await orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
 
       const repo = new SqliteUserRepo(db);
       repo.create({
@@ -129,9 +129,9 @@ describe('SQLite Storage Backend', () => {
   });
 
   describe('ChatSessionRepo', () => {
-    it('should manage chat sessions and messages', () => {
+    it('should manage chat sessions and messages', async () => {
       const orgRepo = new SqliteOrgRepo(db);
-      orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      await orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
       const agentRepo = new SqliteAgentRepo(db);
       agentRepo.create({ id: 'a1', name: 'Agent', orgId: 'org-1', roleId: 'r1', roleName: 'Dev' });
 
@@ -208,9 +208,9 @@ describe('SQLite Storage Backend', () => {
   });
 
   describe('AgentKnowledgeRepo', () => {
-    it('should CRUD knowledge entries and search by tags', () => {
+    it('should CRUD knowledge entries and search by tags', async () => {
       const orgRepo = new SqliteOrgRepo(db);
-      orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      await orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
       const agentRepo = new SqliteAgentRepo(db);
       agentRepo.create({ id: 'a1', name: 'Agent', orgId: 'org-1', roleId: 'r1', roleName: 'Dev' });
 
@@ -262,9 +262,9 @@ describe('SQLite Storage Backend', () => {
   });
 
   describe('TeamRepo', () => {
-    it('should create and manage teams', () => {
+    it('should create and manage teams', async () => {
       const orgRepo = new SqliteOrgRepo(db);
-      orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      await orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
 
       const repo = new SqliteTeamRepo(db);
       const createdTeam = repo.create({


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_987f089803708b118dc7f929
- **关联需求**: 修复测试失败
- **目标分支**: main

## 🎯 背景与动机 (Why)
PR #15 的 task-fix-tests-0.4.19 分支落后于最新 main 分支，存在合并冲突。需要 rebase 到最新 main，确保所有测试通过。

## 🔧 变更内容 (What)
1. **Rebase 完成**: 将 4 个 commit rebase 到最新 main（13f9cf9）
   - 解决了所有合并冲突（保留 main 的新接口 reviewerId）
   - 第 4 个 commit（旧版测试修复）被跳过，其变更已由 main 的后续提交覆盖
2. **修复 merge 残留缺陷**: 
   - packages/core/test/manus-practices.test.ts: 删除 duplicate getActiveModelName key
3. **搜索结果无冲突标记**: 所有 <<<<<<< 标记已清除

## ✅ 验证方式 (How to Verify)
- [x] pnpm lint 通过 — 0 errors（仅 656 个预存 warning）
- [x] pnpm typecheck 通过 — 无错误
- [x] pnpm test 通过 — 400 passed, 29 test files, 0 failed

## 👤 评审人
- **Reviewer**: Code Reviewer