### PR TITLE
[TASK-tsk_bf43ca94359b08ca126b25f9][Backend] feat: 新增 Bing 搜索 Provider 作为零 Key fallback

### DIFF
--- a/packages/core/src/tools/web-search.ts
+++ b/packages/core/src/tools/web-search.ts
@@ -58,7 +58,7 @@ function hasProxy(): boolean {
 
 /**
  * Multi-backend web search tool.
- * Priority: Serper (Google) > Brave Search > DuckDuckGo Lite/HTML fallback.
+ * Priority: Serper (Google) > Brave Search > Bing (free) > DuckDuckGo Lite/HTML fallback.
  * API keys are read from environment variables.
  */
 export const WebSearchTool: AgentToolHandler = {
@@ -88,6 +88,7 @@ export const WebSearchTool: AgentToolHandler = {
     const backends: Array<{ name: string; fn: typeof searchSerper }> = [
       { name: 'Serper', fn: searchSerper },
       { name: 'Brave', fn: searchBrave },
+      { name: 'Bing', fn: searchBing },
       { name: 'DuckDuckGo', fn: searchDuckDuckGo },
     ];
     const errors: Array<{ backend: string; error: string }> = [];
@@ -195,6 +196,68 @@ async function searchBrave(query: string, maxResults: number): Promise<SearchRes
     snippet: r.description,
     date: r.page_age,
   }));
+}
+
+// ── Bing (free, no API key) ─────────────────────────────────────────────────
+
+const BING_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36';
+
+/**
+ * Scrape Bing search results from HTML. No API key required.
+ * Follows redirects from www.bing.com to regional endpoints (e.g. cn.bing.com).
+ */
+async function searchBing(query: string, maxResults: number): Promise<SearchResult[]> {
+  const encoded = encodeURIComponent(query);
+  let res: Response;
+  try {
+    res = await proxyFetch(`https://www.bing.com/search?q=${encoded}`, {
+      headers: { 'User-Agent': BING_UA },
+    });
+  } catch (err: unknown) {
+    throw new Error(`Network error: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+
+  const html = await res.text();
+  const results = parseBingHtml(html, maxResults);
+  if (results.length === 0) throw new Error('Parsed 0 results from Bing');
+  return results;
+}
+
+/**
+ * Parse Bing search result HTML.
+ * Results are in <li class="b_algo"> elements, each containing:
+ *   <h2><a href="URL">Title</a></h2>
+ *   <p>Snippet text</p>
+ */
+function parseBingHtml(html: string, max: number): SearchResult[] {
+  const results: SearchResult[] = [];
+  const algoRegex = /<li[^>]*class="b_algo"[^>]*>([\s\S]*?)<\/li>/g;
+  let match;
+
+  while ((match = algoRegex.exec(html)) !== null) {
+    if (results.length >= max) break;
+
+    const item = match[1]!;
+
+    // Extract URL and title from <a href="...">...</a> inside h2
+    const linkMatch = item.match(/<a[^>]+href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/i);
+    if (!linkMatch) continue;
+
+    const url = linkMatch[1]!;
+    const title = stripHtml(linkMatch[2]!);
+    if (!url || !title) continue;
+
+    // Extract snippet from first <p> tag
+    const snippetMatch = item.match(/<p[^>]*>([\s\S]*?)<\/p>/i);
+    const snippet = snippetMatch ? stripHtml(snippetMatch[1]!) : '';
+
+    results.push({ title, url, snippet });
+  }
+
+  return results;
 }
 
 // ── DuckDuckGo fallback (no API key) ───────────────────────────────────────


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_bf43ca94359b08ca126b25f9
- **关联需求**: web_search 工具增强
- **目标分支**: main

## 🎯 背景与动机 (Why)
当前 web_search 工具的 fallback 链中，Serper 和 Brave 都需要 API Key。零 Key 情况下仅依赖 DuckDuckGo，但 DDG 的 HTML 结构不稳定且反爬较严。Bing 的 HTML 搜索结果结构稳定（`<li class="b_algo">`），作为零 Key fallback 更可靠。

## 🔧 变更内容 (What)
- packages/core/src/tools/web-search.ts: 新增 Bing provider
  - `searchBing()` — 通过 www.bing.com/search 抓取 HTML（无需 API Key）
  - `parseBingHtml()` — 从 `<li class="b_algo">` 解析 URL/标题/摘要
  - 将 Bing 插入 fallback 链在 Brave 之后、DuckDuckGo 之前

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm test 通过（590/590）
- [x] eslint 无新增错误
- [x] 实际通过 curl 验证 Bing HTML 结构：www.bing.com 返回 server-rendered `b_algo` 元素

## 👤 评审人
- **Reviewer**: Code Reviewer