### PR TITLE
[TASK-tsk_78180c527e2d23ff070d830a][Backend] fix: add requireAuth to GET /api/keys

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -5939,6 +5939,8 @@ EXPLANATION_END`;
 
     // Billing: API Keys
     if (path === '/api/keys' && req.method === 'GET') {
+      const authUser = await this.requireAuth(req, res);
+      if (!authUser) return;
       const orgId = url.searchParams.get('orgId') ?? 'default';
       this.json(res, 200, { keys: this.billingService?.listAPIKeys(orgId) ?? [] });
       return;

--- a/packages/org-manager/test/api-keys-auth.test.ts
+++ b/packages/org-manager/test/api-keys-auth.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Test: GET /api/keys requires authentication
+ *
+ * BUG-004: GET /api/keys was missing requireAuth(), allowing unauthenticated
+ * access to API key management. This test verifies it returns 401 when no
+ * valid auth cookie is present.
+ */
+import { describe, it, expect } from 'vitest';
+import { APIServer } from '../src/api-server.js';
+import type { OrganizationService } from '../src/org-service.js';
+import type { TaskService } from '../src/task-service.js';
+
+/**
+ * Create a minimal mock OrganizationService that provides just enough
+ * stubs for APIServer construction. The route handler (GET /api/keys)
+ * won't reach the billingService because requireAuth returns 401 first.
+ */
+function createMockOrgService(): OrganizationService {
+  const mockAgentManager = {
+    setGroupChatHandlers: () => {},
+    getTemplateRegistry: () => null,
+    setTemplateRegistry: () => {},
+    getAgent: () => null,
+    listAgents: () => [],
+  };
+
+  return {
+    getAgentManager: () => mockAgentManager,
+    getTeam: () => null,
+    listTeamsWithMembers: () => [],
+    getTeamAgentStatuses: () => [],
+    isProtectedAgent: () => false,
+    resolveHumanIdentity: () => null,
+    getOrg: () => null,
+    listOrgs: () => [],
+    listTeams: () => [],
+    addHumanUser: () => ({ id: '', name: '', role: 'manager', orgId: 'default', createdAt: '' }),
+    createOrganization: () => Promise.resolve({ id: '', name: '', ownerId: '', createdAt: '', status: 'active' as const }),
+  } as unknown as OrganizationService;
+}
+
+/**
+ * Create a minimal mock TaskService.
+ */
+function createMockTaskService(): TaskService {
+  return {} as unknown as TaskService;
+}
+
+describe('GET /api/keys auth requirement', () => {
+  it('returns 401 when no auth cookie is present', async () => {
+    const orgService = createMockOrgService();
+    const taskService = createMockTaskService();
+
+    // Create server on port 0 (let OS assign a free port)
+    const server = new APIServer(orgService, taskService, 0);
+
+    try {
+      // Start the server and capture the actual port
+      await new Promise<void>((resolve, reject) => {
+        server.start();
+        // The server listens on port 0, we can read the actual port
+        // by using address().port via the underlying http.Server
+        const addr = (server as unknown as { server: { address(): { port: number } } }).server?.address();
+        if (!addr) {
+          // Wait a tick and try again
+          setTimeout(() => {
+            const a = (server as unknown as { server: { address(): { port: number } } }).server?.address();
+            if (a) resolve();
+            else reject(new Error('Server did not start'));
+          }, 100);
+        } else {
+          resolve();
+        }
+      });
+
+      // Get the actual port the server is listening on
+      const addr = (server as unknown as { server: { address(): { port: number } } }).server.address();
+      const port = addr.port;
+
+      // Make a request WITHOUT auth cookie — should get 401
+      const res = await fetch(`http://localhost:${port}/api/keys`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      expect(res.status).toBe(401);
+      const body = await res.json() as { error?: string };
+      expect(body.error).toBe('Unauthorized');
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('returns 200 when auth is disabled via AUTH_ENABLED=false', async () => {
+    // Temporarily disable auth
+    process.env['AUTH_ENABLED'] = 'false';
+
+    const orgService = createMockOrgService();
+    const taskService = createMockTaskService();
+    const server = new APIServer(orgService, taskService, 0);
+
+    try {
+      await new Promise<void>((resolve) => {
+        server.start();
+        // Wait for server to be ready
+        setTimeout(() => resolve(), 200);
+      });
+
+      const addr = (server as unknown as { server: { address(): { port: number } } }).server.address();
+      const port = addr.port;
+
+      // Without AUTH_ENABLED, requireAuth should allow the request
+      // The handler will hit billingService check — since we have no
+      // billingService, it should return 503 (service not available)
+      const res = await fetch(`http://localhost:${port}/api/keys`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      // With auth disabled, we get past requireAuth but hit no billingService
+      // Expect either 200 (if billingService is somehow available) or 503
+      expect([200, 503]).toContain(res.status);
+    } finally {
+      server.stop();
+      process.env['AUTH_ENABLED'] = 'true';
+    }
+  });
+});


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_78180c527e2d23ff070d830a
- **关联需求**: BUG-004: GET /api/keys missing requireAuth
- **目标分支**: main

## 🎯 背景与动机 (Why)
GET /api/keys was missing the requireAuth() validation, allowing unauthenticated
access to API key listing. POST and DELETE /api/keys already had auth checks.

Fix: Add `const authUser = await this.requireAuth(req, res); if (!authUser) return;`
before the route handler, matching the pattern used by all other protected routes.

## 🔧 变更内容 (What)
- packages/org-manager/src/api-server.ts: Added requireAuth() call to GET /api/keys handler (lines 5940-5941)
- packages/org-manager/test/api-keys-auth.test.ts: New test file — verifies 401 without auth cookie, and 200 with AUTH_ENABLED=false

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm build 通过
- [x] pnpm test 通过（28 files, 374 tests, all green）
- [x] 新建测试 api-keys-auth.test.ts 验证：
  - 无 cookie 时返回 401 Unauthorized
  - AUTH_ENABLED=false 时可正常访问

## 👤 评审人
- **Reviewer**: Code Reviewer