### PR TITLE
[TASK-tsk_c08428d470df3a11bed4d5a9][Backend] feat: 扩展 SiliconFlow 模型列表 + 自动降级 + 错误优化

### DIFF
--- a/templates/skills/image-generation/SKILL.md
+++ b/templates/skills/image-generation/SKILL.md
@@ -43,7 +43,7 @@ If no provider is specified, the first available one is used.
 | Replicate | `REPLICATE_API_TOKEN` | black-forest-labs/flux-1.1-pro | Wide model selection, Flux models |
 | Tongyi Wanxiang | `DASHSCOPE_API_KEY` | wanx2.1-t2i-turbo | Chinese text support, fast turbo mode |
 | Zhipu CogView | `ZHIPU_API_KEY` | cogview-4 | Chinese text support, multiple styles |
-| SiliconFlow | `SILICONFLOW_API_KEY` | FLUX.1-schnell | Affordable, hosts FLUX & SD models, fast |
+| SiliconFlow | `SILICONFLOW_API_KEY` | FLUX.1-schnell | Affordable, hosts FLUX & SD & Qwen models, fast |
 | Together AI | `TOGETHER_API_KEY` | FLUX.1.1-pro | High-quality FLUX, competitive pricing |
 | FAL | `FAL_KEY` | flux-pro/v1.1 | Fast inference, Flux Pro/Dev/Schnell |
 | Ideogram | `IDEOGRAM_API_KEY` | V_2 | Excellent text-in-image, supports editing |
@@ -71,7 +71,7 @@ If no provider is specified, the first available one is used.
   - Replicate: `black-forest-labs/flux-1.1-pro`, `black-forest-labs/flux-schnell`
   - Tongyi: `wanx2.1-t2i-turbo`, `wanx2.1-t2i-plus`
   - Zhipu: `cogview-4`, `cogview-4-250304`, `cogview-3-plus`
-  - SiliconFlow: `black-forest-labs/FLUX.1-schnell`, `stabilityai/stable-diffusion-3-5-large`
+  - SiliconFlow: `black-forest-labs/FLUX.1-schnell`, `black-forest-labs/FLUX.1-dev`, `black-forest-labs/FLUX.1-pro`, `black-forest-labs/FLUX.1.1-pro`, `stabilityai/stable-diffusion-3-5-large`, `stabilityai/stable-diffusion-3-5-medium`, `Qwen/Qwen-Image`, `deepseek-ai/Janus-Pro-7B`
   - Together: `black-forest-labs/FLUX.1.1-pro`, `black-forest-labs/FLUX.1-schnell`
   - FAL: `fal-ai/flux-pro/v1.1`, `fal-ai/flux/schnell`, `fal-ai/flux/dev`
   - Ideogram: `V_2`, `V_2_TURBO`, `V_1`

