### PR TITLE
[TASK-tsk_4a93733be19e059ecf7abf99][Frontend] feat: add image rendering support to MarkdownMessage

### DIFF
--- a/packages/web-ui/src/components/MarkdownMessage.tsx
+++ b/packages/web-ui/src/components/MarkdownMessage.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -76,6 +77,9 @@ const mdComponents = {
   ),
   strong: ({ children }: { children?: React.ReactNode }) => <strong className="font-semibold text-fg-primary">{children}</strong>,
   em: ({ children }: { children?: React.ReactNode }) => <em className="italic text-fg-secondary">{children}</em>,
+  img: ({ src, alt }: { src?: string; alt?: string }) => (
+    <MarkdownImage src={src ?? ''} alt={alt} />
+  ),
   blockquote: ({ children }: { children?: React.ReactNode }) => (
     <blockquote className="border-l-2 border-brand-500 pl-3 my-2 text-fg-secondary italic">{children}</blockquote>
   ),
@@ -98,6 +102,77 @@ const mdComponents = {
     <td className="px-3 py-1.5 text-xs text-fg-secondary border border-border-default">{children}</td>
   ),
 };
+
+// ─── Image support ───────────────────────────────────────────────────────────
+
+function MarkdownImage({ src, alt, onPreview }: { src: string; alt?: string; onPreview?: (src: string) => void }) {
+  const [loaded, setLoaded] = useState(false);
+  const [error, setError] = useState(false);
+
+  return (
+    <span className="inline-block align-middle max-w-full">
+      {!loaded && !error && (
+        <span className="block w-full min-h-[80px] max-w-[400px] bg-surface-elevated rounded-lg animate-pulse" />
+      )}
+      {error ? (
+        <span className="inline-flex items-center gap-1.5 px-3 py-2 text-xs text-fg-tertiary bg-surface-elevated rounded-lg border border-border-default">
+          <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5}>
+            <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+            <circle cx="8.5" cy="8.5" r="1.5" />
+            <polyline points="21 15 16 10 5 21" />
+          </svg>
+          Failed to load image
+        </span>
+      ) : (
+        <img
+          src={src}
+          alt={alt ?? ''}
+          loading="lazy"
+          onLoad={() => setLoaded(true)}
+          onError={() => setError(true)}
+          onClick={() => onPreview?.(src)}
+          className="max-w-full h-auto rounded-lg cursor-pointer hover:opacity-90 transition-opacity my-1"
+          style={{ maxHeight: '400px', objectFit: 'contain' }}
+        />
+      )}
+    </span>
+  );
+}
+
+// ─── Image Preview Modal ────────────────────────────────────────────────────
+
+function ImagePreviewModal({ src, onClose }: { src: string; onClose: () => void }) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[9999] bg-black/80 flex items-center justify-center p-4"
+      onClick={onClose}
+    >
+      <button
+        onClick={onClose}
+        className="absolute top-4 right-4 w-10 h-10 rounded-full bg-white/10 hover:bg-white/20 flex items-center justify-center transition-colors z-10"
+      >
+        <svg className="w-6 h-6 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+          <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      </button>
+      <img
+        src={src}
+        alt="Preview"
+        className="max-w-full max-h-[90vh] object-contain rounded-lg"
+        onClick={e => e.stopPropagation()}
+      />
+    </div>,
+    document.body,
+  );
+}
 
 // ─── Copy menu ───────────────────────────────────────────────────────────────
 
@@ -184,6 +259,7 @@ function CopyMenu({ content, contentRef }: { content: string; contentRef: React.
 export function MarkdownMessage({ content, className = '', onMentionClick }: Props) {
   const { thinking, rest } = extractThinkBlocks(content);
   const contentRef = useRef<HTMLDivElement>(null);
+  const [previewSrc, setPreviewSrc] = useState<string | null>(null);
 
   const processedRest = useMemo(() => {
     let t = normalizeMathDelimiters(rest);
@@ -192,9 +268,15 @@ export function MarkdownMessage({ content, className = '', onMentionClick }: Pro
   }, [rest, onMentionClick]);
 
   const components = useMemo(() => {
-    if (!onMentionClick) return mdComponents;
-    return {
+    const base: Record<string, React.ComponentType<any>> = {
       ...mdComponents,
+      img: ({ src, alt }: { src?: string; alt?: string }) => (
+        <MarkdownImage src={src ?? ''} alt={alt} onPreview={setPreviewSrc} />
+      ),
+    };
+    if (!onMentionClick) return base;
+    return {
+      ...base,
       a: ({ href, children }: { href?: string; children?: React.ReactNode }) => {
         if (href?.startsWith(MENTION_PREFIX)) {
           const name = decodeURIComponent(href.slice(MENTION_PREFIX.length));
@@ -248,6 +330,7 @@ export function MarkdownMessage({ content, className = '', onMentionClick }: Pro
           </ReactMarkdown>
         </div>
       </div>
+      {previewSrc && <ImagePreviewModal src={previewSrc} onClose={() => setPreviewSrc(null)} />}
     </div>
   );
 }


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Frontend Developer (ID: agt_ca836fdc2c08b8e9ec1370a8)
- **关联任务**: TASK-tsk_4a93733be19e059ecf7abf99
- **关联需求**: 实现 MarkdownMessage 图片渲染支持
- **目标分支**: main

## 🎯 背景与动机
MarkdownMessage 组件目前不支持渲染 Markdown 中的 img 标签。当消息中包含图片链接（如 data URL、远程图片）时，图片会不显示。需要添加完整的图片渲染支持，包括 lazy loading、加载骨架屏、错误状态显示、点击放大预览等功能。

## 🔧 变更内容
- `packages/web-ui/src/components/MarkdownMessage.tsx` (1 file, +85/-2):
  - **MarkdownImage 组件**: 自定义图片组件，支持懒加载 (loading=\lazy\)、加载中骨架屏 (animate-pulse)、加载失败占位 (broken image icon + 提示文本)
  - **ImagePreviewModal 组件**: 全屏预览弹窗，支持点击关闭、点击遮罩关闭、Escape 键关闭，通过 portal 渲染到 document.body
  - **mdComponents.img**: 添加 img 组件供 think block 内的 ReactMarkdown 使用
  - **MarkdownMessage components**: 扩展 memoized components 包含 img 组件，传递 onPreview 回调实现前后联动
  - **previewSrc 状态**: 管理当前预览图片 src，用于控制 ImagePreviewModal 显示

## ✅ 验证方式 (How to Verify)
- [x] pnpm lint 通过 (0 errors, 0 new warnings)
- [x] pnpm --filter @markus/web-ui build 通过

## 👤 评审人
- **Reviewer**: Code Reviewer