### PR TITLE
fix: team chat stop button, session context loss, and empty bubble is…

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -2663,6 +2663,13 @@ export class Agent {
     images?: string[],
     fileNames?: string[],
   ): Promise<string> {
+    // Early bail-out: if already cancelled (e.g. user stopped while item was queued)
+    if (cancelToken?.cancelled) {
+      log.info('Stream cancelled before processing started', { agentId: this.id });
+      if (this.activeTasks.size === 0) this.setStatus('idle');
+      return '';
+    }
+
     if (this.activeTasks.size === 0) {
       this.setStatus('working');
     }
@@ -2809,10 +2816,13 @@ export class Agent {
 
         if (cancelToken?.cancelled) {
           log.info('Stream cancelled by user during tool loop', { agentId: this.id });
-          if (lastResponseContent && this.currentSessionId) {
+          if (this.currentSessionId) {
+            const content = lastResponseContent
+              ? lastResponseContent + '\n\n[interrupted by user]'
+              : '[interrupted by user]';
             this.memory.appendMessage(this.currentSessionId, {
               role: 'assistant',
-              content: lastResponseContent + '\n\n[interrupted by user]',
+              content,
             });
           }
           if (streamChatActivityId) this.endActivity(streamChatActivityId);
@@ -2832,6 +2842,19 @@ export class Agent {
             content: '[Continue from where you left off. Do not repeat what you already said.]',
           });
         } else {
+          // Check cancel before executing tools (tools may be long-running)
+          if (cancelToken?.cancelled) {
+            log.info('Stream cancelled before tool execution', { agentId: this.id });
+            this.memory.appendMessage(this.currentSessionId, {
+              role: 'assistant',
+              content: response.content + '\n\n[interrupted by user]',
+              reasoningContent: response.reasoningContent,
+            });
+            if (streamChatActivityId) this.endActivity(streamChatActivityId);
+            if (this.activeTasks.size === 0) this.setStatus('idle');
+            return response.content || lastResponseContent || '';
+          }
+
           this.memory.appendMessage(this.currentSessionId, {
             role: 'assistant',
             content: response.content,
@@ -2943,10 +2966,13 @@ export class Agent {
 
         if (cancelToken?.cancelled) {
           log.info('Stream cancelled before LLM re-call', { agentId: this.id });
-          if (lastResponseContent && this.currentSessionId) {
+          if (this.currentSessionId) {
+            const content = lastResponseContent
+              ? lastResponseContent + '\n\n[interrupted by user]'
+              : '[interrupted by user]';
             this.memory.appendMessage(this.currentSessionId, {
               role: 'assistant',
-              content: lastResponseContent + '\n\n[interrupted by user]',
+              content,
             });
           }
           if (streamChatActivityId) this.endActivity(streamChatActivityId);
@@ -3011,11 +3037,14 @@ export class Agent {
       streamMarkerDelta.flush();
       if (streamChatActivityId) this.endActivity(streamChatActivityId, { success: !cancelToken?.cancelled });
       if (cancelToken?.cancelled) {
-        if (lastResponseContent && this.currentSessionId) {
+        if (this.currentSessionId) {
           try {
+            const content = lastResponseContent
+              ? lastResponseContent + '\n\n[interrupted by user]'
+              : '[interrupted by user]';
             this.memory.appendMessage(this.currentSessionId, {
               role: 'assistant',
-              content: lastResponseContent + '\n\n[interrupted by user]',
+              content,
             });
           } catch { /* avoid masking */ }
         }

--- a/packages/org-manager/src/sse-handler.ts
+++ b/packages/org-manager/src/sse-handler.ts
@@ -91,6 +91,12 @@ export class SSEHandler {
         this.sessionId = this.options.sessionId ?? null;
       }
 
+      // Deliver sessionId early so the client can persist it even if the stream
+      // is aborted before the final 'done' event arrives.
+      if (this.sessionId && this.sseBuffer && !this.sseDisconnected) {
+        this.sseBuffer.send({ type: 'session_start', sessionId: this.sessionId });
+      }
+
       const reply = await this.options.agent.sendMessageStream(
         this.options.userText,
         (event) => this.handleStreamEvent(event),

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -19,9 +19,10 @@ export interface AgentToolEvent {
 }
 
 export interface StreamCommitEvent {
-  type: 'thinking_commit' | 'text_commit';
+  type: 'thinking_commit' | 'text_commit' | 'session_start';
   content: string;
   createdAt: string;
+  sessionId?: string;
 }
 
 export interface AuthUser {
@@ -890,13 +891,16 @@ export const api = {
               if (!trimmed.startsWith('data: ')) continue;
               try {
                 const event = JSON.parse(trimmed.slice(6)) as { type: string; text?: string; content?: string; thinking?: string; tool?: string; phase?: 'start' | 'end'; success?: boolean; arguments?: unknown; result?: string; error?: string; durationMs?: number; toolCall?: { id?: string; name?: string }; sessionId?: string };
-                if (event.type === 'text_delta' && event.text) {
+                if (event.type === 'session_start' && event.sessionId) {
+                  resultSessionId = event.sessionId;
+                  onCommit?.({ type: 'session_start', content: '', createdAt: new Date().toISOString(), sessionId: event.sessionId });
+                } else if (event.type === 'text_delta' && event.text) {
                   fullContent += event.text;
                   onChunk(event.text);
                 } else if (event.type === 'thinking_delta' && event.thinking) {
                   onChunk?.(`<think>${event.thinking}</think>`);
                 } else if (event.type === 'done') {
-                  fullContent = event.content ?? fullContent;
+                  fullContent = event.content || fullContent;
                   if (event.sessionId) resultSessionId = event.sessionId;
                   const doneSegments = (event as Record<string, unknown>).segments as StoredSegment[] | undefined;
                   if (doneSegments?.length) resultSegments = doneSegments;

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -1651,6 +1651,17 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
 
       /** Handle server-committed per-turn text/thinking entries (clean, non-fragmented) */
       const handleCommitEvent = (event: StreamCommitEvent) => {
+        // Capture sessionId early so subsequent messages continue in the same session
+        // even if the stream is aborted before the final 'done' event.
+        if (event.type === 'session_start' && event.sessionId) {
+          if (currentConvKeyRef.current === sendKey) {
+            setActiveSessionId(event.sessionId);
+            setOpenSessionTabs(prev =>
+              prev.map(t => t.id === NEW_CHAT_PLACEHOLDER_ID ? { ...t, id: event.sessionId! } : t)
+            );
+          }
+          return;
+        }
         updateConvMsgs(sendKey, prev => {
           const u = [...prev];
           const idx = u.findIndex(m => m.id === agentMsgId);
@@ -1795,7 +1806,16 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
                   ? { type: 'tool' as const, key: `${s.tool}_${i}`, tool: s.tool, status: s.status, args: s.arguments, result: s.result, error: s.error, durationMs: s.durationMs, createdAt: s.createdAt }
                   : { type: 'text' as const, content: s.content, thinking: s.thinking, createdAt: s.createdAt }
               );
-              const finalText = streamResult.content || u[idx]!.text;
+              // Reconstruct text from segments if both streamResult.content and
+              // accumulated msg.text are empty — prevents blank bubble when all
+              // content arrived via text_commit events.
+              let finalText = streamResult.content || u[idx]!.text;
+              if (!finalText) {
+                finalText = finalSegs
+                  .filter(s => s.type === 'text')
+                  .map(s => (s as { content: string }).content)
+                  .join('');
+              }
               u[idx] = { ...u[idx]!, text: finalText, segments: finalSegs, committedSegments: finalSegs };
               return u;
             });
@@ -1918,7 +1938,10 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
       const currentMsgs = msgBuffers.current.get(sendKey) ?? [];
       const agentMsg = currentMsgs.find(m => m.id === agentMsgId);
       const pollSessionId = activeSessionId && activeSessionId !== NEW_CHAT_PLACEHOLDER_ID ? activeSessionId : null;
-      if (agentMsg && !agentMsg.text && chatMode === 'direct' && pollSessionId && !abortCtrl.signal.aborted) {
+      const hasVisibleContent = agentMsg?.text || (agentMsg?.segments?.some(s =>
+        (s.type === 'text' && (s as { content: string }).content) || s.type === 'tool'
+      ));
+      if (agentMsg && !hasVisibleContent && chatMode === 'direct' && pollSessionId && !abortCtrl.signal.aborted) {
         const pollForReply = async (retries: number, delayMs: number) => {
           for (let i = 0; i < retries; i++) {
             await new Promise(r => setTimeout(r, delayMs));


### PR DESCRIPTION
…sues

- Add early cancel check in handleMessageStream to abort if cancelled while queued
- Check cancelToken before tool execution to avoid running tools after stop
- Always append assistant message to memory on cancel (even if empty) for context continuity
- Send session_start SSE event early so frontend captures sessionId before abort
- Fix done event overwriting accumulated content with empty string (use || instead of ??)
- Reconstruct display text from segments when both content sources are empty
- Improve fallback poll condition to check segment visibility