### PR TITLE
[TASK-48a934b1] fix: Agent API 缺陷修复 (BUG-001 & BUG-002)

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -1258,6 +1258,7 @@ export class APIServer {
           role: agent.role.name,
           agentRole: agent.config.agentRole,
           status: agent.getState().status,
+          skills: agent.config.skills ?? [],
         },
       });
       return;
@@ -1403,6 +1404,15 @@ export class APIServer {
 
     if (path.match(/^\/api\/agents\/[^/]+$/) && req.method === 'DELETE') {
       const agentId = path.split('/')[3]!;
+
+      // Validate agent exists before deletion
+      try {
+        this.orgService.getAgentManager().getAgent(agentId);
+      } catch {
+        this.json(res, 404, { error: 'Agent not found' });
+        return;
+      }
+
       if (this.orgService.isProtectedAgent(agentId)) {
         this.json(res, 403, { error: 'The Secretary agent is a protected system agent and cannot be deleted.' });
         return;


### PR DESCRIPTION
## 修复内容

修复 QA 测试发现的两个 Agent API 缺陷：

### BUG-001: POST /api/agents 返回缺少 skills 字段
**问题**：`hireAgent` 创建 Agent 后返回的 JSON 中缺少 `skills` 字段  
**修复**：在 `POST /api/agents` 响应中添加 `skills: agent.config.skills ?? []`

### BUG-002: DELETE /api/agents/:id 对不存在 Agent 返回 200 而非 404
**问题**：删除不存在的 Agent 时，`fireAgent` 内部调用 `removeAgent` 无视 agent 是否存在，始终返回 200  
**修复**：在 DELETE 处理前先通过 `getAgentManager().getAgent(agentId)` 验证 Agent 存在性，不存在则返回 404

## 修改文件
- `packages/org-manager/src/api-server.ts`