### PR TITLE
[TASK-tsk_718ddbc2] fix: add missing agent FK setup in sqlite-storage tests

### DIFF
--- a/packages/storage/test/sqlite-storage.test.ts
+++ b/packages/storage/test/sqlite-storage.test.ts
@@ -85,9 +85,12 @@ describe('SQLite Storage Backend', () => {
     it('should create, update, and query tasks', () => {
       const orgRepo = new SqliteOrgRepo(db);
       orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      const agentRepo = new SqliteAgentRepo(db);
+      agentRepo.create({ id: 'agent-1', name: 'Agent1', orgId: 'org-1', roleId: 'r1', roleName: 'Dev' });
+      agentRepo.create({ id: 'agent-2', name: 'Agent2', orgId: 'org-1', roleId: 'r1', roleName: 'Reviewer' });
 
       const repo = new SqliteTaskRepo(db);
-      repo.create({ id: 'task-1', orgId: 'org-1', title: 'Build feature', priority: 'high' });
+      repo.create({ id: 'task-1', orgId: 'org-1', title: 'Build feature', priority: 'high', assignedAgentId: 'agent-1', reviewerAgentId: 'agent-2' });
       repo.updateStatus('task-1', 'in_progress');
 
       const task = repo.findById('task-1');
@@ -241,8 +244,11 @@ describe('SQLite Storage Backend', () => {
     it('should append and retrieve task logs', () => {
       const orgRepo = new SqliteOrgRepo(db);
       orgRepo.createOrg({ id: 'org-1', name: 'Org', ownerId: 'u1' });
+      const agentRepo = new SqliteAgentRepo(db);
+      agentRepo.create({ id: 'agent-1', name: 'Agent1', orgId: 'org-1', roleId: 'r1', roleName: 'Dev' });
+      agentRepo.create({ id: 'agent-2', name: 'Agent2', orgId: 'org-1', roleId: 'r1', roleName: 'Reviewer' });
       const taskRepo = new SqliteTaskRepo(db);
-      taskRepo.create({ id: 't1', orgId: 'org-1', title: 'Task' });
+      taskRepo.create({ id: 't1', orgId: 'org-1', title: 'Task', assignedAgentId: 'agent-1', reviewerAgentId: 'agent-2' });
 
       const repo = new SqliteTaskLogRepo(db);
       repo.append({ taskId: 't1', agentId: 'a1', seq: 0, type: 'status', content: 'started' });


### PR DESCRIPTION
## Summary

Fix 2 pre-existing test failures in `packages/storage/test/sqlite-storage.test.ts` caused by schema NOT NULL + FK constraint changes.

## Root Cause

The `tasks` table schema has:
- `assigned_agent_id TEXT NOT NULL REFERENCES agents(id)` (FK constraint)
- `reviewer_agent_id TEXT NOT NULL` (NOT NULL)

Two tests were creating tasks without these required fields, and without creating the referenced agent records.

### Test 1: TaskRepo (line 90)
`repo.create({ id: 'task-1', orgId: 'org-1', title: 'Build feature', priority: 'high' })`
→ Missing `assignedAgentId` and `reviewerAgentId`, and no agent 'agent-1' in DB

### Test 2: TaskLogRepo (line 245)
`taskRepo.create({ id: 't1', orgId: 'org-1', title: 'Task' })`
→ Same issue

## Fix
- Added agent creation (`agent-1`, `agent-2`) before task creation in both tests
- Added `assignedAgentId` and `reviewerAgentId` to task creation calls

## Verification
- ✅ `pnpm typecheck` passes
- ✅ `pnpm test` — all 12 tests pass, 0 unhandled errors