### PR TITLE
[TASK-tsk_d48638231fe489a2e5b89cc4][Backend] fix: add 100-char name length validation for POST/PATCH /api/agents

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -1952,6 +1952,10 @@ export class APIServer {
         this.json(res, 400, { error: 'name is required' });
         return;
       }
+      if (agentName.length > 100) {
+        this.json(res, 400, { error: 'name must be 100 characters or fewer' });
+        return;
+      }
       const orgId = (body['orgId'] as string) ?? 'default';
 
       // Sanitize: strip HTML tags from name to prevent XSS
@@ -3372,7 +3376,14 @@ export class APIServer {
         const agent = this.orgService.getAgentManager().getAgent(agentId);
         const body = await this.readBody(req);
         const cfg = agent.config as unknown as Record<string, unknown>;
-        if (body['name'] !== undefined) cfg.name = stripHtmlTags(body['name'] as string);
+        if (body['name'] !== undefined) {
+          const name = stripHtmlTags(body['name'] as string);
+          if (name.length > 100) {
+            this.json(res, 400, { error: 'name must be 100 characters or fewer' });
+            return;
+          }
+          cfg.name = name;
+        }
         if (body['agentRole'] !== undefined) cfg.agentRole = body['agentRole'];
         if (body['skills'] !== undefined) cfg.skills = body['skills'];
         if (body['llmConfig'] !== undefined) {


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_d48638231fe489a2e5b89cc4
- **关联需求**: BUG-007 Agent名称长度限制
- **目标分支**: main

## 🎯 背景与动机 (Why)
Agent 名称目前没有长度限制，用户可以传入任意长度的字符串。需要限制为最多 100 字符，防止 API 滥用和数据异常。

## 🔧 变更内容 (What)
- packages/org-manager/src/api-server.ts: POST /api/agents — 在 name 为空校验后添加 length > 100 校验
- packages/org-manager/src/api-server.ts: PATCH /api/agents/:id/config — 在 name 更新时添加 length > 100 校验

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm test 通过 (27 files, 372 tests)
- 手动测试：POST /api/agents 传 name 长度 > 100 返回 400
- 手动测试：PATCH /api/agents/:id/config 传 name > 100 返回 400

## 👤 评审人
- **Reviewer**: Code Reviewer