### PR TITLE
[TASK-tsk_7302d17a13f0015cafef7dff+TASK-tsk_68e52ab0c0c824686343f647][Backend] fix: BUG-003 POST null body → 400, BUG-005 missing Content-Type → 415

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -1218,21 +1218,37 @@ export class APIServer {
       return;
     }
 
+    // BUG-005: Validate Content-Type for POST/PUT/PATCH before routing (before auth)
+    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
+      const contentType = req.headers['content-type'];
+      if (!contentType || !String(contentType).toLowerCase().includes('application/json')) {
+        this.json(res, 415, { error: 'Content-Type must be application/json' });
+        return;
+      }
+    }
+
     const url = new URL(req.url ?? '/', `http://localhost:${this.port}`);
     const path = url.pathname;
 
     this.route(req, res, path, url).catch(error => {
-      log.error('Request handler error', { error: String(error), path });
+      const msg = error instanceof Error ? error.message : String(error);
+      log.error('Request handler error', { error: msg, path });
       if (res.headersSent) {
         // SSE or chunked stream already started — send an error event and close gracefully
         try {
-          res.write(`data: ${JSON.stringify({ type: 'error', message: String(error) })}\n\n`);
+          res.write(`data: ${JSON.stringify({ type: 'error', message: msg })}\n\n`);
         } catch {
           /* ignore if write also fails */
         }
         res.end();
       } else {
-        this.json(res, 500, { error: 'Internal server error' });
+        if (msg.startsWith('CONTENT_TYPE_ERROR:')) {
+          this.json(res, 415, { error: 'Content-Type must be application/json' });
+        } else if (msg.startsWith('BODY_PARSE_ERROR:')) {
+          this.json(res, 400, { error: 'Invalid request body' });
+        } else {
+          this.json(res, 500, { error: 'Internal server error' });
+        }
       }
     });
   }
