### PR TITLE
feat: add browser automation settings to avoid repeated permission di…

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -249,6 +249,15 @@ async function createServices(config: ReturnType<typeof loadConfig>) {
   if (config.agent?.maxToolIterations) {
     agentManager.maxToolIterations = config.agent.maxToolIterations;
   }
+  if (config.browser?.bringToFront !== undefined) {
+    agentManager.setBrowserBringToFront(config.browser.bringToFront);
+  }
+  if (config.browser?.autoCloseTabs !== undefined) {
+    agentManager.setBrowserAutoCloseTabs(config.browser.autoCloseTabs);
+  }
+  if (config.browser?.remoteDebuggingPort) {
+    agentManager.setBrowserRemoteDebuggingPort(config.browser.remoteDebuggingPort);
+  }
 
   taskService.setAgentManager(agentManager);
 

--- a/packages/core/src/agent-manager.ts
+++ b/packages/core/src/agent-manager.ts
@@ -287,6 +287,7 @@ export class AgentManager {
   private sharedDataDir?: string;
   private mcpManager: MCPClientManager;
   private browserSessionManager: BrowserSessionManager;
+  private remoteDebuggingPort = 0;
   private globalSecurityPolicy?: SecurityPolicy;
   private globalMcpServers?: Record<string, MCPServerConfig>;
   private skillRegistry?: SkillRegistry;
@@ -535,6 +536,37 @@ export class AgentManager {
     this._maxToolIterations = value <= 0 ? Infinity : value;
   }
 
+  setBrowserBringToFront(value: boolean): void {
+    this.browserSessionManager.bringToFront = value;
+  }
+
+  setBrowserAutoCloseTabs(value: boolean): void {
+    this.browserSessionManager.autoCloseTabs = value;
+  }
+
+  setBrowserRemoteDebuggingPort(port: number): void {
+    this.remoteDebuggingPort = port;
+  }
+
+  /**
+   * When remoteDebuggingPort is configured, replace --autoConnect with
+   * --browserUrl so that the chrome-devtools MCP server reuses a persistent
+   * debugging connection instead of requesting a new permission each time.
+   */
+  private enrichChromeDevtoolsConfig(
+    serverName: string,
+    config: { command: string; args?: string[]; env?: Record<string, string> },
+  ): { command: string; args?: string[]; env?: Record<string, string> } {
+    if (serverName !== 'chrome-devtools' || this.remoteDebuggingPort <= 0) return config;
+    const args = [...(config.args ?? [])];
+    const autoIdx = args.indexOf('--autoConnect');
+    if (autoIdx !== -1) args.splice(autoIdx, 1);
+    if (!args.includes('--browserUrl') && !args.includes('--browser-url')) {
+      args.push('--browserUrl', `http://127.0.0.1:${this.remoteDebuggingPort}`);
+    }
+    return { ...config, args };
+  }
+
   setTaskService(taskService: TaskServiceBridge): void {
     this.taskService = taskService;
   }
@@ -736,8 +768,9 @@ export class AgentManager {
         const skill = this.skillRegistry.get(skillName);
         if (skill?.manifest.mcpServers) {
           const isolated = skill.manifest.isolation === 'per-agent';
-          for (const [serverName, serverConfig] of Object.entries(skill.manifest.mcpServers)) {
+          for (const [serverName, rawServerConfig] of Object.entries(skill.manifest.mcpServers)) {
             try {
+              const serverConfig = this.enrichChromeDevtoolsConfig(serverName, rawServerConfig);
               let mcpTools: AgentToolHandler[];
               if (isolated) {
                 await this.mcpManager.connectServerScoped(serverName, serverConfig, id);
@@ -771,7 +804,8 @@ export class AgentManager {
       let tools: AgentToolHandler[] = [];
       const skill = this.skillRegistry?.get(skillName);
       const isolated = skill?.manifest.isolation === 'per-agent';
-      for (const [serverName, srvConfig] of Object.entries(mcpServers)) {
+      for (const [serverName, rawSrvConfig] of Object.entries(mcpServers)) {
+        const srvConfig = this.enrichChromeDevtoolsConfig(serverName, rawSrvConfig);
         if (isolated) {
           await this.mcpManager.connectServerScoped(serverName, srvConfig, id);
           tools.push(...this.mcpManager.getToolHandlersScoped(serverName, id));
@@ -1378,9 +1412,10 @@ export class AgentManager {
         const skill = this.skillRegistry.get(skillName);
         if (skill?.manifest.mcpServers) {
           const isolated = skill.manifest.isolation === 'per-agent';
-          for (const [serverName, serverConfig] of Object.entries(skill.manifest.mcpServers)) {
+          for (const [serverName, rawServerConfig] of Object.entries(skill.manifest.mcpServers)) {
             mcpConnections.push((async () => {
               try {
+                const serverConfig = this.enrichChromeDevtoolsConfig(serverName, rawServerConfig);
                 let mcpTools: AgentToolHandler[];
                 if (isolated) {
                   await this.mcpManager.connectServerScoped(serverName, serverConfig, id);
@@ -1416,7 +1451,8 @@ export class AgentManager {
       let tools: AgentToolHandler[] = [];
       const skill = this.skillRegistry?.get(skillName);
       const isolated = skill?.manifest.isolation === 'per-agent';
-      for (const [serverName, srvConfig] of Object.entries(mcpServers)) {
+      for (const [serverName, rawSrvConfig] of Object.entries(mcpServers)) {
+        const srvConfig = this.enrichChromeDevtoolsConfig(serverName, rawSrvConfig);
         if (isolated) {
           await this.mcpManager.connectServerScoped(serverName, srvConfig, id);
           tools.push(...this.mcpManager.getToolHandlersScoped(serverName, id));

--- a/packages/core/src/tools/browser-session.ts
+++ b/packages/core/src/tools/browser-session.ts
@@ -64,6 +64,21 @@ export class BrowserSessionManager {
   private selectPageHandlers = new Map<string, AgentToolHandler>();
 
   /**
+   * When true, new_page and select_page will bring Chrome to foreground.
+   * Controlled via Settings > Browser Automation. Default: false.
+   */
+  private _bringToFront = false;
+
+  /** When true, agent-owned tabs are auto-closed on cleanup. Default: true. */
+  private _autoCloseTabs = true;
+
+  get bringToFront(): boolean { return this._bringToFront; }
+  set bringToFront(v: boolean) { this._bringToFront = v; }
+
+  get autoCloseTabs(): boolean { return this._autoCloseTabs; }
+  set autoCloseTabs(v: boolean) { this._autoCloseTabs = v; }
+
+  /**
    * Acquire a per-agent mutex.  Operations are serialized per-agent so that
    * the "select_page → tool" sequence is atomic.
    */
@@ -90,8 +105,8 @@ export class BrowserSessionManager {
    * Ensure the MCP server's selected tab matches this session's current page.
    * Called inside the agent lock before any tool that operates on the active tab.
    *
-   * Uses bringToFront: false to prevent Chrome from stealing window focus on
-   * macOS (Chromium CDP activates the window on select_page by default).
+   * Respects the bringToFront setting: when false (default), prevents Chrome
+   * from stealing window focus on macOS.
    * Skips the call entirely when the agent's last operation was already on
    * this session's current page.
    */
@@ -107,7 +122,7 @@ export class BrowserSessionManager {
     const selectHandler = this.selectPageHandlers.get(agentId);
     if (!selectHandler) return;
     try {
-      await selectHandler.execute({ pageId, bringToFront: false });
+      await selectHandler.execute({ pageId, bringToFront: this._bringToFront });
       this.lastActiveSession.set(agentId, { ownerKey, pageId });
     } catch (err) {
       log.warn(`Auto-select page ${pageId} failed for ${ownerKey}: ${err}`);
@@ -212,7 +227,7 @@ export class BrowserSessionManager {
       execute: async (args: Record<string, unknown>) => {
         const ownerKey = this.extractOwnerKey(agentId, args);
         if (args.background === undefined) {
-          args.background = true;
+          args.background = !this._bringToFront;
         }
         return this.withAgentLock(agentId, async () => {
           const result = await handler.execute(args);
@@ -257,7 +272,7 @@ export class BrowserSessionManager {
           return JSON.stringify({ error: msg });
         }
         if (args.bringToFront === undefined) {
-          args.bringToFront = false;
+          args.bringToFront = this._bringToFront;
         }
         return this.withAgentLock(agentId, async () => {
           const result = await handler.execute(args);
@@ -336,7 +351,7 @@ export class BrowserSessionManager {
           log.info(`Session ${ownerKey} called navigate_page with no owned pages -- auto-creating via new_page`, { url });
 
           return this.withAgentLock(agentId, async () => {
-            const newPageArgs: Record<string, unknown> = { url, background: true };
+            const newPageArgs: Record<string, unknown> = { url, background: !this._bringToFront };
             if (args.timeout) newPageArgs.timeout = args.timeout;
 
             try {

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -5069,6 +5069,53 @@ EXPLANATION_END`;
       return;
     }
 
+    // Settings — Browser automation
+    if (path === '/api/settings/browser' && req.method === 'GET') {
+      const { loadConfig: loadCfg } = await import('@markus/shared');
+      const currentConfig = loadCfg(this.markusConfigPath);
+      const browser = currentConfig.browser ?? {};
+      this.json(res, 200, {
+        bringToFront: browser.bringToFront ?? false,
+        remoteDebuggingPort: browser.remoteDebuggingPort ?? 0,
+        autoCloseTabs: browser.autoCloseTabs ?? true,
+      });
+      return;
+    }
+
+    if (path === '/api/settings/browser' && req.method === 'POST') {
+      const auth = await this.requireAuth(req, res);
+      if (!auth) return;
+      const body = await this.readBody(req);
+      const updates: Record<string, unknown> = {};
+      if (typeof body['bringToFront'] === 'boolean') updates.bringToFront = body['bringToFront'];
+      if (typeof body['remoteDebuggingPort'] === 'number') updates.remoteDebuggingPort = body['remoteDebuggingPort'];
+      if (typeof body['autoCloseTabs'] === 'boolean') updates.autoCloseTabs = body['autoCloseTabs'];
+      try {
+        saveConfig({ browser: updates } as any, this.markusConfigPath);
+        const am = this.orgService.getAgentManager();
+        if (typeof updates.bringToFront === 'boolean') {
+          am.setBrowserBringToFront(updates.bringToFront);
+        }
+        if (typeof updates.autoCloseTabs === 'boolean') {
+          am.setBrowserAutoCloseTabs(updates.autoCloseTabs);
+        }
+        if (typeof updates.remoteDebuggingPort === 'number') {
+          am.setBrowserRemoteDebuggingPort(updates.remoteDebuggingPort);
+        }
+      } catch (e) {
+        log.warn('Failed to persist browser settings', { error: String(e) });
+      }
+      const { loadConfig: loadCfg } = await import('@markus/shared');
+      const currentConfig = loadCfg(this.markusConfigPath);
+      const browser = currentConfig.browser ?? {};
+      this.json(res, 200, {
+        bringToFront: browser.bringToFront ?? false,
+        remoteDebuggingPort: browser.remoteDebuggingPort ?? 0,
+        autoCloseTabs: browser.autoCloseTabs ?? true,
+      });
+      return;
+    }
+
     if (path === '/api/settings/llm/models' && req.method === 'GET') {
       if (!this.llmRouter) {
         this.json(res, 200, { models: [] });

--- a/packages/shared/src/utils/config.ts
+++ b/packages/shared/src/utils/config.ts
@@ -50,6 +50,14 @@ export interface MarkusConfig {
     /** Safety cap on tool iterations per agent turn (default: 200) */
     maxToolIterations?: number;
   };
+  browser?: {
+    /** Bring Chrome tabs/windows to foreground when agent navigates (default: false) */
+    bringToFront?: boolean;
+    /** Remote debugging port for persistent Chrome connection (avoids repeated permission dialogs). Set to e.g. 9222 to enable. */
+    remoteDebuggingPort?: number;
+    /** Automatically close agent-owned tabs when the task completes (default: true) */
+    autoCloseTabs?: boolean;
+  };
   integrations?: {
     feishu?: { appId?: string; appSecret?: string };
     search?: { serperApiKey?: string; braveApiKey?: string };

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -1079,6 +1079,9 @@ export const api = {
     getAgent: () => request<{ maxToolIterations: number }>('/settings/agent'),
     updateAgent: (settings: { maxToolIterations?: number }) =>
       request<{ maxToolIterations: number }>('/settings/agent', { method: 'POST', body: JSON.stringify(settings) }),
+    getBrowser: () => request<{ bringToFront: boolean; remoteDebuggingPort: number; autoCloseTabs: boolean }>('/settings/browser'),
+    updateBrowser: (settings: { bringToFront?: boolean; remoteDebuggingPort?: number; autoCloseTabs?: boolean }) =>
+      request<{ bringToFront: boolean; remoteDebuggingPort: number; autoCloseTabs: boolean }>('/settings/browser', { method: 'POST', body: JSON.stringify(settings) }),
   },
   skills: {
     list: () => request<{ skills: Array<{ name: string; version: string; description?: string; author?: string; category?: string; tags?: string[]; tools?: Array<{ name: string; description: string }>; requiredPermissions?: string[]; type: 'builtin' | 'filesystem' | 'imported'; sourcePath?: string; agentIds: string[] }> }>('/skills'),

--- a/packages/web-ui/src/pages/Settings.tsx
+++ b/packages/web-ui/src/pages/Settings.tsx
@@ -65,6 +65,13 @@ export function Settings({ theme, onThemeChange }: { theme?: ThemeMode; onThemeC
   const [agentSaving, setAgentSaving] = useState(false);
   const [agentMsg, setAgentMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null);
 
+  // Browser automation settings
+  const [browserBringToFront, setBrowserBringToFront] = useState(false);
+  const [browserRemotePort, setBrowserRemotePort] = useState(0);
+  const [browserAutoClose, setBrowserAutoClose] = useState(true);
+  const [browserSaving, setBrowserSaving] = useState(false);
+  const [browserMsg, setBrowserMsg] = useState<{ type: 'ok' | 'err'; text: string } | null>(null);
+
   // Storage transparency
   const [storageInfo, setStorageInfo] = useState<StorageInfo | null>(null);
   const [storageLoading, setStorageLoading] = useState(false);
@@ -111,13 +118,25 @@ export function Settings({ theme, onThemeChange }: { theme?: ThemeMode; onThemeC
       .catch(() => {});
   }, []);
 
+  const loadBrowserSettings = useCallback(() => {
+    api.settings.getBrowser()
+      .then(d => {
+        if (d) {
+          setBrowserBringToFront(d.bringToFront ?? false);
+          setBrowserRemotePort(d.remoteDebuggingPort ?? 0);
+          setBrowserAutoClose(d.autoCloseTabs ?? true);
+        }
+      })
+      .catch(() => {});
+  }, []);
+
   const loadStorage = useCallback(() => {
     setStorageLoading(true);
     api.system.storage().then(setStorageInfo).catch(() => {}).finally(() => setStorageLoading(false));
     api.system.orphans().then(setOrphanInfo).catch(() => {});
   }, []);
 
-  useEffect(() => { loadSettings(); loadOAuthProviders(); loadAuthProfiles(); loadAgentSettings(); loadStorage(); }, [loadSettings, loadOAuthProviders, loadAuthProfiles, loadAgentSettings, loadStorage]);
+  useEffect(() => { loadSettings(); loadOAuthProviders(); loadAuthProfiles(); loadAgentSettings(); loadBrowserSettings(); loadStorage(); }, [loadSettings, loadOAuthProviders, loadAuthProfiles, loadAgentSettings, loadBrowserSettings, loadStorage]);
 
   useEffect(() => {
     const handler = () => loadStorage();
@@ -1129,6 +1148,117 @@ export function Settings({ theme, onThemeChange }: { theme?: ThemeMode; onThemeC
               </div>
             </div>
             {agentMsg && <Msg type={agentMsg.type} text={agentMsg.text} />}
+          </div>
+        </Section>
+
+        <Section title="Browser Automation">
+          <div className="bg-surface-secondary border border-border-default rounded-xl p-5 space-y-5">
+            <div className="text-xs text-fg-tertiary">
+              Settings for the Chrome DevTools browser skill. Agents use Chrome to browse, test web apps, and inspect pages.
+            </div>
+
+            {/* Bring to Front toggle */}
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm font-medium text-fg-primary">Bring to Foreground</div>
+                <div className="text-xs text-fg-tertiary mt-0.5">
+                  When enabled, Chrome tabs will be brought to the foreground when agents navigate.
+                  When disabled (default), agents work silently in the background without stealing focus.
+                </div>
+              </div>
+              <button
+                onClick={async () => {
+                  const newVal = !browserBringToFront;
+                  setBrowserBringToFront(newVal);
+                  setBrowserSaving(true); setBrowserMsg(null);
+                  try {
+                    const d = await api.settings.updateBrowser({ bringToFront: newVal });
+                    setBrowserBringToFront(d.bringToFront);
+                    setBrowserMsg({ type: 'ok', text: newVal ? 'Tabs will be brought to foreground' : 'Tabs will stay in background' });
+                  } catch { setBrowserMsg({ type: 'err', text: 'Failed to save' }); setBrowserBringToFront(!newVal); }
+                  setBrowserSaving(false);
+                }}
+                disabled={browserSaving}
+                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${browserBringToFront ? 'bg-green-500' : 'bg-gray-600'} ${browserSaving ? 'opacity-50' : ''}`}
+              >
+                <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${browserBringToFront ? 'translate-x-4' : 'translate-x-1'}`} />
+              </button>
+            </div>
+
+            {/* Auto-close tabs toggle */}
+            <div className="flex items-center justify-between border-t border-border-default pt-4">
+              <div>
+                <div className="text-sm font-medium text-fg-primary">Auto-close Tabs</div>
+                <div className="text-xs text-fg-tertiary mt-0.5">
+                  Automatically close agent-owned browser tabs when the agent task completes or the agent is removed.
+                </div>
+              </div>
+              <button
+                onClick={async () => {
+                  const newVal = !browserAutoClose;
+                  setBrowserAutoClose(newVal);
+                  setBrowserSaving(true); setBrowserMsg(null);
+                  try {
+                    const d = await api.settings.updateBrowser({ autoCloseTabs: newVal });
+                    setBrowserAutoClose(d.autoCloseTabs);
+                    setBrowserMsg({ type: 'ok', text: 'Saved' });
+                  } catch { setBrowserMsg({ type: 'err', text: 'Failed to save' }); setBrowserAutoClose(!newVal); }
+                  setBrowserSaving(false);
+                }}
+                disabled={browserSaving}
+                className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${browserAutoClose ? 'bg-green-500' : 'bg-gray-600'} ${browserSaving ? 'opacity-50' : ''}`}
+              >
+                <span className={`inline-block h-3.5 w-3.5 rounded-full bg-white transition-transform ${browserAutoClose ? 'translate-x-4' : 'translate-x-1'}`} />
+              </button>
+            </div>
+
+            {/* Remote Debugging Port */}
+            <div className="border-t border-border-default pt-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-sm font-medium text-fg-primary">Remote Debugging Port</div>
+                  <div className="text-xs text-fg-tertiary mt-0.5">
+                    Set a persistent debugging port (e.g. 9222) to avoid Chrome&apos;s permission
+                    dialog every time an agent connects. Start Chrome with{' '}
+                    <code className="text-fg-secondary bg-surface-elevated px-1 rounded">--remote-debugging-port=9222</code>{' '}
+                    then set the same port here. Set to 0 to use auto-connect (requires manual permission approval).
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <input
+                    type="number"
+                    min={0}
+                    max={65535}
+                    value={browserRemotePort}
+                    onChange={e => { setBrowserRemotePort(Number(e.target.value)); setBrowserMsg(null); }}
+                    className="w-24 px-3 py-1.5 text-sm border border-border-default rounded-lg bg-surface-primary text-fg-primary text-right"
+                    placeholder="0"
+                  />
+                  <button
+                    disabled={browserSaving}
+                    onClick={async () => {
+                      setBrowserSaving(true); setBrowserMsg(null);
+                      try {
+                        const d = await api.settings.updateBrowser({ remoteDebuggingPort: browserRemotePort });
+                        setBrowserRemotePort(d.remoteDebuggingPort);
+                        setBrowserMsg({
+                          type: 'ok',
+                          text: d.remoteDebuggingPort > 0
+                            ? `Using persistent connection on port ${d.remoteDebuggingPort} (no more permission dialogs)`
+                            : 'Using auto-connect mode (permission dialog required on each connection)',
+                        });
+                      } catch { setBrowserMsg({ type: 'err', text: 'Failed to save' }); }
+                      setBrowserSaving(false);
+                    }}
+                    className="px-3 py-1.5 text-xs bg-brand-500 text-white rounded-lg hover:bg-brand-600 transition-colors disabled:opacity-40"
+                  >
+                    {browserSaving ? 'Saving...' : 'Save'}
+                  </button>
+                </div>
+              </div>
+            </div>
+
+            {browserMsg && <Msg type={browserMsg.type} text={browserMsg.text} />}
           </div>
         </Section>
 

--- a/templates/skills/chrome-devtools/SKILL.md
+++ b/templates/skills/chrome-devtools/SKILL.md
@@ -24,17 +24,35 @@ Chrome DevTools is for interactive browser sessions that require a real renderin
 
 ## Prerequisites
 
-The MCP server connects to the user's running Chrome via `--autoConnect` (Chrome 144+).
+The MCP server connects to the user's running Chrome via one of two modes:
 
-**Setup steps:**
+### Mode 1: Auto-Connect (default)
+Uses `--autoConnect` to discover Chrome automatically (Chrome 144+).
 1. Chrome version must be 144 or newer (146+ recommended).
 2. Open `chrome://inspect/#remote-debugging` in Chrome and enable remote debugging.
 3. On first MCP connection, Chrome will show a permission dialog — the user must click **Allow**.
+4. **Note:** This permission is per-connection. Each new agent or session may trigger a new dialog.
+
+### Mode 2: Persistent Debugging Port (recommended for unattended use)
+Set **Remote Debugging Port** in Settings > Browser Automation (e.g. 9222) to skip the
+permission dialog entirely. This requires launching Chrome with:
+```
+chrome --remote-debugging-port=9222
+```
+Once configured, all agents reuse this connection without prompting for permission.
 
 **Frozen/suspended tabs cause connection timeout:** When Chrome has frozen tabs (Memory Saver
 or restored tabs), the MCP server may hang. If you encounter a timeout, inform the user to:
 upgrade Chrome to 146+, disable Memory Saver at `chrome://settings/performance`, click suspended
 tabs to wake them, or use a dedicated Chrome profile with few tabs.
+
+## Configurable behavior (Settings > Browser Automation)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| **Bring to Foreground** | Off | When on, Chrome tabs are brought to the foreground during agent operations. When off (default), agents operate silently in background tabs. |
+| **Auto-close Tabs** | On | When on, agent-owned tabs are closed when the agent task completes or the agent is removed. |
+| **Remote Debugging Port** | 0 (auto-connect) | Set to a port number (e.g. 9222) to use a persistent debugging connection instead of auto-connect, eliminating repeated permission dialogs. |
 
 ## Tool reference
 
@@ -136,18 +154,19 @@ on the current page?" If yes, call `new_page` first.
 ## CRITICAL: operate in the background — never steal user focus
 
 The user may be working in another application (IDE, terminal, another browser tab) while
-you interact with Chrome. **You must never cause Chrome to steal window focus.**
+you interact with Chrome. **By default, you must never cause Chrome to steal window focus.**
 
-The system enforces this automatically for internal operations, but you must also follow
-these rules for your own tool calls:
+The system enforces this automatically based on the "Bring to Foreground" setting
+(Settings > Browser Automation). When the setting is **off** (default):
 
-- **`new_page`**: Always pass `background: true`. This opens the tab without bringing
-  Chrome to the foreground. Example: `new_page({ url: "...", background: true })`
-- **`select_page`**: Always pass `bringToFront: false` (or omit `bringToFront` — the
-  system defaults it to `false`). Never pass `bringToFront: true` unless the user
-  explicitly asks you to show them a page.
-- **`navigate_page`**: This navigates the current tab in-place and does not have a
-  focus parameter. The system handles background selection automatically.
+- **`new_page`**: The system automatically opens tabs in the background.
+- **`select_page`**: The system automatically prevents Chrome from coming to foreground.
+- **`navigate_page`**: The system handles background selection automatically.
+
+When the setting is **on**, the system will bring Chrome to the foreground during operations,
+which is useful when you want to watch what the agent is doing in real-time.
+
+Regardless of the setting:
 - **Do NOT call `select_page` unnecessarily.** The system auto-selects your current
   tab before each operation. Only call `select_page` when you need to switch between
   multiple tabs you own.


### PR DESCRIPTION
…alogs

- Add browser config section (bringToFront, remoteDebuggingPort, autoCloseTabs) to MarkusConfig for persistent browser automation preferences
- Add GET/POST /api/settings/browser endpoints with runtime propagation
- BrowserSessionManager now respects bringToFront setting for new_page, select_page, navigate_page and ensureCorrectPage operations
- When remoteDebuggingPort is set, chrome-devtools MCP server uses --browserUrl instead of --autoConnect, eliminating Chrome's per-connection permission dialog entirely
- Add Browser Automation section to Settings page with three controls: Bring to Foreground toggle, Auto-close Tabs toggle, Remote Debugging Port
- Update chrome-devtools SKILL.md with configurable behavior docs

Made-with: Cursor