### PR TITLE
[TASK-tsk_46953e17c600154315f265fc] fix: publishDeliverablestoShared 中文文件名路径编码异常

### DIFF
--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -2864,8 +2864,9 @@ export class TaskService {
         }
       }
       // For file types without a physical path, write the summary as a file
-      if (d.type === 'file' && d.summary && !existsSync(d.reference)) {
-        const safeName = d.reference.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+      if (d.type === 'file' && d.summary && !existsSync(src)) {
+        const baseName = d.reference.split('/').pop() ?? 'deliverable';
+        const safeName = baseName.replace(/[^a-zA-Z0-9_一-鿿.-]/g, '_').slice(0, 80);
         writeFileSync(join(taskSharedDir, `${safeName}.md`), d.summary);
       }
     }


### PR DESCRIPTION
Fix two defects in publishDeliverablestoShared():

1. Use resolved  path instead of raw  for existsSync check
2. Extract basename before sanitization and add Chinese character range