### PR TITLE
[TASK-tsk_1262ca4e5f2985ddcc69afc9] feat: 修复中文文件名写入问题 + DRY重构

### DIFF
--- a/packages/core/src/tools/patch.ts
+++ b/packages/core/src/tools/patch.ts
@@ -1,5 +1,5 @@
 import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { dirname } from 'node:path';
 import type { PathAccessPolicy } from '@markus/shared';
 import type { AgentToolHandler } from '../agent.js';
 import { defaultSecurityGuard, type SecurityGuard } from '../security.js';
@@ -76,10 +76,10 @@ export function createPatchTool(security?: SecurityGuard, workspacePath?: string
         return JSON.stringify({ status: 'error', error: 'patches array is required and must not be empty' });
       }
 
-      const basePath = workspacePath ?? process.cwd();
+      const resolvedPaths: string[] = [];
       const results: Array<{ file: string; action: string; status: string; detail?: string }> = [];
 
-      // Validation pass
+      // Validation pass — collect resolved paths so the apply pass reuses them
       for (const patch of patches) {
         const { resolved: filePath, access } = resolveAndCheckAccess(patch.file, workspacePath, policy);
 
@@ -125,6 +125,8 @@ export function createPatchTool(security?: SecurityGuard, workspacePath?: string
         if (patch.action === 'create' && !patch.content && patch.content !== '') {
           return JSON.stringify({ status: 'error', error: `create action requires content for ${patch.file}` });
         }
+
+        resolvedPaths.push(filePath);
       }
 
       if (dryRun) {
@@ -135,9 +137,10 @@ export function createPatchTool(security?: SecurityGuard, workspacePath?: string
         });
       }
 
-      // Apply pass
-      for (const patch of patches) {
-        const filePath = resolve(basePath, patch.file);
+      // Apply pass — use the already-validated resolved paths from the validation pass
+      for (let i = 0; i < patches.length; i++) {
+        const patch = patches[i]!;
+        const filePath = resolvedPaths[i]!;
 
         switch (patch.action) {
           case 'edit': {

--- a/packages/core/test/patch-tool.test.ts
+++ b/packages/core/test/patch-tool.test.ts
@@ -150,4 +150,127 @@ describe('apply_patch tool', () => {
     const parsed = JSON.parse(result);
     expect(parsed.status).toBe('denied');
   });
+
+  // ── Chinese / Unicode filename tests ────────────────────────────────────
+
+  it('should create a file with a Chinese filename', async () => {
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '测试文件.txt', action: 'create', content: '中文内容\n' },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(parsed.appliedPatches).toBe(1);
+    expect(existsSync(join(tempDir, '测试文件.txt'))).toBe(true);
+    expect(readFileSync(join(tempDir, '测试文件.txt'), 'utf-8')).toContain('中文内容');
+  });
+
+  it('should edit a file with a Chinese filename', async () => {
+    const file = join(tempDir, '中文文档.txt');
+    writeFileSync(file, '你好，世界！\n');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '中文文档.txt', action: 'edit', hunks: [{ old_string: '你好，世界！', new_string: '你好，Markus！' }] },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(readFileSync(file, 'utf-8')).toContain('你好，Markus！');
+  });
+
+  it('should edit a file with Japanese filename', async () => {
+    const file = join(tempDir, '日本語ファイル.txt');
+    writeFileSync(file, 'こんにちは\n');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '日本語ファイル.txt', action: 'edit', hunks: [{ old_string: 'こんにちは', new_string: 'こんばんは' }] },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(readFileSync(file, 'utf-8')).toContain('こんばんは');
+  });
+
+  it('should delete a file with Chinese filename', async () => {
+    const file = join(tempDir, '待删除文件.txt');
+    writeFileSync(file, 'delete me');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [{ file: '待删除文件.txt', action: 'delete' }],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it('should create a file in a deep Chinese path', async () => {
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '深度目录/子文件夹/测试文件.txt', action: 'create', content: '深度路径测试\n' },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(existsSync(join(tempDir, '深度目录', '子文件夹', '测试文件.txt'))).toBe(true);
+  });
+
+  it('should handle filenames with mixed Chinese and special characters', async () => {
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '测试-2024年_报告(v1).md', action: 'create', content: '# 混合文件名测试\n' },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(existsSync(join(tempDir, '测试-2024年_报告(v1).md'))).toBe(true);
+  });
+
+  it('should handle Korean filename', async () => {
+    const file = join(tempDir, '한글파일.txt');
+    writeFileSync(file, '안녕하세요\n');
+
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '한글파일.txt', action: 'edit', hunks: [{ old_string: '안녕하세요', new_string: '감사합니다' }] },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(readFileSync(file, 'utf-8')).toContain('감사합니다');
+  });
+
+  it('should support multiple patches with mixed Chinese/English filenames', async () => {
+    const tool = createTool();
+    const result = await tool.execute({
+      patches: [
+        { file: '中文文件.txt', action: 'create', content: '中文内容\n' },
+        { file: 'english-file.txt', action: 'create', content: 'English content\n' },
+        { file: '混合-混合-file.txt', action: 'create', content: '混合内容\n' },
+      ],
+    });
+
+    const parsed = JSON.parse(result);
+    expect(parsed.status).toBe('success');
+    expect(parsed.appliedPatches).toBe(3);
+    expect(existsSync(join(tempDir, '中文文件.txt'))).toBe(true);
+    expect(existsSync(join(tempDir, 'english-file.txt'))).toBe(true);
+    expect(existsSync(join(tempDir, '混合-混合-file.txt'))).toBe(true);
+  });
 });


### PR DESCRIPTION
## 问题
调研 Agent 文件写入工具对中文文件名的处理机制。

## 调研结论
- **file\_write** / **file\_edit** — 单路径操作，路径仅解析一次，无问题
- **apply\_patch** — 验证阶段解析路径，应用阶段重新 resolve() 违反了 DRY 原则
- Node.js `fs` 原生支持 UTF-8 路径（macOS/Linux），工具层无需额外编码处理
- 中文文件名写入从未真正"不工作"，但存在重复解析的冗余代码

## 改动
1. **packages/core/src/tools/patch.ts**: DRY 重构 — 在验证阶段收集解析后的路径，在应用阶段复用
2. **packages/core/test/patch-tool.test.ts**: 添加 8 个中文/日文/韩文文件名测试用例

## 验证
- ✅ pnpm typecheck 通过
- ✅ 全部 16 个 patch 测试通过（8 原始 + 8 新）

Closes TASK-tsk_1262ca4e5f2985ddcc69afc9