### PR TITLE
fix: 修复需求状态历史中 agent 名字无法显示及含空格名字 @mention 渲染问题

### DIFF
--- a/packages/core/src/agent-manager.ts
+++ b/packages/core/src/agent-manager.ts
@@ -113,14 +113,15 @@ export interface RequirementServiceBridge {
   updateRequirementStatus(
     id: string,
     status: string,
-    userId?: string
+    userId?: string,
+    actorType?: 'human' | 'agent' | 'system',
   ): { id: string; title: string; status: string };
   rejectRequirement(
     id: string,
     userId: string,
     reason: string
   ): { id: string; title: string; status: string };
-  cancelRequirement(id: string): { id: string; title: string; status: string };
+  cancelRequirement(id: string, cancelledBy?: string, cancelledByType?: 'human' | 'agent' | 'system'): { id: string; title: string; status: string };
   updateRequirement(
     id: string,
     data: { title?: string; description?: string; priority?: string; tags?: string[] }
@@ -1107,9 +1108,9 @@ export class AgentManager {
                 return this.requirementService!.rejectRequirement(reqId, id, reason ?? '');
               }
               if (status === 'cancelled') {
-                return this.requirementService!.cancelRequirement(reqId);
+                return this.requirementService!.cancelRequirement(reqId, id, 'agent');
               }
-              return this.requirementService!.updateRequirementStatus(reqId, status, id);
+              return this.requirementService!.updateRequirementStatus(reqId, status, id, 'agent');
             }
           : undefined,
         updateRequirement: this.requirementService
@@ -1754,9 +1755,9 @@ export class AgentManager {
                 return this.requirementService!.rejectRequirement(reqId, id, reason ?? '');
               }
               if (status === 'cancelled') {
-                return this.requirementService!.cancelRequirement(reqId);
+                return this.requirementService!.cancelRequirement(reqId, id, 'agent');
               }
-              return this.requirementService!.updateRequirementStatus(reqId, status, id);
+              return this.requirementService!.updateRequirementStatus(reqId, status, id, 'agent');
             }
           : undefined,
         updateRequirement: this.requirementService

