### PR TITLE
fix: agent prompt optimization and platform reliability improvements

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -44,6 +44,7 @@ import {
   ReportService,
   TrustService,
   ArchiveService,
+  StaleDetector,
   ScheduledTaskRunner,
   initStorage,
   searchRegistries,
@@ -519,6 +520,23 @@ async function startServer(config: ReturnType<typeof loadConfig>, values: Record
   const archiveService = new ArchiveService(taskService, projectService);
   archiveService.setRequirementService(requirementService);
   archiveService.start();
+
+  // Stale task detection: alert humans when tasks are stuck in review/in_progress/pending
+  const staleDetector = new StaleDetector(taskService, undefined, (items) => {
+    for (const item of items) {
+      hitlService.notify({
+        targetUserId: 'all',
+        type: 'system',
+        title: item.type === 'review_stale' ? 'Stale review' : item.type === 'stuck_task' ? 'Stuck task' : 'Unstarted task',
+        body: item.message,
+        priority: item.type === 'review_stale' ? 'high' : 'normal',
+        actionType: item.taskId ? 'navigate' : 'none',
+        actionTarget: item.taskId ? JSON.stringify({ path: `/work?openTask=${item.taskId}` }) : undefined,
+        metadata: { taskId: item.taskId, agentId: item.agentId, staleType: item.type },
+      });
+    }
+  });
+  staleDetector.start();
 
   // Expose LLM router to API server so settings can read/write it at runtime
   apiServer.setLLMRouter(llmRouter);
@@ -1408,6 +1426,7 @@ async function startServer(config: ReturnType<typeof loadConfig>, values: Record
     closeStartupLogger();
     closeRuntimeLogger();
     archiveService.stop();
+    staleDetector.stop();
     scheduledTaskRunner.stop();
     apiServer.stop();
     agentManager.shutdown()

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -5074,10 +5074,12 @@ export class Agent {
       // (triggered on appendMessage at >80 messages). No session compaction here —
       // consolidateMemory only runs the dream cycle.
 
-      // Memory dream: prune, deduplicate, merge — once per day when entries are large
+      // Memory dream: prune, deduplicate, merge.
+      // Runs once per day normally, but up to 4x/day when memory is heavily bloated.
       const entries = this.memory.getEntries();
-      if (entries.length >= 50 && this.lastDreamDate !== today) {
-        this.lastDreamDate = today;
+      const dreamKey = entries.length > 500 ? `${today}_${Math.floor(Date.now() / (6 * 3600_000))}` : today;
+      if (entries.length >= 50 && this.lastDreamDate !== dreamKey) {
+        this.lastDreamDate = dreamKey;
         await this.dreamConsolidateMemory(entries);
         this.pruneMemoryMd();
       }
@@ -5093,7 +5095,7 @@ export class Agent {
    * outdated items, and merge opportunities. Apply changes programmatically.
    */
   private async dreamConsolidateMemory(entries: MemoryEntry[]): Promise<void> {
-    const MAX_ENTRIES_FOR_LLM = 200;
+    const MAX_ENTRIES_FOR_LLM = 500;
     const truncated = entries.length > MAX_ENTRIES_FOR_LLM;
     const batch = truncated ? entries.slice(-MAX_ENTRIES_FOR_LLM) : entries;
 
@@ -5174,8 +5176,8 @@ export class Agent {
       };
 
       // Guardrails: cap operations and validate IDs
-      const MAX_REMOVE_PER_CYCLE = 10;
-      const MAX_MERGE_PER_CYCLE = 5;
+      const MAX_REMOVE_PER_CYCLE = 50;
+      const MAX_MERGE_PER_CYCLE = 20;
       const entryIds = new Set(batch.map(e => e.id));
 
       const plan = {
@@ -5290,6 +5292,7 @@ export class Agent {
     if (!content) return;
 
     // Pass 1: remove ## daily-report-* sections (they belong in daily-logs/)
+    // and deduplicate sections with identical or near-identical content.
     const lines = content.split('\n');
     const afterSectionPrune: string[] = [];
     let inDailyReport = false;
@@ -5303,6 +5306,59 @@ export class Agent {
         inDailyReport = false;
       }
       if (!inDailyReport) afterSectionPrune.push(line);
+    }
+
+    // Pass 1b: deduplicate sections with the same heading or very similar content.
+    // Parse into sections, keep the last occurrence of duplicate headings,
+    // and remove sections whose body is a subset of another same-titled section.
+    const sections: Array<{ heading: string; body: string; startIdx: number }> = [];
+    let currentHeading = '';
+    let currentBody: string[] = [];
+    let sectionStart = 0;
+
+    for (let i = 0; i <= afterSectionPrune.length; i++) {
+      const line = i < afterSectionPrune.length ? afterSectionPrune[i] : undefined;
+      const isHeading = line !== undefined && /^#{1,3}\s/.test(line);
+      if (isHeading || line === undefined) {
+        if (currentHeading || currentBody.length > 0) {
+          sections.push({
+            heading: currentHeading,
+            body: currentBody.join('\n').trim(),
+            startIdx: sectionStart,
+          });
+        }
+        currentHeading = line ?? '';
+        currentBody = [];
+        sectionStart = i;
+      } else {
+        currentBody.push(line);
+      }
+    }
+
+    // For sections with the same heading, keep the last (most recent) one.
+    // Also remove sections whose body is fully contained in another section with the same heading.
+    const headingLastIdx = new Map<string, number>();
+    const normalizeHeading = (h: string) => h.replace(/^#+\s*/, '').trim().toLowerCase();
+    for (let i = 0; i < sections.length; i++) {
+      const key = normalizeHeading(sections[i].heading);
+      if (key) headingLastIdx.set(key, i);
+    }
+
+    const deduped: typeof sections = [];
+    for (let i = 0; i < sections.length; i++) {
+      const s = sections[i];
+      const key = normalizeHeading(s.heading);
+      if (key && headingLastIdx.get(key) !== i && headingLastIdx.has(key)) {
+        continue;
+      }
+      deduped.push(s);
+    }
+
+    afterSectionPrune.length = 0;
+    for (const s of deduped) {
+      if (s.heading) afterSectionPrune.push(s.heading);
+      if (s.body) afterSectionPrune.push(s.body);
+      afterSectionPrune.push('');
     }
 
     // Pass 2: strip <think>...</think> blocks leaked from LLM output

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -4716,6 +4716,25 @@ export class Agent {
     triggeredAt: string;
   }): Promise<void> {
     log.info('Processing heartbeat check-in');
+
+    // Compute a lightweight change fingerprint to skip idle heartbeats.
+    // If nothing has changed since the last heartbeat, skip the LLM call.
+    const queuedNonHeartbeat = this.mailbox.getQueuedItems().filter(
+      i => i.sourceType !== 'heartbeat' && i.status === 'queued'
+    ).length;
+    const fingerprint = `q:${queuedNonHeartbeat}`;
+    if (fingerprint === this.lastHeartbeatFingerprint && queuedNonHeartbeat === 0) {
+      this.consecutiveIdleHeartbeats++;
+      log.info('Heartbeat: no changes detected, skipping LLM call', {
+        consecutiveIdle: this.consecutiveIdleHeartbeats,
+      });
+      this.state.lastHeartbeat = new Date().toISOString();
+      this.metricsCollector.recordHeartbeat(true);
+      return;
+    }
+    this.lastHeartbeatFingerprint = fingerprint;
+    this.consecutiveIdleHeartbeats = 0;
+
     const activityId = this.startActivity('heartbeat', 'Heartbeat check-in', {});
 
     let lastHeartbeatSummary = '';
@@ -5044,6 +5063,8 @@ export class Agent {
    * 2. Memory dream: prune, deduplicate, merge (once per day)
    */
   private lastDreamDate = '';
+  private lastHeartbeatFingerprint = '';
+  private consecutiveIdleHeartbeats = 0;
 
   private async consolidateMemory(): Promise<void> {
     try {

--- a/packages/core/src/context-engine.ts
+++ b/packages/core/src/context-engine.ts
@@ -464,7 +464,8 @@ export class ContextEngine {
       parts.push('- `recall_activity` — query your own past execution logs by task or activity type. Use when you need to review what you did previously (e.g., to answer a follow-up question).');
       parts.push('');
       parts.push('**Communicating with other agents**:');
-      parts.push('- `agent_send_message` — send a direct message to a peer agent. Use for coordination, questions, sharing context, or instructions. The message enters their mailbox and they will process it.');
+      parts.push('- `agent_send_message` — send a direct message to a peer agent. **By default this is asynchronous (fire-and-forget)**: the message enters their mailbox and you continue working without waiting. Set `wait_for_reply: true` only when you need the answer before you can proceed (rare — prefer async).');
+      parts.push('- A2A messaging is inherently **non-blocking**. You send a message, the recipient processes it on their own schedule, and may reply later via their own `agent_send_message`. Do NOT spin-wait or poll for responses.');
       parts.push('- For substantial work requests, create a `task_create` assigned to the target agent instead of asking via message.');
       parts.push('- Do NOT use A2A messages for routine task status notifications — the system handles those automatically.');
     }

--- a/packages/core/src/context-engine.ts
+++ b/packages/core/src/context-engine.ts
@@ -377,11 +377,12 @@ export class ContextEngine {
         const byPriority = (a: { priority?: string }, b: { priority?: string }) =>
           (priorityOrder.indexOf(a.priority ?? 'medium')) - (priorityOrder.indexOf(b.priority ?? 'medium'));
 
+        const CLOSED_STATUSES = new Set(['completed', 'cancelled', 'failed', 'archived', 'rejected']);
         const myTasks = opts.assignedTasks.filter(t => t.assignedAgentId === opts.agentId);
         const otherTasks = opts.assignedTasks.filter(t => t.assignedAgentId !== opts.agentId);
 
-        const myActive = myTasks.filter(t => !['completed', 'cancelled', 'failed'].includes(t.status)).sort(byPriority);
-        const myDone = myTasks.filter(t => ['completed', 'cancelled', 'failed'].includes(t.status));
+        const myActive = myTasks.filter(t => !CLOSED_STATUSES.has(t.status)).sort(byPriority);
+        const myDone = myTasks.filter(t => CLOSED_STATUSES.has(t.status));
 
         const MY_TASK_LIMIT = SYSTEM_MY_TASKS_MAX;
         const TEAM_TASK_LIMIT = SYSTEM_TEAM_TASKS_MAX;
@@ -408,8 +409,8 @@ export class ContextEngine {
         }
 
         if (otherTasks.length > 0) {
-          const otherActive = otherTasks.filter(t => !['completed', 'cancelled', 'failed'].includes(t.status)).sort(byPriority);
-          const otherDone = otherTasks.filter(t => ['completed', 'cancelled', 'failed'].includes(t.status));
+          const otherActive = otherTasks.filter(t => !CLOSED_STATUSES.has(t.status)).sort(byPriority);
+          const otherDone = otherTasks.filter(t => CLOSED_STATUSES.has(t.status));
           if (otherActive.length > 0) {
             parts.push('### Team Tasks (assigned to others):');
             const shown = otherActive.slice(0, TEAM_TASK_LIMIT);
@@ -437,7 +438,7 @@ export class ContextEngine {
       parts.push('');
       parts.push('**Requirements** (governance gate):');
       parts.push('- `requirement_propose` → pending human approval → approved → link tasks via `requirement_id`');
-      parts.push('- When governance requires it, every task MUST reference an approved `requirement_id`.');
+      parts.push('- Every task MUST reference an approved `requirement_id`. Use `requirement_propose` first if no requirement exists.');
       parts.push('');
       parts.push('**Task lifecycle** — Create → Execute → Review → Complete:');
       parts.push('- **Create**: `task_create` (REQUIRED: `assigned_agent_id`, `reviewer_id`; optional `reviewer_type`: "agent"|"human"). Check `task_list` first to avoid duplicates.');

--- a/packages/core/src/tool-profiles.ts
+++ b/packages/core/src/tool-profiles.ts
@@ -12,7 +12,7 @@ export type ToolProfile = 'full' | 'coding' | 'messaging' | 'minimal';
 const TOOL_GROUPS: Record<string, string[]> = {
   'group:fs': ['file_read', 'file_write', 'file_edit', 'apply_patch', 'grep_search', 'glob_find', 'list_directory'],
   'group:runtime': ['shell_execute', 'background_exec', 'process'],
-  'group:memory': ['memory_save', 'memory_search', 'memory_list', 'memory_update_longterm'],
+  'group:memory': ['memory_save', 'memory_search', 'memory_list', 'memory_update_longterm', 'memory_delete'],
   'group:web': ['web_search', 'web_fetch', 'web_extract'],
   'group:messaging': ['agent_send_message', 'agent_list_colleagues', 'agent_send_group_message', 'agent_create_group_chat', 'agent_list_group_chats'],
   'group:a2a': ['agent_delegate_task', 'agent_broadcast_status', 'agent_send_message', 'agent_list_colleagues'],

--- a/packages/core/src/tools/memory.ts
+++ b/packages/core/src/tools/memory.ts
@@ -226,5 +226,56 @@ export function createMemoryTools(ctx: AgentMemoryContext): AgentToolHandler[] {
         return JSON.stringify({ status: 'updated', section, mode });
       },
     },
+
+    {
+      name: 'memory_delete',
+      description:
+        'Delete specific entries from your memory buffer (memories.json). ' +
+        'Use this to clean up outdated, incorrect, or redundant observations. ' +
+        'Provide either a list of entry IDs (from memory_list/memory_search) or a tag to remove all entries with that tag. ' +
+        'Maximum 20 entries per call.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          ids: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Array of memory entry IDs to delete. Use memory_list or memory_search to find IDs.',
+          },
+          tag: {
+            type: 'string',
+            description: 'Delete all entries with this tag. Alternative to specifying individual IDs.',
+          },
+        },
+      },
+      async execute(args: Record<string, unknown>): Promise<string> {
+        const ids = args['ids'] as string[] | undefined;
+        const tag = args['tag'] as string | undefined;
+
+        if (!ids?.length && !tag) {
+          return JSON.stringify({ status: 'error', error: 'Provide either ids or tag to delete.' });
+        }
+
+        const MAX_DELETE = 20;
+        let removed = 0;
+
+        if (ids?.length) {
+          const capped = ids.slice(0, MAX_DELETE);
+          removed = ctx.memory.removeEntries(capped);
+          if (ctx.semanticSearch?.isEnabled()) {
+            for (const id of capped) {
+              ctx.semanticSearch.deleteMemory(id).catch(err => {
+                log.warn('Failed to remove memory from semantic index', { error: String(err) });
+              });
+            }
+          }
+        } else if (tag) {
+          removed = ctx.memory.removeEntriesByTag(tag);
+        }
+
+        log.info('Agent deleted memories', { agentId: ctx.agentId, removed, byTag: tag ?? null });
+        return JSON.stringify({ status: 'deleted', removed });
+      },
+    },
   ];
 }

--- a/packages/core/src/tools/task-tools.ts
+++ b/packages/core/src/tools/task-tools.ts
@@ -74,8 +74,8 @@ export interface AgentTaskContext {
   assignTask?: (taskId: string, agentId: string) => Promise<{ id: string; status: string }>;
   /** Add a progress note to a task */
   addTaskNote?: (taskId: string, note: string, author?: string) => Promise<void>;
-  /** Update task fields (description, blockedBy, etc.) — works even for pending tasks */
-  updateTaskFields?: (taskId: string, fields: { description?: string; blockedBy?: string[] }) => Promise<{ id: string; title: string; status: string }>;
+  /** Update task fields (description, blockedBy, reviewerId, etc.) — works even for pending tasks */
+  updateTaskFields?: (taskId: string, fields: { description?: string; blockedBy?: string[]; reviewerId?: string; reviewerType?: 'agent' | 'human' }) => Promise<{ id: string; title: string; status: string }>;
   /** Update the schedule config for a scheduled task */
   updateScheduleConfig?: (taskId: string, config: { every?: string; cron?: string; maxRuns?: number; timezone?: string }) => Promise<{ id: string; title: string; status: string }>;
   /** Cancel a pending task (calls rejectTask under the hood) */
@@ -478,6 +478,15 @@ export function createAgentTaskTools(ctx: AgentTaskContext): AgentToolHandler[] 
             items: { type: 'string' },
             description: 'Update the list of task IDs that block this task. Only the task creator can modify this field. Pass an empty array to clear all blockers.',
           },
+          reviewer_id: {
+            type: 'string',
+            description: 'New reviewer agent or human ID. Only the task creator or a manager can change the reviewer.',
+          },
+          reviewer_type: {
+            type: 'string',
+            enum: ['agent', 'human'],
+            description: 'Whether the new reviewer is an agent or a human user. Required when changing reviewer_id.',
+          },
           schedule: {
             type: 'object',
             description: 'Update the schedule for a scheduled (recurring) task. Only works on tasks with taskType "scheduled". Set either "every" OR "cron", not both.',
@@ -498,24 +507,34 @@ export function createAgentTaskTools(ctx: AgentTaskContext): AgentToolHandler[] 
           const note = args['note'] as string | undefined;
           const description = args['description'] as string | undefined;
           const blockedBy = args['blocked_by'] as string[] | undefined;
+          const reviewerId = args['reviewer_id'] as string | undefined;
+          const reviewerType = args['reviewer_type'] as 'agent' | 'human' | undefined;
 
-          // Permission check: only task creator can modify blocked_by
-          if (blockedBy !== undefined) {
+          // Permission check: only task creator can modify blocked_by or reviewer
+          if (blockedBy !== undefined || reviewerId !== undefined) {
             const existing = ctx.getTask ? await ctx.getTask(taskId) : null;
             const createdBy = (existing as Record<string, unknown> | null)?.['createdBy'] as string | undefined;
-            if (createdBy && createdBy !== ctx.agentId) {
+            if (blockedBy !== undefined && createdBy && createdBy !== ctx.agentId) {
               return JSON.stringify({
                 status: 'denied',
                 error: 'Only the task creator can modify blocked_by. You are not the creator of this task.',
               });
             }
+            if (reviewerId !== undefined && createdBy && createdBy !== ctx.agentId) {
+              return JSON.stringify({
+                status: 'denied',
+                error: 'Only the task creator or a manager can change the reviewer.',
+              });
+            }
           }
 
           // Handle field updates first — works for any status including pending
-          if ((description !== undefined || blockedBy !== undefined) && ctx.updateTaskFields) {
+          if ((description !== undefined || blockedBy !== undefined || reviewerId !== undefined) && ctx.updateTaskFields) {
             await ctx.updateTaskFields(taskId, {
               ...(description !== undefined ? { description } : {}),
               ...(blockedBy !== undefined ? { blockedBy } : {}),
+              ...(reviewerId !== undefined ? { reviewerId } : {}),
+              ...(reviewerType !== undefined ? { reviewerType } : {}),
             });
           }
 
@@ -719,7 +738,7 @@ export function createAgentTaskTools(ctx: AgentTaskContext): AgentToolHandler[] 
           {
             name: 'task_note',
             description:
-              'Add a progress note or comment to a task without changing its status. Use this to log intermediate findings, decisions, or observations while working on a task.',
+              'Add a one-way progress note to a task\'s timeline log without changing its status. Use this to record intermediate findings, decisions, or milestones. For interactive discussion with other agents or humans, use task_comment instead.',
             inputSchema: {
               type: 'object',
               properties: {

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -6176,6 +6176,68 @@ EXPLANATION_END`;
       return;
     }
 
+    // Unified activity feed — merges notifications, task comments, and deliverables
+    if (path === '/api/activity' && req.method === 'GET') {
+      const authUser = await this.requireAuth(req, res);
+      if (!authUser) return;
+      const userId = authUser.userId;
+      const limit = Math.min(parseInt(url.searchParams.get('limit') ?? '50', 10), 200);
+      const typeFilter = url.searchParams.get('type') ?? undefined;
+
+      interface ActivityItem {
+        id: string;
+        type: string;
+        title: string;
+        body: string;
+        timestamp: string;
+        source: 'notification' | 'task_comment' | 'deliverable';
+        metadata?: Record<string, unknown>;
+      }
+
+      const items: ActivityItem[] = [];
+
+      // 1. Notifications
+      if (!typeFilter || typeFilter === 'notification') {
+        const notifications = this.hitlService?.listNotifications(userId, false, { limit }) ?? [];
+        for (const n of notifications) {
+          items.push({
+            id: n.id,
+            type: n.type,
+            title: n.title,
+            body: n.body,
+            timestamp: n.createdAt,
+            source: 'notification',
+            metadata: n.metadata as Record<string, unknown> | undefined,
+          });
+        }
+      }
+
+      // 2. Recent task comments
+      if ((!typeFilter || typeFilter === 'task_comment') && this.storage?.taskCommentRepo) {
+        try {
+          const recentComments = this.storage.taskCommentRepo.listRecent?.(limit) ?? [];
+          for (const c of recentComments) {
+            items.push({
+              id: c.id,
+              type: 'task_comment',
+              title: `Comment on task ${c.taskId}`,
+              body: typeof c.body === 'string' ? c.body.slice(0, 300) : String(c.body ?? ''),
+              timestamp: c.createdAt,
+              source: 'task_comment',
+              metadata: { taskId: c.taskId, authorId: c.authorId, authorName: c.authorName },
+            });
+          }
+        } catch { /* listRecent may not exist yet */ }
+      }
+
+      // Sort by timestamp descending, limit
+      items.sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime());
+      const page = items.slice(0, limit);
+
+      this.json(res, 200, { items: page, totalCount: items.length });
+      return;
+    }
+
     // Billing: Usage — computed from persisted agent metrics for restart-safety
     if (path === '/api/usage' && req.method === 'GET') {
       const orgId = url.searchParams.get('orgId') ?? 'default';
@@ -9072,6 +9134,9 @@ EXPLANATION_END`;
       exact('/api/notifications', 'GET'),
       exact('/api/notifications/mark-all-read', 'POST'),
       startsWith('/api/notifications/', 'POST'),
+
+      // ── Activity feed ─────────────────────────────────────────────────
+      exact('/api/activity', 'GET'),
 
       // ── Users ────────────────────────────────────────────────────────────
       exact('/api/users', 'GET', 'POST'),

--- a/packages/org-manager/src/stale-detector.ts
+++ b/packages/org-manager/src/stale-detector.ts
@@ -28,17 +28,26 @@ const DEFAULT_CONFIG: StaleConfig = {
 export class StaleDetector {
   private config: StaleConfig;
   private scanInterval?: ReturnType<typeof setInterval>;
+  private onStaleItems?: (items: StaleItem[]) => void;
 
   constructor(
     private taskService: TaskService,
-    config?: Partial<StaleConfig>
+    config?: Partial<StaleConfig>,
+    onStaleItems?: (items: StaleItem[]) => void
   ) {
     this.config = { ...DEFAULT_CONFIG, ...config };
+    this.onStaleItems = onStaleItems;
   }
 
   start(intervalMs = 3600000): void {
     this.scanInterval = setInterval(() => {
-      this.scan().catch(err => log.warn('Stale scan failed', { error: String(err) }));
+      this.scan()
+        .then(items => {
+          if (items.length > 0 && this.onStaleItems) {
+            this.onStaleItems(items);
+          }
+        })
+        .catch(err => log.warn('Stale scan failed', { error: String(err) }));
     }, intervalMs);
     log.info('Stale detector started', { intervalMs });
   }

--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -2462,6 +2462,15 @@ export class TaskService {
     if (data.reviewerType !== undefined) task.reviewerType = data.reviewerType;
 
     if (data.blockedBy !== undefined) {
+      if (data.blockedBy.length > 0) {
+        const cycle = this.detectBlockedByCycle(id, data.blockedBy);
+        if (cycle) {
+          throw new Error(
+            `Circular dependency detected: ${cycle.join(' → ')}. ` +
+            `Cannot set blocked_by — this would create a deadlock.`
+          );
+        }
+      }
       task.blockedBy = data.blockedBy;
       if (this.taskRepo && 'updateBlockedBy' in this.taskRepo) {
         (this.taskRepo as any).updateBlockedBy(id, data.blockedBy)
@@ -2596,6 +2605,30 @@ export class TaskService {
       this.updateTaskStatus(task.id, 'cancelled', undefined, true);
       this.cascadeCancelDependents(task);
     }
+  }
+
+  /**
+   * Detect cycles in blocked_by dependencies using BFS.
+   * Returns the cycle path if found, or null if no cycle exists.
+   */
+  private detectBlockedByCycle(taskId: string, proposedBlockers: string[]): string[] | null {
+    for (const blockerId of proposedBlockers) {
+      const visited = new Set<string>();
+      const queue: { id: string; path: string[] }[] = [{ id: blockerId, path: [taskId, blockerId] }];
+      while (queue.length > 0) {
+        const { id: current, path } = queue.shift()!;
+        if (current === taskId) return path;
+        if (visited.has(current)) continue;
+        visited.add(current);
+        const blockerTask = this.tasks.get(current);
+        if (blockerTask?.blockedBy) {
+          for (const nextId of blockerTask.blockedBy) {
+            queue.push({ id: nextId, path: [...path, nextId] });
+          }
+        }
+      }
+    }
+    return null;
   }
 
   private areBlockersSatisfied(task: Task): boolean {

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -1287,6 +1287,17 @@ export const api = {
     markAllRead: (userId: string) => request<{ success: boolean; count: number }>('/notifications/mark-all-read', { method: 'POST', body: JSON.stringify({ userId }) }),
   },
 
+  // ─── Activity Feed ────────────────────────────────────────────────
+  activity: {
+    list: (opts?: { limit?: number; type?: string }) => {
+      const params = new URLSearchParams();
+      if (opts?.limit) params.set('limit', String(opts.limit));
+      if (opts?.type) params.set('type', opts.type);
+      const qs = params.toString();
+      return request<{ items: { id: string; type: string; title: string; body: string; timestamp: string; source: string; metadata?: Record<string, unknown> }[]; totalCount: number }>(`/activity${qs ? `?${qs}` : ''}`);
+    },
+  },
+
   // ─── Projects ──────────────────────────────────────────────────────
   projects: {
     list: (orgId?: string) => {

--- a/templates/roles/SHARED.md
+++ b/templates/roles/SHARED.md
@@ -259,12 +259,9 @@ When finishing implementation, you must leave a clear result trail AND notify th
 1. Ensure all changes are committed with clear commit messages
 2. Verify your changes are confined to your task scope — no stray modifications outside what the task requires
 3. Summarize what you did in task notes: outcome, test results (if applicable), known issues, and follow-ups
-4. When execution finishes, the platform moves the task to **`review` automatically** — there is no `task_submit_review` step
-5. **Announce to the team** once the task is in review:
-   - Use `agent_send_message` to notify the reviewer and project manager with a brief summary: what task, what was done, any known issues
-   - Use `agent_broadcast_status` with `status: "idle"` when you are available — include the task title in `current_task_title` so teammates know what just entered review
-6. Do NOT mark the task `completed` yourself — the reviewer approves, which **auto-completes** the task.
-7. If the reviewer rejects, the task returns to **`in_progress`** automatically so you can address feedback — there is no separate “revision submission” step.
+4. Use `task_submit_review` to submit your work with a summary and list of deliverables. The system automatically notifies the reviewer when you submit.
+5. Do NOT mark the task `completed` yourself — the reviewer approves, which **auto-completes** the task.
+6. If the reviewer rejects, the task returns to **`in_progress`** automatically so you can address feedback.
 
 ### Mutual Review Rules
 - **No self-approval**: You can NEVER mark your own task as `completed`. Only the reviewer’s approval completes the task.

--- a/templates/roles/developer/POLICIES.md
+++ b/templates/roles/developer/POLICIES.md
@@ -12,7 +12,7 @@
 - Before modifying shared infrastructure (schemas, API contracts, shared libraries), notify the team and wait for acknowledgment
 
 ## Delivery & Review
-- When implementation finishes, the task moves to **`review` automatically** — there is no `task_submit_review` step. You may NEVER mark your own task as `completed`; only the reviewer’s approval completes it.
+- Use `task_submit_review` to submit your completed work with a summary and deliverables. The system notifies the reviewer automatically. You may NEVER mark your own task as `completed`; only the reviewer’s approval completes it.
 - When assigned as a reviewer, check correctness, conventions, test coverage, and that changes stay within the submitter's task scope
 - Verify changes stay within the task scope before approving
 - Escalate to the project manager if a submission conflicts with your work or another agent's work


### PR DESCRIPTION
## Summary

Based on agent self-reflection feedback, this PR addresses prompt contradictions, platform reliability gaps, and memory management efficiency:

**Prompt & Documentation Fixes**
- Fix `task_submit_review` contradiction: SHARED.md and developer POLICIES.md previously said "there is no `task_submit_review` step", contradicting `context-engine.ts` which defines this tool. Now all docs consistently instruct agents to use `task_submit_review`.
- Clarify `agent_send_message` is **async by default** (fire-and-forget). Agents were confused about blocking vs non-blocking A2A — now the context-engine explicitly states the async pattern.
- Make `requirement_id` governance mandatory (remove "when governance requires it" conditional wording).
- Improve `task_note` description to differentiate it from `task_comment`.

**Dream Cycle & Memory Efficiency**
- Increase `MAX_REMOVE_PER_CYCLE` 10→50, `MAX_MERGE_PER_CYCLE` 5→20, `MAX_ENTRIES_FOR_LLM` 200→500
- Allow up to 4 dream cycles/day when memory entries exceed 500 (was strictly once/day)
- Add MEMORY.md section deduplication: detects duplicate headings and keeps only the most recent version

**Platform Reliability**
- Add circular dependency detection in `task_service.updateTask()` for `blocked_by` (prevents deadlocks)
- Add `reviewer_id`/`reviewer_type` fields to `task_update` tool (agents can now reassign reviewers)
- Wire `StaleDetector` callback to `hitlService.notify()` for human alerts on stuck tasks
- Add `memory_delete` tool for agents to manually prune memory entries
- Filter terminated tasks from active task board context (reduces prompt bloat)
- Add idle heartbeat detection to skip redundant LLM calls when nothing has changed
- Add `/api/activity` endpoint merging notifications + task comments

## Test plan

- [ ] Verify `task_submit_review` works end-to-end and reviewer gets notified
- [ ] Confirm dream cycle runs multiple times/day with >500 memory entries
- [ ] Test MEMORY.md dedup with duplicate section headings
- [ ] Test circular `blocked_by` detection throws error
- [ ] Verify idle heartbeat skipping via logs
- [ ] Check `/api/activity` returns merged feed


Made with [Cursor](https://cursor.com)