### PR TITLE
[TASK-tsk_46953e17c600154315f265fc] fix: publishDeliverablestoShared 中文文件名路径编码异常

### DIFF
--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -2852,8 +2852,8 @@ export class TaskService {
 
     // For file-type deliverables, try to copy the file to shared space
     for (const d of deliverables) {
+      const src = d.reference ? resolve(d.reference) : '';
       if (d.type === 'file' && d.reference) {
-        const src = resolve(d.reference);
         if (existsSync(src)) {
           try {
             const destName = src.split('/').pop() ?? 'deliverable';
@@ -2864,8 +2864,9 @@ export class TaskService {
         }
       }
       // For file types without a physical path, write the summary as a file
-      if (d.type === 'file' && d.summary && !existsSync(d.reference)) {
-        const safeName = d.reference.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80);
+      if (d.type === 'file' && d.summary && d.reference && !existsSync(src)) {
+        const baseName = d.reference.split('/').pop() ?? 'deliverable';
+        const safeName = baseName.replace(/[^a-zA-Z0-9_\u4e00-\u9fff.-]/g, '_').slice(0, 80);
         writeFileSync(join(taskSharedDir, `${safeName}.md`), d.summary);
       }
     }

--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -2852,8 +2852,9 @@ export class TaskService {
 
     // For file-type deliverables, try to copy the file to shared space
     for (const d of deliverables) {
-      const src = d.reference ? resolve(d.reference) : '';
+      let src: string | undefined;
       if (d.type === 'file' && d.reference) {
+        src = resolve(d.reference);
         if (existsSync(src)) {
           try {
             const destName = src.split('/').pop() ?? 'deliverable';
@@ -2864,7 +2865,7 @@ export class TaskService {
         }
       }
       // For file types without a physical path, write the summary as a file
-      if (d.type === 'file' && d.summary && d.reference && !existsSync(src)) {
+      if (d.type === 'file' && d.summary && src && !existsSync(src)) {
         const baseName = d.reference.split('/').pop() ?? 'deliverable';
         const safeName = baseName.replace(/[^a-zA-Z0-9_\u4e00-\u9fff.-]/g, '_').slice(0, 80);
         writeFileSync(join(taskSharedDir, `${safeName}.md`), d.summary);


### PR DESCRIPTION
## 修复内容

修复 `packages/org-manager/src/task-service.ts` 中 `publishDeliverablestoShared()` 方法的两处缺陷：

### Defect 1 — 错误的路径变量
原代码：`!existsSync(d.reference)` — 使用未解析的原始路径字符串
修复：`!existsSync(src)` — 使用通过 resolve() 解析的绝对路径

### Defect 2 — 中文文件名被错误 sanitize
原正则：`/[^a-zA-Z0-9._-]/g` — 将中文字符替换为 `_`
修复：先提取 basename，再用 `/[^a-zA-Z0-9_\\u4e00-\\u9fff.-]/g` 保留中文

## 验证
- ✅ `tsc -b --noEmit` 通过
- ✅ 无外部 API 或数据结构变更

Closes #36 (old branch with unrelated changes mixed in)