--- a/packages/org-manager/src/requirement-service.ts
+++ b/packages/org-manager/src/requirement-service.ts
@@ -406,7 +406,8 @@ export class RequirementService {
   updateRequirementStatus(
     id: string,
     newStatus: RequirementStatus,
-    userId?: string
+    userId?: string,
+    actorType?: 'human' | 'agent' | 'system',
   ): Requirement {
     if (!RequirementService.VALID_STATUSES.has(newStatus)) {
       throw new Error(`Invalid requirement status "${newStatus}". Valid values: ${[...RequirementService.VALID_STATUSES].join(', ')}`);
@@ -466,7 +467,8 @@ export class RequirementService {
       } catch { /* agent not found — skip */ }
     }
 
-    this.recordTransition(id, oldStatus, newStatus, userId, userId ? 'human' : 'system');
+    const resolvedActorType = actorType ?? (userId ? 'human' : 'system');
+    this.recordTransition(id, oldStatus, newStatus, userId, resolvedActorType);
     this.broadcast('requirement:updated', req);
     log.info('Requirement status updated', { id, from: oldStatus, to: newStatus });
 

--- a/packages/web-ui/src/components/CommentInput.tsx
+++ b/packages/web-ui/src/components/CommentInput.tsx
@@ -123,32 +123,85 @@ export function renderMentionText(
   onMentionClick?: (agent: AgentInfo) => void,
 ): React.ReactNode[] {
   const parts: React.ReactNode[] = [];
-  const re = new RegExp(MENTION_RE.source, MENTION_RE.flags);
-  let lastIndex = 0;
-  let m: RegExpExecArray | null;
   let key = 0;
 
-  while ((m = re.exec(text)) !== null) {
-    if (m.index > lastIndex) {
-      parts.push(<span key={key++}>{text.slice(lastIndex, m.index)}</span>);
-    }
-    const name = m[1] ?? m[2]!;
-    const agent = agents.find(a => a.name.toLowerCase() === name.toLowerCase());
-    parts.push(
-      <span
-        key={key++}
-        className={`text-brand-500 font-medium ${onMentionClick && agent ? 'cursor-pointer hover:underline' : ''}`}
-        onClick={onMentionClick && agent ? () => onMentionClick(agent) : undefined}
-        title={agent ? `${agent.name} (${agent.role})` : undefined}
-      >
-        @{name}
-      </span>,
-    );
-    lastIndex = m.index + m[0].length;
-  }
+  const sortedNames = agents.map(a => a.name).sort((a, b) => b.length - a.length);
 
-  if (lastIndex < text.length) {
-    parts.push(<span key={key++}>{text.slice(lastIndex)}</span>);
+  let idx = 0;
+  while (idx < text.length) {
+    const atPos = text.indexOf('@', idx);
+    if (atPos < 0) {
+      parts.push(<span key={key++}>{text.slice(idx)}</span>);
+      break;
+    }
+
+    if (atPos > idx) {
+      parts.push(<span key={key++}>{text.slice(idx, atPos)}</span>);
+    }
+
+    // Try bracketed syntax: @[Name With Spaces]
+    if (text[atPos + 1] === '[') {
+      const close = text.indexOf(']', atPos + 2);
+      if (close > atPos + 2) {
+        const bracketed = text.slice(atPos + 2, close);
+        const agent = agents.find(a => a.name.toLowerCase() === bracketed.toLowerCase());
+        parts.push(
+          <span
+            key={key++}
+            className={`text-brand-500 font-medium ${onMentionClick && agent ? 'cursor-pointer hover:underline' : ''}`}
+            onClick={onMentionClick && agent ? () => onMentionClick(agent) : undefined}
+            title={agent ? `${agent.name} (${agent.role})` : undefined}
+          >
+            @{bracketed}
+          </span>,
+        );
+        idx = close + 1;
+        continue;
+      }
+    }
+
+    // Try full name prefix match (handles multi-word names like "Markus Platform Dev Manager")
+    const after = text.slice(atPos + 1);
+    const afterLower = after.toLowerCase();
+    const fullMatch = sortedNames.find(n => afterLower.startsWith(n.toLowerCase()));
+    if (fullMatch) {
+      const agent = agents.find(a => a.name.toLowerCase() === fullMatch.toLowerCase());
+      parts.push(
+        <span
+          key={key++}
+          className={`text-brand-500 font-medium ${onMentionClick && agent ? 'cursor-pointer hover:underline' : ''}`}
+          onClick={onMentionClick && agent ? () => onMentionClick(agent) : undefined}
+          title={agent ? `${agent.name} (${agent.role})` : undefined}
+        >
+          @{fullMatch}
+        </span>,
+      );
+      idx = atPos + 1 + fullMatch.length;
+      continue;
+    }
+
+    // Fallback: single-token match via regex
+    const tokenRe = /^([\w\p{L}\p{N}]+)/u;
+    const tokenMatch = after.match(tokenRe);
+    if (tokenMatch) {
+      const name = tokenMatch[1]!;
+      const agent = agents.find(a => a.name.toLowerCase() === name.toLowerCase());
+      parts.push(
+        <span
+          key={key++}
+          className={`text-brand-500 font-medium ${onMentionClick && agent ? 'cursor-pointer hover:underline' : ''}`}
+          onClick={onMentionClick && agent ? () => onMentionClick(agent) : undefined}
+          title={agent ? `${agent.name} (${agent.role})` : undefined}
+        >
+          @{name}
+        </span>,
+      );
+      idx = atPos + 1 + name.length;
+      continue;
+    }
+
+    parts.push(<span key={key++}>@</span>);
+    idx = atPos + 1;
   }
 
   return parts.length > 0 ? parts : [<span key={0}>{text}</span>];

--- a/packages/web-ui/src/components/MarkdownMessage.tsx
+++ b/packages/web-ui/src/components/MarkdownMessage.tsx
@@ -13,6 +13,8 @@ interface Props {
   className?: string;
   /** When provided, @mentions in the text become clickable and invoke this callback with the mentioned name and click event */
   onMentionClick?: (name: string, event: React.MouseEvent) => void;
+  /** Known agent/user names for multi-word mention matching (e.g. "Markus Platform Dev Manager") */
+  knownNames?: string[];
 }
 
 const thinkRegex = /<think>([\s\S]*?)(<\/think>|$)/g;
@@ -43,12 +45,62 @@ function normalizeMathDelimiters(text: string): string {
 const MENTION_PREFIX = '#mention:';
 
 /** Convert @mentions in raw text to markdown links before ReactMarkdown processes it.
- *  Uses `#mention:` (hash prefix) so ReactMarkdown's URL sanitiser doesn't strip them. */
-function preprocessMentions(text: string): string {
-  return text.replace(/@\[([^\]]+)\]|@([\w\p{L}\p{N}]+)/gu, (_full, bracketName: string | undefined, wordName: string | undefined) => {
-    const name = bracketName ?? wordName!;
-    return `[@${name}](${MENTION_PREFIX}${encodeURIComponent(name)})`;
-  });
+ *  Uses `#mention:` (hash prefix) so ReactMarkdown's URL sanitiser doesn't strip them.
+ *  When knownNames is provided, also matches multi-word names (e.g. "@Markus Platform Dev Manager"). */
+function preprocessMentions(text: string, knownNames?: string[]): string {
+  if (!knownNames || knownNames.length === 0) {
+    return text.replace(/@\[([^\]]+)\]|@([\w\p{L}\p{N}]+)/gu, (_full, bracketName: string | undefined, wordName: string | undefined) => {
+      const name = bracketName ?? wordName!;
+      return `[@${name}](${MENTION_PREFIX}${encodeURIComponent(name)})`;
+    });
+  }
+
+  const sorted = [...knownNames].sort((a, b) => b.length - a.length);
+  let result = '';
+  let idx = 0;
+  while (idx < text.length) {
+    const atPos = text.indexOf('@', idx);
+    if (atPos < 0) {
+      result += text.slice(idx);
+      break;
+    }
+    result += text.slice(idx, atPos);
+
+    // Bracketed: @[Name With Spaces]
+    if (text[atPos + 1] === '[') {
+      const close = text.indexOf(']', atPos + 2);
+      if (close > atPos + 2) {
+        const name = text.slice(atPos + 2, close);
+        result += `[@${name}](${MENTION_PREFIX}${encodeURIComponent(name)})`;
+        idx = close + 1;
+        continue;
+      }
+    }
+
+    // Full name prefix match
+    const after = text.slice(atPos + 1);
+    const afterLower = after.toLowerCase();
+    const fullMatch = sorted.find(n => afterLower.startsWith(n.toLowerCase()));
+    if (fullMatch) {
+      const actual = after.slice(0, fullMatch.length);
+      result += `[@${actual}](${MENTION_PREFIX}${encodeURIComponent(actual)})`;
+      idx = atPos + 1 + fullMatch.length;
+      continue;
+    }
+
+    // Single-word fallback
+    const tokenMatch = after.match(/^([\w\p{L}\p{N}]+)/u);
+    if (tokenMatch) {
+      const name = tokenMatch[1]!;
+      result += `[@${name}](${MENTION_PREFIX}${encodeURIComponent(name)})`;
+      idx = atPos + 1 + name.length;
+      continue;
+    }
+
+    result += '@';
+    idx = atPos + 1;
+  }
+  return result;
 }
 
 const mdComponents = {
@@ -181,15 +233,15 @@ function CopyMenu({ content, contentRef }: { content: string; contentRef: React.
 
 // ─── MarkdownMessage ─────────────────────────────────────────────────────────
 
-export function MarkdownMessage({ content, className = '', onMentionClick }: Props) {
+export function MarkdownMessage({ content, className = '', onMentionClick, knownNames }: Props) {
   const { thinking, rest } = extractThinkBlocks(content);
   const contentRef = useRef<HTMLDivElement>(null);
 
   const processedRest = useMemo(() => {
     let t = normalizeMathDelimiters(rest);
-    if (onMentionClick) t = preprocessMentions(t);
+    if (onMentionClick) t = preprocessMentions(t, knownNames);
     return t;
-  }, [rest, onMentionClick]);
+  }, [rest, onMentionClick, knownNames]);
 
   const components = useMemo(() => {
     if (!onMentionClick) return mdComponents;

--- a/packages/web-ui/src/pages/Work.tsx
+++ b/packages/web-ui/src/pages/Work.tsx
@@ -714,7 +714,7 @@ function CommentBubble({ comment, agents, onReply }: {
             <span className="truncate max-w-[200px]">{comment.replyToContent ?? '...'}</span>
           </button>
         )}
-        <MarkdownMessage content={comment.content} className="text-xs text-fg-primary" onMentionClick={handleMentionClick} />
+        <MarkdownMessage content={comment.content} className="text-xs text-fg-primary" onMentionClick={handleMentionClick} knownNames={agents.map(a => a.name)} />
         {comment.attachments?.map((att, i) => (
           att.type === 'image' ? <img key={i} src={att.url} alt={att.name} className="mt-1 max-w-[200px] rounded" /> : null
         ))}


### PR DESCRIPTION
1. requirement-service: updateRequirementStatus 新增 actorType 参数， 修复 agent 更新需求状态时 changedByType 被错误记录为 'human' 的问题
2. agent-manager: 调用 updateRequirementStatus/cancelRequirement 时 显式传入 'agent' 类型
3. CommentInput/MarkdownMessage: 重写 @mention 渲染逻辑，使用全名前缀 匹配策略，正确处理含空格的多词 agent 名字（如 "Markus Platform Dev Manager"）

Made-with: Cursor