### PR TITLE
fix: scheduled task stuck when maxRuns is 0

### DIFF
--- a/packages/org-manager/src/scheduled-task-runner.ts
+++ b/packages/org-manager/src/scheduled-task-runner.ts
@@ -49,7 +49,7 @@ export class ScheduledTaskRunner {
 
       const config = task.scheduleConfig;
 
-      if (config.maxRuns !== undefined && (config.currentRuns ?? 0) >= config.maxRuns) {
+      if (config.maxRuns && config.maxRuns > 0 && (config.currentRuns ?? 0) >= config.maxRuns) {
         continue;
       }
 

--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -3571,7 +3571,7 @@ export class TaskService {
     const updated: ScheduleConfig = { ...task.scheduleConfig };
     if (fields.every !== undefined) { updated.every = fields.every; updated.cron = undefined; updated.runAt = undefined; }
     if (fields.cron !== undefined) { updated.cron = fields.cron; updated.every = undefined; updated.runAt = undefined; }
-    if (fields.maxRuns !== undefined) updated.maxRuns = fields.maxRuns;
+    if (fields.maxRuns !== undefined) updated.maxRuns = fields.maxRuns > 0 ? fields.maxRuns : undefined;
     if (fields.timezone !== undefined) updated.timezone = fields.timezone;
     updated.nextRunAt = computeNextRunFromConfig(updated);
     await this.updateScheduleConfig(taskIdStr, updated);

--- a/packages/web-ui/src/pages/Work.tsx
+++ b/packages/web-ui/src/pages/Work.tsx
@@ -2081,7 +2081,7 @@ function TaskDetailPanel({
               setScheduleMode(task.scheduleConfig?.cron ? 'cron' : 'every');
               setScheduleEveryDraft(task.scheduleConfig?.every ?? '4h');
               setScheduleCronDraft(task.scheduleConfig?.cron ?? '');
-              setScheduleMaxRunsDraft(task.scheduleConfig?.maxRuns != null ? String(task.scheduleConfig.maxRuns) : '');
+              setScheduleMaxRunsDraft(task.scheduleConfig?.maxRuns && task.scheduleConfig.maxRuns > 0 ? String(task.scheduleConfig.maxRuns) : '');
               setEditingSchedule(true);
             }}>
             <div className="flex items-center gap-2 flex-wrap">
@@ -2153,7 +2153,7 @@ function TaskDetailPanel({
               </div>
             ) : (
               <div className="flex items-center gap-2 mt-1 text-fg-tertiary">
-                <span>{t('work:task.scheduleRuns', { current: task.scheduleConfig.currentRuns ?? 0, max: task.scheduleConfig.maxRuns != null ? t('work:task.scheduleRunsMax', { max: task.scheduleConfig.maxRuns }) : '' })}</span>
+                <span>{t('work:task.scheduleRuns', { current: task.scheduleConfig.currentRuns ?? 0, max: task.scheduleConfig.maxRuns && task.scheduleConfig.maxRuns > 0 ? t('work:task.scheduleRunsMax', { max: task.scheduleConfig.maxRuns }) : '' })}</span>
                 {task.scheduleConfig.lastRunAt && (
                   <>
                     <span>·</span>


### PR DESCRIPTION
maxRuns=0 caused the scheduler to always skip the task because `currentRuns >= 0` is trivially true. Treat maxRuns<=0 as unlimited across scheduler, API, and UI display.

- Scheduler: only enforce maxRuns limit when maxRuns > 0
- API: convert maxRuns<=0 to undefined (remove limit)
- UI: don't display "/ 0" suffix, treat as unlimited in edit form