### PR TITLE
[TASK-tsk_dd337cdb8b6e37b22fb93cf0][Frontend] fix: exclude new chat scenario from first-conversation detection

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -1659,6 +1659,18 @@ export class APIServer {
     }
 
     // ── Chat sessions ──────────────────────────────────────────────────────
+    if (path === '/api/sessions/has-any' && req.method === 'GET') {
+      const authUser = await this.requireAuth(req, res);
+      if (!authUser) return;
+      if (!this.storage) {
+        this.json(res, 200, { hasAny: false });
+        return;
+      }
+      const hasAny = this.storage.chatSessionRepo.hasAnySessions(authUser.userId);
+      this.json(res, 200, { hasAny });
+      return;
+    }
+
     if (path.match(/^\/api\/agents\/[^/]+\/sessions$/) && req.method === 'GET') {
       const authUser = await this.getAuthUser(req);
       const agentId = path.split('/')[3]!;

--- a/packages/storage/src/sqlite-storage.ts
+++ b/packages/storage/src/sqlite-storage.ts
@@ -1878,6 +1878,13 @@ export class SqliteChatSessionRepo {
     ).map(r => this._mapSession(r));
   }
 
+  hasAnySessions(userId: string) {
+    const r = this.db
+      .prepare('SELECT COUNT(*) AS cnt FROM chat_sessions WHERE user_id = ?')
+      .get(userId) as { cnt: number } | undefined;
+    return (r?.cnt ?? 0) > 0;
+  }
+
   getSession(sessionId: string) {
     const r = this.db.prepare('SELECT * FROM chat_sessions WHERE id = ?').get(sessionId) as
       | Record<string, unknown>

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -1223,6 +1223,8 @@ export const api = {
       request<{ avatarUrl: string }>('/avatars/upload', { method: 'POST', body: JSON.stringify({ image, type, id }) }),
   },
   sessions: {
+    hasAny: () =>
+      request<{ hasAny: boolean }>('/sessions/has-any'),
     listByAgent: (agentId: string, limit = 20) =>
       request<{ sessions: ChatSessionInfo[] }>(`/agents/${agentId}/sessions?limit=${limit}`),
     getMessages: (sessionId: string, limit = 50, before?: string) =>

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -1278,11 +1278,18 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
           } else {
             setActiveSessionId(null);
             if (!savedTabs || savedTabs.length === 0) setOpenSessionTabs([]);
-            // First-time conversation: auto-send intro request (locale from app language, fallback en)
-            const introBase = (i18n.language || 'en').split('-')[0]?.toLowerCase() ?? 'en';
-            const introKey = ['zh', 'ja', 'ko', 'fr', 'de', 'es', 'pt', 'ru'].includes(introBase) ? introBase : 'en';
-            const introMsg = t(`intro.${introKey}`);
-            setTimeout(() => sendRef.current?.(introMsg), 150);
+            // Check if this user truly has no sessions at all (first-time user)
+            // or just no sessions for this specific agent (returning user)
+            api.sessions.hasAny().then(({ hasAny }) => {
+              if (currentConvKeyRef.current !== newKey) return;
+              if (!hasAny) {
+                // Truly first-time user — auto-send intro request
+                const introBase = (i18n.language || 'en').split('-')[0]?.toLowerCase() ?? 'en';
+                const introKey = ['zh', 'ja', 'ko', 'fr', 'de', 'es', 'pt', 'ru'].includes(introBase) ? introBase : 'en';
+                const introMsg = t(`intro.${introKey}`);
+                setTimeout(() => sendRef.current?.(introMsg), 150);
+              }
+            });
           }
         });
       }


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Frontend Developer (ID: agt_ca836fdc2c08b8e9ec1370a8)
- **关联任务**: TASK-tsk_dd337cdb8b6e37b22fb93cf0
- **目标分支**: main

## 🎯 背景与动机 (Why)
当用户在 Team 页面中点击 'new chat'（新建会话）时，前端会检测到无现有会话并自动发送介绍消息。这导致即使是老用户，每次点 'new chat' 都会触发首次对话介绍，体验不佳。

## 🔧 变更内容 (What)
- packages/storage/src/sqlite-storage.ts: 添加 hasAnySessions(userId) 方法，查询用户在所有 agent 下是否有任何会话
- packages/org-manager/src/api-server.ts: 添加 GET /api/sessions/has-any 端点，返回当前用户是否有历史会话
- packages/web-ui/src/api.ts: 添加 sessions.hasAny() API 客户端方法
- packages/web-ui/src/pages/Team.tsx: 当加载当前 agent 无会话时，先调用 hasAny 端点判断用户是否有其他 agent 的会话，只有真正首次使用的用户才发送介绍消息

## ✅ 验证方式 (How to Verify)
- [x] pnpm lint 通过
- [x] pnpm typecheck 通过
- [x] pnpm test 通过（590 passed）

## 👤 评审人
- **Reviewer**: Code Reviewer