--- a/templates/skills/image-generation/server.mjs
+++ b/templates/skills/image-generation/server.mjs
@@ -83,7 +83,18 @@ const PROVIDERS = {
     name: 'SiliconFlow',
     envKey: 'SILICONFLOW_API_KEY',
     defaultModel: 'black-forest-labs/FLUX.1-schnell',
-    models: ['black-forest-labs/FLUX.1-schnell', 'stabilityai/stable-diffusion-3-5-large', 'stabilityai/stable-diffusion-3-5-large-turbo', 'stabilityai/stable-diffusion-xl-base-1.0'],
+    models: [
+      'black-forest-labs/FLUX.1-schnell',
+      'black-forest-labs/FLUX.1-dev',
+      'black-forest-labs/FLUX.1-pro',
+      'black-forest-labs/FLUX.1.1-pro',
+      'stabilityai/stable-diffusion-3-5-large',
+      'stabilityai/stable-diffusion-3-5-large-turbo',
+      'stabilityai/stable-diffusion-3-5-medium',
+      'stabilityai/stable-diffusion-xl-base-1.0',
+      'Qwen/Qwen-Image',
+      'deepseek-ai/Janus-Pro-7B',
+    ],
     supportedSizes: ['1024x1024', '1024x768', '768x1024', '1024x576', '576x1024'],
     supportsEdit: false,
     supportsNegativePrompt: true,
@@ -539,7 +550,9 @@ async function generateZhipu(args) {
 
 async function generateSiliconFlow(args) {
   const apiKey = getEnv('SILICONFLOW_API_KEY');
-  const model = args.model || 'black-forest-labs/FLUX.1-schnell';
+  const SILICONFLOW_DEFAULT = 'black-forest-labs/FLUX.1-schnell';
+  const model = args.model || SILICONFLOW_DEFAULT;
+  const isFallbackAttempt = args._siliconflowRetry === true;
 
   const body = {
     model,
@@ -558,10 +571,37 @@ async function generateSiliconFlow(args) {
     },
     body: JSON.stringify(body),
   });
+
   if (!res.ok) {
     const errText = await res.text().catch(() => '');
-    throw new Error(`SiliconFlow API error ${res.status}: ${errText}`);
+    const isModelIssue = (res.status === 400 || res.status === 404) &&
+      (errText.toLowerCase().includes('not found') ||
+       errText.toLowerCase().includes('disabled') ||
+       errText.toLowerCase().includes('not support') ||
+       errText.toLowerCase().includes('available') ||
+       errText.toLowerCase().includes('permission'));
+
+    if (isModelIssue && !isFallbackAttempt && model !== SILICONFLOW_DEFAULT) {
+      // Auto-fallback: retry with the default model
+      const fallbackArgs = { ...args, model: SILICONFLOW_DEFAULT, _siliconflowRetry: true };
+      const fallbackResult = await generateSiliconFlow(fallbackArgs);
+      // Tag the result so the caller knows fallback occurred
+      fallbackResult._fallback = true;
+      fallbackResult._originalModel = model;
+      fallbackResult._fallbackModel = SILICONFLOW_DEFAULT;
+      // Update args.model so the response handler uses the actual model
+      args.model = SILICONFLOW_DEFAULT;
+      return fallbackResult;
+    }
+
+    // Enhanced error message with available models hint
+    const modelHint = isModelIssue
+      ? `The requested model "${model}" is not available on your account. Available models: ${PROVIDERS.siliconflow.models.join(', ')}`
+      : `Available models: ${PROVIDERS.siliconflow.models.join(', ')}`;
+
+    throw new Error(`SiliconFlow API error ${res.status}: ${errText}. ${modelHint}`);
   }
+
   const data = await res.json();
   const results = [];
   for (const item of (data.images || data.data || [])) {
@@ -1046,7 +1086,7 @@ async function handleGenerateImage(toolArgs) {
     status: 'success',
     provider: providerCfg.name,
     provider_id: providerId,
-    model,
+    model: genArgs.model,  // Use genArgs.model to reflect auto-fallback model changes
     prompt: toolArgs.prompt,
     images,
     count: images.length,


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_c08428d470df3a11bed4d5a9
- **目标分支**: main

## 🎯 背景与动机 (Why)
SiliconFlow 的 image-generation 技能存在三个缺陷：
1. 模型列表仅硬编码 4 个模型，全部可能被用户账号禁用，容易误判
2. 模型返回 400/404 (not found/disabled) 时直接报错，没有自动降级
3. 错误信息没有提示可用模型，用户不知道哪些模型可用

## 🔧 变更内容 (What)
- templates/skills/image-generation/server.mjs: 模型列表从 4 个扩展到 10 个（新增 FLUX.1-dev、FLUX.1-pro、FLUX.1.1-pro、SD 3.5 medium、Qwen/Qwen-Image、Janus-Pro-7B）
- templates/skills/image-generation/server.mjs: generateSiliconFlow 加入自动降级机制 — 检测到 400/404 模型不可用错误时自动用默认模型 FLUX.1-schnell 重试
- templates/skills/image-generation/server.mjs: 错误信息优化 — 模型不可用时在错误中列出所有可用模型
- templates/skills/image-generation/server.mjs: handleGenerateImage 响应使用 genArgs.model 反映降级后的实际模型
- templates/skills/image-generation/SKILL.md: 更新 SiliconFlow 描述和模型列表

## ✅ 验证方式 (How to Verify)
- [x] node -c server.mjs 语法验证通过
- [ ] 需要设置 SILICONFLOW_API_KEY 手动验证自动降级

## 👤 评审人
- **Reviewer**: Code Reviewer