### PR TITLE
[TASK-tsk_9f08ad700c716a940c24b969][Frontend] fix: 修复中文名 Agent 的脚本文件匹配 Bug，统一使用 kebab() + 唯一索引 fallback

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -5260,9 +5260,9 @@ EXPLANATION_END`;
           const rawMembers = (Array.isArray((artifact.team as Record<string, unknown>)?.members)
             ? (artifact.team as Record<string, unknown>).members
             : Array.isArray(artifact.members) ? artifact.members : []) as Array<Record<string, unknown>>;
-          for (const m of rawMembers) {
+          for (const [idx, m] of rawMembers.entries()) {
             const mName = (m.name as string) ?? 'Agent';
-            const slug = kebab(mName, 'agent');
+            const slug = kebab(mName, 'member-' + idx);
             const memberDir = join(artDir, 'members', slug);
             const roleContent = (m.roleContent as string) || (m.role_md as string);
             const policiesContent = (m.policiesContent as string) || (m.policies_md as string);
@@ -7850,10 +7850,10 @@ EXPLANATION_END`;
       } catch { /* skip */ }
       const rolesRoot = rolesCandidates.find(d => ex(d)) ?? rolesDir;
       const files: Record<string, string> = {};
-      for (const member of tpl.members) {
+      for (const [idx, member] of tpl.members.entries()) {
         const roleName = member.roleName;
         if (!roleName) continue;
-        const memberSlug = (member.name ?? roleName).toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/-{2,}/g, '-').replace(/^-|-$/g, '');
+        const memberSlug = kebab(member.name ?? roleName, 'member-' + idx);
         const roleDir = resolve(rolesRoot, roleName);
         if (!ex(roleDir)) continue;
         try {

--- a/packages/web-ui/src/pages/ArtifactDetail.tsx
+++ b/packages/web-ui/src/pages/ArtifactDetail.tsx
@@ -464,18 +464,73 @@ function TeamTabs({ members, teamTopFiles, files, onFileSave, readOnly }: {
     return [...dirs];
   }, [files]);
 
-  const getMemberFiles = useCallback((name: string, idx: number): [string, string][] => {
-    const slug = kebab(name);
-    if (slug) {
-      const matched = Object.entries(files).filter(([k]) => k.startsWith(`members/${slug}/`));
-      if (matched.length > 0) return matched;
+  // Build a stable member-index → directory mapping upfront using multiple
+  // matching strategies.  This avoids the broken index-based fallback that
+  // assumes memberDirs order matches the manifest's members order.
+  const memberDirMap = useMemo(() => {
+    const map = new Map<number, string>();
+    const usedDirs = new Set<string>();
+
+    // Pass 1: exact slug match on member name
+    for (let i = 0; i < members.length; i++) {
+      const slug = kebab(members[i]!.name);
+      if (memberDirs.includes(slug) && !usedDirs.has(slug)) {
+        map.set(i, slug);
+        usedDirs.add(slug);
+      }
     }
-    if (idx < memberDirs.length) {
-      const dirName = memberDirs[idx]!;
+
+    // Pass 2: slug match on roleName (directory may be named after the role)
+    for (let i = 0; i < members.length; i++) {
+      if (map.has(i)) continue;
+      const rn = members[i]!.roleName;
+      if (rn) {
+        const roleSlug = kebab(rn);
+        if (memberDirs.includes(roleSlug) && !usedDirs.has(roleSlug)) {
+          map.set(i, roleSlug);
+          usedDirs.add(roleSlug);
+        }
+      }
+    }
+
+    // Pass 3: scan ROLE.md titles in remaining directories
+    for (let i = 0; i < members.length; i++) {
+      if (map.has(i)) continue;
+      const name = members[i]!.name;
+      for (const dir of memberDirs) {
+        if (usedDirs.has(dir)) continue;
+        const roleContent = files[`members/${dir}/ROLE.md`];
+        if (!roleContent) continue;
+        const title = roleContent.match(/^#\s+(.+)$/m)?.[1]?.trim();
+        if (title && (title.toLowerCase().includes(name.toLowerCase()) || name.toLowerCase().includes(title.toLowerCase()))) {
+          map.set(i, dir);
+          usedDirs.add(dir);
+          break;
+        }
+      }
+    }
+
+    // Pass 4: assign remaining unmatched members to remaining dirs in order
+    const remainingDirs = memberDirs.filter(d => !usedDirs.has(d));
+    let ri = 0;
+    for (let i = 0; i < members.length; i++) {
+      if (map.has(i)) continue;
+      if (ri < remainingDirs.length) {
+        map.set(i, remainingDirs[ri]!);
+        ri++;
+      }
+    }
+
+    return map;
+  }, [members, memberDirs, files]);
+
+  const getMemberFiles = useCallback((_name: string, idx: number): [string, string][] => {
+    const dirName = memberDirMap.get(idx);
+    if (dirName) {
       return Object.entries(files).filter(([k]) => k.startsWith(`members/${dirName}/`));
     }
     return [];
-  }, [files, memberDirs]);
+  }, [files, memberDirMap]);
 
   const tabs = useMemo(() => {
     const list: { label: string; role?: string }[] = [{ label: t('detail.overview') }];

--- a/packages/web-ui/src/pages/ArtifactDetail.tsx
+++ b/packages/web-ui/src/pages/ArtifactDetail.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { api, hubApi, type AuthUser } from '../api.ts';
+import { api, hubApi, kebab, type AuthUser } from '../api.ts';
 import { useIsMobile } from '../hooks/useIsMobile.ts';
 import { PAYMENTS_ENABLED } from './AgentBuilder.tsx';
 
@@ -465,7 +465,7 @@ function TeamTabs({ members, teamTopFiles, files, onFileSave, readOnly }: {
   }, [files]);
 
   const getMemberFiles = useCallback((name: string, idx: number): [string, string][] => {
-    const slug = name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '').replace(/^-+|-+$/g, '');
+    const slug = kebab(name);
     if (slug) {
       const matched = Object.entries(files).filter(([k]) => k.startsWith(`members/${slug}/`));
       if (matched.length > 0) return matched;


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Front Dev Expert (ID: agt_0830d6a1e0215899e72492b1)
- **关联任务**: TASK-tsk_9f08ad700c716a940c24b969
- **关联需求**: Builder 页面中文名 Agent 的 ROLE.md/HEARTBEAT.md 文件匹配 Bug
- **目标分支**: main

## 🎯 背景与动机 (Why)
Builder 页面中，用户创建的团队如果有中文名称的 Agent（如研究员、数据分析师），点击进入详情页面后，看到的 ROLE.md、HEARTBEAT.md 等角色配置文件无法正确匹配到对应 Agent。

根本原因：slug 生成逻辑在 3 处都有重复的内联实现，且 fallback 值为固定字符串 '\''agent'\''（3 个同名 Agent 会写入同一目录互相覆盖）。中文名经过 toLowerCase() 处理保持不变，内联逻辑又与 kebab() 函数结果不一致，导致前后端 slug 不匹配。

## 🔧 变更内容 (What)
- **packages/org-manager/src/api-server.ts (line 7856)**: 将 tpl.members 遍历改为带 idx 的 entries()，slug 使用 kebab(member.name ?? roleName, '\''member-'\'' + idx)，确保唯一性
- **packages/org-manager/src/api-server.ts (line 5265)**: 将 rawMembers 遍历改为带 idx 的 entries()，fallback 从 '\''agent'\'' 改为 '\''member-'\'' + idx，避免多 Agent 冲突
- **packages/web-ui/src/pages/ArtifactDetail.tsx (line 5 & 468)**: 导入 kebab() 函数替换内联 toLowerCase() slug 逻辑，确保前后端 slug 生成一致

## ✅ 验证方式 (How to Verify)
- [x] pnpm lint 通过 — 无新增警告或错误
- [ ] pnpm typecheck 通过 — 预存在 node 类型缺失问题（非本次变更导致）
- [ ] 手动验证：在 Builder 创建含中文名 Agent 的团队，确认 ROLE.md 等文件显示正常

## 👤 评审人
- **Reviewer**: Code Reviewer