### PR TITLE
fix: keep completed/failed tasks visible, only hide closed states

### DIFF
--- a/packages/web-ui/src/pages/Work.tsx
+++ b/packages/web-ui/src/pages/Work.tsx
@@ -3021,8 +3021,7 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
   const kanbanScrollRef = useRef<HTMLDivElement>(null);
   const kanbanSwipeOpts = useMemo(() => ({ scrollContainerRef: kanbanScrollRef }), []);
   const kanbanSwipe = useSwipeTabs(boardTabs, boardType, setBoardType, kanbanSwipeOpts);
-  const [showArchived, setShowArchived] = useState(false);
-  const [showTerminal, setShowTerminal] = useState(false);
+  const [showClosed, setShowClosed] = useState(false);
   const [showFilterSheet, setShowFilterSheet] = useState(false);
   const dragTaskRef = useRef<TaskInfo | null>(null);
   const dragReqRef = useRef<RequirementInfo | null>(null);
@@ -3484,12 +3483,11 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
 
   // ── Filter & display helpers ──
 
-  const isArchived = (t: { status: string }) => t.status === 'archived';
-  const TERMINAL_STATUSES = new Set(['completed', 'failed', 'rejected', 'cancelled', 'archived']);
-  const isTerminal = (t: { status: string }) => TERMINAL_STATUSES.has(t.status);
+  const CLOSED_STATUSES = new Set(['rejected', 'cancelled', 'archived']);
+  const isClosed = (t: { status: string }) => CLOSED_STATUSES.has(t.status);
 
   const filterTasks = (tasks: TaskInfo[], includeArchived = false) => {
-    let result = tasks.filter(t => showTerminal || !isTerminal(t));
+    let result = tasks.filter(t => showClosed || !isClosed(t));
     if (viewMode === 'project' && selectedProjectId) {
       result = result.filter(t => t.projectId === selectedProjectId);
     }
@@ -3506,7 +3504,7 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
 
   const filteredReqs = useMemo(() => {
     let list = allRequirements;
-    if (!showTerminal) list = list.filter(r => !isTerminal(r));
+    if (!showClosed) list = list.filter(r => !isClosed(r));
     if (viewMode === 'project' && selectedProjectId) list = list.filter(r => r.projectId === selectedProjectId);
     if (projectFilter.size > 0) list = list.filter(r => r.projectId && projectFilter.has(r.projectId));
     if (agentFilter.size > 0) {
@@ -3519,7 +3517,7 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
     }
     if (myTasksOnly && authUser?.id) list = list.filter(r => r.createdBy === authUser.id);
     return list;
-  }, [allRequirements, showTerminal, viewMode, selectedProjectId, projectFilter, agentFilter, myTasksOnly, authUser?.id, agentIds]);
+  }, [allRequirements, showClosed, viewMode, selectedProjectId, projectFilter, agentFilter, myTasksOnly, authUser?.id, agentIds]);
 
   const getColumnReqs = useCallback((col: typeof BOARD_COLUMNS_BASE[number] & { label: string }) =>
     filteredReqs.filter(r => REQ_COLUMN_MAP[r.status] === col.id), [filteredReqs]);
@@ -3533,8 +3531,8 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
     return true;
   });
 
-  const terminalCount = Object.values(board).flat().filter(t => isTerminal(t)).length
-    + allRequirements.filter(r => isTerminal(r)).length;
+  const closedCount = Object.values(board).flat().filter(t => isClosed(t)).length
+    + allRequirements.filter(r => isClosed(r)).length;
 
   const sortedAgents = useMemo(() => {
     const terminal = new Set(['completed', 'failed', 'cancelled', 'archived']);
@@ -3631,9 +3629,9 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
                   >{v === 'backlog' ? t('work:task.backlog') : v === 'kanban' ? t('work:task.kanban') : t('work:task.dag')}</button>
                 ))}
               </div>
-              {terminalCount > 0 && (
-                <button onClick={() => setShowTerminal(v => !v)} className={`text-[10px] shrink-0 px-2 py-0.5 rounded-md transition-colors ${showTerminal ? 'bg-surface-overlay text-fg-secondary' : 'text-fg-tertiary'}`}>
-                  {showTerminal ? t('work:task.hideArchived') : t('work:task.archivedCount', { count: terminalCount })}
+              {closedCount > 0 && (
+                <button onClick={() => setShowClosed(v => !v)} className={`text-[10px] shrink-0 px-2 py-0.5 rounded-md transition-colors ${showClosed ? 'bg-surface-overlay text-fg-secondary' : 'text-fg-tertiary'}`}>
+                  {showClosed ? t('work:task.hideArchived') : t('work:task.archivedCount', { count: closedCount })}
                 </button>
               )}
               <div className="flex-1" />
@@ -3675,9 +3673,9 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
               {projects.length === 1 ? projects[0].name : t('work:task.projectsCount', { count: projects.length })}
             </h2>
           )}
-          {terminalCount > 0 && (
-            <button onClick={() => setShowTerminal(v => !v)} className={`text-[10px] shrink-0 px-2 py-0.5 rounded-md transition-colors ${showTerminal ? 'bg-surface-overlay text-fg-secondary' : 'text-fg-tertiary hover:text-fg-secondary'}`}>
-                {showTerminal ? t('work:task.hideArchivedWithCount', { count: terminalCount }) : t('work:task.archivedCount', { count: terminalCount })}
+          {closedCount > 0 && (
+            <button onClick={() => setShowClosed(v => !v)} className={`text-[10px] shrink-0 px-2 py-0.5 rounded-md transition-colors ${showClosed ? 'bg-surface-overlay text-fg-secondary' : 'text-fg-tertiary hover:text-fg-secondary'}`}>
+                {showClosed ? t('work:task.hideArchivedWithCount', { count: closedCount }) : t('work:task.archivedCount', { count: closedCount })}
             </button>
           )}
 
@@ -3813,8 +3811,8 @@ export function WorkPage({ authUser }: { authUser?: AuthUser }) {
             tasks={filterTasks(Object.values(board).flat(), true)}
             requirements={filteredReqs}
             agents={agents}
-            showArchived={showTerminal}
-            onShowArchivedChange={setShowTerminal}
+            showArchived={showClosed}
+            onShowArchivedChange={setShowClosed}
             onTaskClick={(task) => handleSelectTask(task)}
             onReqClick={(req) => handleSelectReq(req)}
             onDependencyChange={refreshBoard}


### PR DESCRIPTION
## Summary
- PR #99 过度过滤了任务看板：把 completed/failed 也默认隐藏了，导致任务一完成就消失，用户体验很差
- 本 PR 将默认隐藏范围缩小为仅 `rejected`、`cancelled`、`archived` 三种真正"冷掉"的状态
- `completed`（已完成）和 `failed`（失败）的任务始终可见，用户无需点击即可看到

## Changes
- `TERMINAL_STATUSES` → `CLOSED_STATUSES`（移除 completed/failed）
- 清理了遗留的无用 `showArchived` state 变量
- 仅修改 `packages/web-ui/src/pages/Work.tsx`（+16/-18）

## Test plan
- [ ] 任务完成后仍然显示在看板上
- [ ] 任务失败后仍然显示在看板上
- [ ] rejected/cancelled/archived 任务默认隐藏
- [ ] 点击按钮可以切换显示/隐藏 closed 状态的任务

Made with [Cursor](https://cursor.com)