### PR TITLE
fix: use official hub URL (markus.global) instead of localhost:8059

### DIFF
--- a/packages/shared/src/utils/config.ts
+++ b/packages/shared/src/utils/config.ts
@@ -77,7 +77,7 @@ const DEFAULT_CONFIG: MarkusConfig = {
   },
   server: { apiPort: 8056, webPort: 8057 },
   security: { adminPassword: 'markus123', gatewaySecret: 'markus-gateway-default-secret-change-me' },
-  hub: { url: 'http://localhost:8059' },
+  hub: { url: 'https://markus.global' },
 };
 
 export function getDefaultConfigPath(): string {

--- a/packages/web-ui/src/pages/SkillStore.tsx
+++ b/packages/web-ui/src/pages/SkillStore.tsx
@@ -747,7 +747,7 @@ export function SkillStore() {
             <div className="text-center text-fg-tertiary py-20">
               <div className="text-4xl mb-3">🏪</div>
               <div>No skills found on Markus Hub</div>
-              <div className="text-xs mt-1">Hub may be offline or empty. Run the hub server at port 8059.</div>
+              <div className="text-xs mt-1">Hub may be offline or empty. Check your network connection or hub URL configuration.</div>
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/packages/web-ui/src/pages/TeamsStore.tsx
+++ b/packages/web-ui/src/pages/TeamsStore.tsx
@@ -205,7 +205,7 @@ export function TeamsStore() {
             <div className="text-center py-16">
               <div className="text-fg-tertiary text-3xl mb-3">🏪</div>
               <p className="text-sm text-fg-tertiary">No teams found on Markus Hub</p>
-              <p className="text-xs text-fg-tertiary mt-1">Hub may be offline or empty. Start the hub server at port 8059.</p>
+              <p className="text-xs text-fg-tertiary mt-1">Hub may be offline or empty. Check your network connection or hub URL configuration.</p>
             </div>
           ) : (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">

--- a/packages/web-ui/src/pages/TemplateMarketplace.tsx
+++ b/packages/web-ui/src/pages/TemplateMarketplace.tsx
@@ -188,7 +188,7 @@ export function TemplateMarketplace({ authUser: _authUser }: { authUser?: AuthUs
             <div className="text-center py-16">
               <div className="text-fg-tertiary text-3xl mb-3">🏪</div>
               <p className="text-sm text-fg-tertiary">No agents found on Markus Hub</p>
-              <p className="text-xs text-fg-tertiary mt-1">Hub may be offline or empty. Start the hub server at port 8059.</p>
+              <p className="text-xs text-fg-tertiary mt-1">Hub may be offline or empty. Check your network connection or hub URL configuration.</p>
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
The default hub config incorrectly pointed to a local dev server. Update to the production URL and adjust empty-state hint messages.

Made-with: Cursor