### PR TITLE
[TASK-tsk_425da68981e1c5cd7d045905] fix: DELETE non-existent agent returns 404

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -2111,6 +2111,11 @@ export class APIServer {
         this.json(res, 403, { error: 'The Secretary agent is a protected system agent and cannot be deleted.' });
         return;
       }
+      const agentExists = this.orgService.getAgentManager().listAgents().some(a => a.id === agentId);
+      if (!agentExists) {
+        this.json(res, 404, { error: 'Agent not found' });
+        return;
+      }
       if (this.gateway) {
         const extReg = this.gateway.listRegistrations().find(r => r.markusAgentId === agentId);
         if (extReg) {


### PR DESCRIPTION
## Summary

When DELETE /api/agents/:id is called with a non-existent agent ID, the endpoint incorrectly returned  with HTTP 200. This fix adds an agent existence check before the delete operation, returning HTTP 404 with  when the agent doesn't exist.

## Root Cause

The  →  chain silently succeeds even when the agent doesn't exist (the in-memory map entry deletion is a no-op for non-existent keys).

## Change

Added agent existence check via  after the protected agent guard in the DELETE handler.

## Verification

-  passes cleanly
- Minimal change: +5 lines