@@ -1243,6 +1259,13 @@ export class APIServer {
     path: string,
     url: URL
   ): Promise<void> {
+    // BUG-003: Pre-read and validate body for POST/PUT/PATCH at route level.
+    // This ensures body validation happens before any route-specific logic,
+    // so invalid bodies (null/array) are caught even for routes without readBody.
+    if (req.method === 'POST' || req.method === 'PUT' || req.method === 'PATCH') {
+      await this.readBody(req);
+    }
+
     // ── Auth endpoints (no auth required) ──────────────────────────────────
     if (path === '/api/auth/login' && req.method === 'POST') {
       const body = await this.readBody(req);
@@ -8643,13 +8666,44 @@ EXPLANATION_END`;
   }
 
   private readBody(req: IncomingMessage): Promise<Record<string, unknown>> {
+    // Return cached body if already pre-read at route level (BUG-003/005)
+    const cached: unknown = (req as any).__parsedBody__;
+    if (cached !== undefined) {
+      if (cached instanceof Error) return Promise.reject(cached);
+      return Promise.resolve(cached as Record<string, unknown>);
+    }
+
     return new Promise((resolve, reject) => {
+      // BUG-005: Validate Content-Type for POST/PUT/PATCH requests
+      const method = req.method ?? '';
+      if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+        const contentType = req.headers['content-type'];
+        if (!contentType || !contentType.toLowerCase().includes('application/json')) {
+          const err = new Error('CONTENT_TYPE_ERROR: Content-Type must be application/json');
+          (req as any).__parsedBody__ = err;
+          reject(err);
+          return;
+        }
+      }
+
       const chunks: Buffer[] = [];
       req.on('data', (chunk: Buffer) => chunks.push(chunk));
       req.on('end', () => {
         try {
-          resolve(JSON.parse(Buffer.concat(chunks).toString()) as Record<string, unknown>);
+          const raw = Buffer.concat(chunks).toString();
+          const parsed = JSON.parse(raw);
+          // BUG-003: JSON literal null or array is not a valid request body
+          if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            const err = new Error('BODY_PARSE_ERROR: Invalid request body');
+            (req as any).__parsedBody__ = err;
+            reject(err);
+            return;
+          }
+          (req as any).__parsedBody__ = parsed;
+          resolve(parsed as Record<string, unknown>);
         } catch {
+          // Malformed JSON → treat as empty object (not 400)
+          (req as any).__parsedBody__ = {};
           resolve({});
         }
       });

--- a/packages/org-manager/test/api-server.test.ts
+++ b/packages/org-manager/test/api-server.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { APIServer } from '../src/api-server.js';
+
+// ---------------------------------------------------------------------------
+// Mock IncomingMessage (simulates an HTTP request)
+// ---------------------------------------------------------------------------
+class MockIncomingMessage extends EventEmitter {
+  method: string;
+  url?: string;
+  headers: Record<string, string | string[] | undefined>;
+  body: string | null;
+  destroyed = false;
+
+  constructor(method: string, url: string, headers: Record<string, string>, body: string | null) {
+    super();
+    this.method = method;
+    this.url = url;
+    this.headers = { ...headers };
+    this.body = body;
+  }
+
+  /** Simulate the incoming data stream (synchronous for test simplicity). */
+  _simulate() {
+    setImmediate(() => {
+      if (this.body !== null) {
+        this.emit('data', Buffer.from(this.body));
+      }
+      this.emit('end');
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock ServerResponse
+// ---------------------------------------------------------------------------
+class MockServerResponse extends EventEmitter {
+  statusCode = 0;
+  statusMessage = '';
+  headers: Record<string, string> = {};
+
+  setHeader(name: string, value: string) {
+    this.headers[name] = value;
+  }
+  chunks: string[] = [];
+  ended = false;
+  destroyed = false;
+  _headersSent = false;
+
+  get headersSent() {
+    return this._headersSent;
+  }
+
+  writeHead(status: number, headers?: Record<string, string>) {
+    this.statusCode = status;
+    if (headers) this.headers = headers;
+  }
+
+  write(data: string): boolean {
+    this._headersSent = true;
+    this.chunks.push(data);
+    return true;
+  }
+
+  end(data?: string) {
+    if (data) this.chunks.push(data);
+    this.ended = true;
+  }
+
+  get bodyText(): string {
+    return this.chunks.join('');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helper: create an ApiServer with minimal dependencies
+// ---------------------------------------------------------------------------
+function createServer() {
+  const mockAgentManager = {
+    getTemplateRegistry: () => null,
+    setTemplateRegistry: () => {},
+    setGroupChatHandlers: () => {},
+    getDataDir: () => '/tmp',
+    getAgent: () => null,
+  };
+  const mockOrgService = {
+    getAgentManager: () => mockAgentManager,
+  } as any;
+  const server = new (APIServer as any)(mockOrgService, {} as any);
+  return server;
+}
+
+// ---------------------------------------------------------------------------
+// Test: BUG-003 + BUG-005 – Request body parsing
+// ---------------------------------------------------------------------------
+describe('ApiServer request body parsing', () => {
+  let server: ApiServer;
+
+  beforeEach(() => {
+    process.env.AUTH_ENABLED = 'false';
+    server = createServer();
+  });
+
+  afterEach(() => {
+    delete process.env.AUTH_ENABLED;
+  });
+
+  describe('BUG-003: null/array body → 400 Bad Request', () => {
+    it('should return 400 when POST body is JSON literal null', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('POST', '/api/agents', { 'content-type': 'application/json' }, 'null');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).toBe(400);
+          const body = JSON.parse(res.bodyText);
+          expect(body.error).toBe('Invalid request body');
+          done();
+        });
+      });
+    });
+
+    it('should return 400 when POST body is a JSON array', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('POST', '/api/agents', { 'content-type': 'application/json' }, '[1,2,3]');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).toBe(400);
+          const body = JSON.parse(res.bodyText);
+          expect(body.error).toBe('Invalid request body');
+          done();
+        });
+      });
+    });
+
+    it('should return 400 when PUT body is JSON literal null', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('PUT', '/api/agents/1', { 'content-type': 'application/json' }, 'null');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).toBe(400);
+          const body = JSON.parse(res.bodyText);
+          expect(body.error).toBe('Invalid request body');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('BUG-005: missing/wrong Content-Type → 415', () => {
+    it('should return 415 when POST has no Content-Type header', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('POST', '/api/agents', {}, '{"name":"test"}');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).toBe(415);
+          const body = JSON.parse(res.bodyText);
+          expect(body.error).toBe('Content-Type must be application/json');
+          done();
+        });
+      });
+    });
+
+    it('should return 415 when POST has wrong Content-Type', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('POST', '/api/agents', { 'content-type': 'text/plain' }, '{"name":"test"}');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).toBe(415);
+          const body = JSON.parse(res.bodyText);
+          expect(body.error).toBe('Content-Type must be application/json');
+          done();
+        });
+      });
+    });
+
+    it('should return 415 when PUT has no Content-Type', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('PUT', '/api/agents/1', {}, '{"name":"test"}');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).toBe(415);
+          const body = JSON.parse(res.bodyText);
+          expect(body.error).toBe('Content-Type must be application/json');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('Regression: valid requests still work', () => {
+    it('should NOT reject POST with valid JSON object body and Content-Type', async () => {
+      // We test that the request reaches the route handler (and fails with 404 because
+      // the route may not be registered — that's fine, as long as it's NOT 400/415)
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('POST', '/api/agents', { 'content-type': 'application/json' }, '{"name":"test"}');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          // Should NOT be 400 or 415 — could be 200, 201, 404, 500, etc.
+          expect(res.statusCode).not.toBe(400);
+          expect(res.statusCode).not.toBe(415);
+          done();
+        });
+      });
+    });
+
+    it('should NOT reject GET requests missing Content-Type', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('GET', '/api/agents', {}, '');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).not.toBe(400);
+          expect(res.statusCode).not.toBe(415);
+          done();
+        });
+      });
+    });
+
+    it('should NOT reject DELETE requests missing Content-Type', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('DELETE', '/api/agents/1', {}, '');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          expect(res.statusCode).not.toBe(400);
+          expect(res.statusCode).not.toBe(415);
+          done();
+        });
+      });
+    });
+
+    it('should handle malformed JSON (non-JSON body) gracefully without 500', async () => {
+      return new Promise<void>((done) => {
+        const req = new MockIncomingMessage('POST', '/api/agents', { 'content-type': 'application/json' }, 'not-json-at-all');
+        const res = new MockServerResponse();
+
+        server.handleRequest(req as unknown as IncomingMessage, res as unknown as ServerResponse);
+        req._simulate();
+
+        setImmediate(() => {
+          // Malformed JSON should resolve({}) — so body is empty, handler gets {}
+          // Handler may return 400 if required field is missing, but must NOT crash (no 500/415)
+          expect(res.statusCode).not.toBe(415);
+          expect(res.statusCode).not.toBe(500);
+          done();
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_7302d17a13f0015cafef7dff (BUG-003) + TASK-tsk_68e52ab0c0c824686343f647 (BUG-005)
- **关联需求**: req_f739b9acb2eab055ef14a7e4 (BUG-003) + req_9920ce88437df520f1dc17fe (BUG-005)
- **目标分支**: main

## 🎯 背景与动机 (Why)
BUG-003: POST/PUT with JSON literal 'null' body returns 500 Internal Server Error instead of 400 Bad Request.
BUG-005: POST request without Content-Type header still processes the request instead of returning 415 Unsupported Media Type.

## 🔧 变更内容 (What)
- packages/org-manager/src/api-server.ts: Add Content-Type validation (415) for POST/PUT/PATCH before routing; add null/array body validation (400) in readBody; add pre-read body caching at route level; enhance error handler to detect structured error prefixes
- packages/org-manager/test/api-server.test.ts: Add 10 unit tests covering BUG-003 (null body, array body), BUG-005 (missing/wrong Content-Type), and regression tests (valid requests still work, malformed JSON handled gracefully)

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm vitest run packages/org-manager/test/api-server.test.ts — 10/10 tests passed

## 👤 评审人
- **Reviewer**: Code Reviewer