### PR TITLE
fix: 6 runtime bugs from log analysis + centralize new limits

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -847,11 +847,12 @@ async function startServer(config: ReturnType<typeof loadConfig>, values: Record
         mailbox.setPersistence({
           save: (item) => {
             try {
+              const { responsePromise, ...persistableMetadata } = (item.metadata ?? {}) as Record<string, unknown>;
               mbRepo.save({
                 id: item.id, agentId: item.agentId, sourceType: item.sourceType,
                 priority: item.priority, status: item.status,
                 payload: item.payload as unknown as Record<string, unknown>,
-                metadata: (item.metadata ?? {}) as unknown as Record<string, unknown>,
+                metadata: persistableMetadata,
                 queuedAt: item.queuedAt,
               });
             } catch (e) { log.warn('Failed to persist mailbox item', { id: item.id, error: String(e) }); }

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -804,10 +804,14 @@ export class Agent {
       ? { name: item.metadata.senderName, role: item.metadata.senderRole ?? 'user' }
       : undefined;
     const resolveResponse = (reply: string) => {
-      item.metadata?.responsePromise?.resolve(stripCompletionMarker(reply));
+      if (typeof item.metadata?.responsePromise?.resolve === 'function') {
+        item.metadata.responsePromise.resolve(stripCompletionMarker(reply));
+      }
     };
     const rejectResponse = (err: unknown) => {
-      item.metadata?.responsePromise?.reject(err);
+      if (typeof item.metadata?.responsePromise?.reject === 'function') {
+        item.metadata.responsePromise.reject(err);
+      }
     };
 
     const ts = Date.now();
@@ -961,8 +965,9 @@ export class Agent {
             agentId: this.id,
             triggeredAt: item.queuedAt,
           });
-          resolveResponse('');
-          return;
+          const hbReply = COMPLETION_MARKER;
+          resolveResponse(hbReply);
+          return hbReply;
         }
 
         case 'system_event':
@@ -2388,13 +2393,14 @@ export class Agent {
           }
           const loopCheck = this.loopDetector.check();
           if (loopCheck.detected) {
+            const warningMsg = `[SYSTEM] Loop detected: ${loopCheck.message}. You are repeating the same actions without progress. Try a different approach or stop.`;
+            this.memory.appendMessage(sessionId, { role: 'user', content: warningMsg });
             if (loopCheck.severity === 'critical') {
-              log.warn('Loop detector: critical pattern — breaking', {
+              log.warn('Loop detector: critical pattern — force-breaking tool loop', {
                 agentId: this.id,
                 pattern: loopCheck.pattern,
               });
-              const warningMsg = `[SYSTEM] Loop detected: ${loopCheck.message}. You are repeating the same actions without progress. Try a different approach or stop.`;
-              this.memory.appendMessage(sessionId, { role: 'user', content: warningMsg });
+              break;
             }
           }
         }
@@ -2744,12 +2750,15 @@ export class Agent {
             this.loopDetector.record(tc.name, tc.arguments ?? {}, toolResults[i]?.content ?? '');
           }
           const loopCheck = this.loopDetector.check();
-          if (loopCheck.detected && loopCheck.severity === 'critical') {
-            log.warn('Stream loop detector: critical pattern — injecting warning', {
-              agentId: this.id, pattern: loopCheck.pattern,
-            });
+          if (loopCheck.detected) {
             const warningMsg = `[SYSTEM] Loop detected: ${loopCheck.message}. You are repeating the same actions without progress. Try a different approach or stop.`;
             this.memory.appendMessage(this.currentSessionId, { role: 'user', content: warningMsg });
+            if (loopCheck.severity === 'critical') {
+              log.warn('Stream loop detector: critical pattern — force-breaking tool loop', {
+                agentId: this.id, pattern: loopCheck.pattern,
+              });
+              break;
+            }
           }
         }
 

--- a/packages/core/src/heartbeat.ts
+++ b/packages/core/src/heartbeat.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@markus/shared';
+import { createLogger, HEARTBEAT_MIN_INITIAL_DELAY_MS } from '@markus/shared';
 import type { EventBus } from './events.js';
 
 const log = createLogger('heartbeat');
@@ -40,7 +40,8 @@ export class HeartbeatScheduler {
     this.running = true;
     this.startTime = Date.now();
 
-    const delay = initialDelayMs ?? Math.floor(Math.random() * this.config.intervalMs);
+    const rawDelay = initialDelayMs ?? Math.floor(Math.random() * this.config.intervalMs);
+    const delay = Math.max(rawDelay, HEARTBEAT_MIN_INITIAL_DELAY_MS);
     this.effectiveInitialDelayMs = delay;
 
     log.info('Starting heartbeat scheduler', {

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -1,4 +1,4 @@
-import { createLogger, getTextContent, type LLMRequest, type LLMResponse, type LLMStreamEvent, type LLMProviderConfig, type ModelDefinition, type ModelCostConfig, type EnhancedProviderSettings, type EnhancedLLMSettings, type AuthProfile } from '@markus/shared';
+import { createLogger, getTextContent, LLM_CIRCUIT_RESET_RATE_LIMIT_MS, LLM_MAX_CONCURRENT_PER_PROVIDER, LLM_CONCURRENCY_JITTER_BASE_MS, type LLMRequest, type LLMResponse, type LLMStreamEvent, type LLMProviderConfig, type ModelDefinition, type ModelCostConfig, type EnhancedProviderSettings, type EnhancedLLMSettings, type AuthProfile } from '@markus/shared';
 import { startSpan } from '../tracing.js';
 import type { LLMProviderInterface } from './provider.js';
 import { AnthropicProvider } from './anthropic.js';
@@ -72,11 +72,16 @@ export class LLMRouter {
   private customModelCatalog = new Map<string, ModelDefinition[]>();
   private disabledProviders = new Set<string>();
 
+  /** Per-provider in-flight request counter for concurrency-aware jitter */
+  private inFlight = new Map<string, number>();
+
   private _profileStore?: AuthProfileStore;
   private _oauthManager?: OAuthManager;
 
   private readonly CIRCUIT_OPEN_AFTER = 2;
   private readonly CIRCUIT_RESET_MS = 5 * 60 * 1000;
+  /** Rate-limit (429) failures recover much faster than generic errors */
+  private readonly CIRCUIT_RESET_RATE_LIMIT_MS = LLM_CIRCUIT_RESET_RATE_LIMIT_MS;
   /** Non-retryable failures (auth, billing, region) get a longer cooldown */
   private readonly CIRCUIT_RESET_FATAL_MS = 30 * 60 * 1000;
 
@@ -185,6 +190,30 @@ export class LLMRouter {
       /authentication/i.test(msg);
   }
 
+  /** Detect rate-limit (429) errors which should use a shorter circuit breaker cooldown. */
+  private static isRateLimitError(error: unknown): boolean {
+    const msg = error instanceof Error ? error.message : String(error);
+    return /\b429\b/.test(msg) || /rate.limit/i.test(msg);
+  }
+
+  /**
+   * Apply random jitter when a provider has many concurrent in-flight requests.
+   * Spreads burst traffic to avoid thundering-herd 429 cascades.
+   */
+  private async applyJitter(providerName: string): Promise<void> {
+    const current = this.inFlight.get(providerName) ?? 0;
+    if (current >= LLM_MAX_CONCURRENT_PER_PROVIDER) {
+      const jitter = Math.round(LLM_CONCURRENCY_JITTER_BASE_MS + Math.random() * LLM_CONCURRENCY_JITTER_BASE_MS * 2);
+      await new Promise(r => setTimeout(r, jitter));
+    }
+    this.inFlight.set(providerName, (this.inFlight.get(providerName) ?? 0) + 1);
+  }
+
+  private releaseInflight(providerName: string): void {
+    const current = this.inFlight.get(providerName) ?? 0;
+    this.inFlight.set(providerName, Math.max(0, current - 1));
+  }
+
   private static healthKey(provider: string, model: string): string {
     return `${provider}:${model}`;
   }
@@ -215,14 +244,16 @@ export class LLMRouter {
       return;
     }
 
+    const isRateLimit = LLMRouter.isRateLimitError(error);
     const h = this.getModelHealth(provider, model);
     h.consecutiveFailures++;
     h.lastFailureAt = Date.now();
 
     if (h.consecutiveFailures >= this.CIRCUIT_OPEN_AFTER && !h.degraded) {
       h.degraded = true;
-      h.resetMs = this.CIRCUIT_RESET_MS;
-      log.warn(`Model ${provider}:${model} marked as degraded after ${h.consecutiveFailures} failures — skipping for ${this.CIRCUIT_RESET_MS / 60000} min`);
+      h.resetMs = isRateLimit ? this.CIRCUIT_RESET_RATE_LIMIT_MS : this.CIRCUIT_RESET_MS;
+      const cooldownSec = h.resetMs / 1000;
+      log.warn(`Model ${provider}:${model} marked as degraded after ${h.consecutiveFailures} failures (${isRateLimit ? 'rate-limit' : 'error'}) — skipping for ${cooldownSec}s`);
     }
   }
 
@@ -527,6 +558,7 @@ export class LLMRouter {
       provider.configure({ provider: providerName as any, model: altModel });
     }
     const activeModel = provider.model;
+    await this.applyJitter(providerName);
     try {
       const response = await provider.chat(request);
       this.recordSuccess(providerName, activeModel);
@@ -537,6 +569,8 @@ export class LLMRouter {
         provider.configure({ provider: providerName as any, model: originalModel });
       }
       throw LLMRouter.enrichError(error, providerName, activeModel);
+    } finally {
+      this.releaseInflight(providerName);
     }
   }
 
@@ -618,6 +652,7 @@ export class LLMRouter {
       provider.configure({ provider: providerName as any, model: altModel });
     }
     const activeModel = provider.model;
+    await this.applyJitter(providerName);
     try {
       let response: LLMResponse;
       if (provider.chatStream) {
@@ -635,6 +670,8 @@ export class LLMRouter {
         provider.configure({ provider: providerName as any, model: originalModel });
       }
       throw LLMRouter.enrichError(error, providerName, activeModel);
+    } finally {
+      this.releaseInflight(providerName);
     }
   }
 

--- a/packages/core/src/tools/browser-session.ts
+++ b/packages/core/src/tools/browser-session.ts
@@ -215,17 +215,20 @@ export class BrowserSessionManager {
           args.background = true;
         }
         return this.withAgentLock(agentId, async () => {
+          const owned = this.getOwned(ownerKey);
+          const prevIds = new Set(owned);
           const result = await handler.execute(args);
           const pages = this.parsePageEntries(result);
-          const owned = this.getOwned(ownerKey);
-          const newPage = pages.find((p) => p.selected) ?? pages.find((p) => !owned.has(p.id));
+          const newPage = pages.find((p) => p.selected)
+            ?? pages.find((p) => !prevIds.has(p.id))
+            ?? (pages.length > 0 ? pages.reduce((a, b) => (a.id > b.id ? a : b)) : undefined);
           if (newPage) {
             owned.add(newPage.id);
             this.currentPage.set(ownerKey, newPage.id);
             this.lastActiveSession.set(agentId, { ownerKey, pageId: newPage.id });
             log.debug(`Page ${newPage.id} (${newPage.url}) assigned to ${ownerKey}`);
           } else {
-            log.warn(`new_page response did not contain a [selected] page for ${ownerKey}`);
+            log.warn(`new_page response contained no pages for ${ownerKey}`);
           }
           return this.annotateResponse(result, ownerKey);
         });
@@ -340,9 +343,12 @@ export class BrowserSessionManager {
             if (args.timeout) newPageArgs.timeout = args.timeout;
 
             try {
+              const prevIds = new Set(owned);
               const result = await newPageHandler.execute(newPageArgs);
               const pages = this.parsePageEntries(result);
-              const newPage = pages.find((p) => p.selected) ?? pages.find((p) => !owned.has(p.id));
+              const newPage = pages.find((p) => p.selected)
+                ?? pages.find((p) => !prevIds.has(p.id))
+                ?? (pages.length > 0 ? pages.reduce((a, b) => (a.id > b.id ? a : b)) : undefined);
 
               if (newPage) {
                 owned.add(newPage.id);

--- a/packages/org-manager/src/org-service.ts
+++ b/packages/org-manager/src/org-service.ts
@@ -5,6 +5,7 @@ import {
   createLogger,
   orgId,
   generateId,
+  HEARTBEAT_STARTUP_JITTER_MS,
   type Organization,
   type Team,
   type TeamInfo,
@@ -826,7 +827,7 @@ export class OrganizationService {
         const id = ids[i]!;
         try {
           const initialHeartbeatDelayMs = ids.length > 1
-            ? Math.floor((i / ids.length) * DEFAULT_HEARTBEAT_INTERVAL_MS)
+            ? Math.floor((i / ids.length) * DEFAULT_HEARTBEAT_INTERVAL_MS) + Math.floor(Math.random() * HEARTBEAT_STARTUP_JITTER_MS)
             : undefined;
           await this.agentManager.startAgent(id, { initialHeartbeatDelayMs });
           started++;

--- a/packages/shared/src/limits.ts
+++ b/packages/shared/src/limits.ts
@@ -374,3 +374,32 @@ export const SHELL_TIMEOUT_MAX_MS = 300_000;
  *  request_user_approval can wait indefinitely for the user. 24 hours is a
  *  generous safety net while allowing realistic human response times. */
 export const APPROVAL_WAIT_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+// ─── Heartbeat Startup ──────────────────────────────────────────────────────
+
+/** Minimum initial delay (ms) before an agent's first heartbeat fires.
+ *  Prevents the first agent from firing immediately at startup, giving the
+ *  system time to settle and avoiding a burst of LLM requests at boot. */
+export const HEARTBEAT_MIN_INITIAL_DELAY_MS = 5_000;
+
+/** Random jitter (ms) added to deterministic heartbeat stagger on startup.
+ *  When multiple agents start together, each gets a stagger offset plus
+ *  this random jitter to avoid deterministic collisions across restarts. */
+export const HEARTBEAT_STARTUP_JITTER_MS = 10_000;
+
+// ─── LLM Router Circuit Breaker ─────────────────────────────────────────────
+
+/** Circuit-breaker cooldown (ms) specifically for rate-limit (HTTP 429) errors.
+ *  Much shorter than the generic 5-minute cooldown because rate limits
+ *  typically clear within seconds. */
+export const LLM_CIRCUIT_RESET_RATE_LIMIT_MS = 30 * 1000;
+
+/** Max concurrent in-flight LLM requests per provider before jitter kicks in.
+ *  When exceeded, additional requests add a random delay to spread the load
+ *  and avoid thundering-herd 429 cascades. */
+export const LLM_MAX_CONCURRENT_PER_PROVIDER = 5;
+
+/** Base delay (ms) for the random jitter applied when per-provider concurrency
+ *  exceeds LLM_MAX_CONCURRENT_PER_PROVIDER.  Actual delay is in the range
+ *  [JITTER_BASE, JITTER_BASE * 3]. */
+export const LLM_CONCURRENCY_JITTER_BASE_MS = 500;


### PR DESCRIPTION
Bug fixes identified from runtime-2026-04-17.log analysis:

1. responsePromise.reject is not a function — guard deserialized mailbox items where JSON.stringify stripped resolve/reject functions; also strip responsePromise before persistence in start.ts.

2. Heartbeat triggers false "abnormal completion" retry loop — return COMPLETION_MARKER from heartbeat case instead of undefined.

3. LLM router thundering herd / cascade degradation — add shorter 30s circuit-breaker cooldown for 429 rate-limit errors (vs generic 5min), plus per-provider concurrency tracking with random jitter.

4. Tool loop detector only warns but never breaks — inject warning message on any detected loop and force-break on critical severity.

5. Browser session new_page race condition — snapshot owned page IDs before executing, add highest-ID fallback for page identification.

6. Startup heartbeat burst — add 5s minimum initial delay and random jitter to deterministic stagger calculation.

Centralize new magic numbers (HEARTBEAT_MIN_INITIAL_DELAY_MS, HEARTBEAT_STARTUP_JITTER_MS, LLM_CIRCUIT_RESET_RATE_LIMIT_MS, LLM_MAX_CONCURRENT_PER_PROVIDER, LLM_CONCURRENCY_JITTER_BASE_MS) into packages/shared/src/limits.ts.

Made-with: Cursor