### PR TITLE
[TASK-tsk_b8107ac82636dbe4b064c260][Backend] fix: add SiliconFlow models to BUILTIN_MODEL_CATALOG

### DIFF
--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -1069,4 +1069,10 @@ const BUILTIN_MODEL_CATALOG: ModelDefinition[] = [
   { id: 'deepseek-v4-pro', name: 'DeepSeek-V4-Pro', provider: 'deepseek', contextWindow: 1000000, maxOutputTokens: 384000, cost: { input: 1.67, output: 3.33, cacheRead: 0.14 }, reasoning: true, inputTypes: ['text'] },
   { id: 'deepseek-chat', name: 'DeepSeek-Chat (legacy)', provider: 'deepseek', contextWindow: 65536, maxOutputTokens: 8192, cost: { input: 0.14, output: 0.28, cacheRead: 0.028 }, reasoning: false, inputTypes: ['text'] },
   { id: 'deepseek-reasoner', name: 'DeepSeek-Reasoner (legacy)', provider: 'deepseek', contextWindow: 65536, maxOutputTokens: 8192, cost: { input: 0.55, output: 2.19, cacheRead: 0.14 }, reasoning: true, inputTypes: ['text'] },
+  // SiliconFlow — https://docs.siliconflow.cn/docs/model-library (OpenAI-compatible proxy, pricing varies)
+  { id: 'Qwen/Qwen3.5-35B-A3B', name: 'Qwen3.5-35B-A3B', provider: 'siliconflow', contextWindow: 131072, maxOutputTokens: 8192, cost: { input: 1.5, output: 4 }, reasoning: true, inputTypes: ['text'] },
+  { id: 'Qwen/Qwen3.5-32B-A3B', name: 'Qwen3.5-32B-A3B', provider: 'siliconflow', contextWindow: 131072, maxOutputTokens: 8192, cost: { input: 1.5, output: 4 }, reasoning: true, inputTypes: ['text'] },
+  { id: 'deepseek-ai/DeepSeek-V3', name: 'DeepSeek-V3 (via SiliconFlow)', provider: 'siliconflow', contextWindow: 65536, maxOutputTokens: 8192, cost: { input: 2, output: 8 }, reasoning: true, inputTypes: ['text'] },
+  { id: 'deepseek-ai/DeepSeek-Coder-V2', name: 'DeepSeek-Coder-V2 (via SiliconFlow)', provider: 'siliconflow', contextWindow: 65536, maxOutputTokens: 8192, cost: { input: 1, output: 4 }, reasoning: false, inputTypes: ['text'] },
+  { id: 'moonshotai/Kimi-K2.5', name: 'Kimi-K2.5 (via SiliconFlow)', provider: 'siliconflow', contextWindow: 131072, maxOutputTokens: 8192, cost: { input: 2, output: 8 }, reasoning: true, inputTypes: ['text'] },
 ];


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_b8107ac82636dbe4b064c260
- **关联需求**: 更新 LLM 模型配置 — 增加最新模型 + 优化默认选择
- **目标分支**: main

## 🎯 背景与动机 (Why)
SiliconFlow Provider 在运行时 availableModels 返回空数组，导致用户无法选择任何模型。诊断发现根因：BUILTIN_MODEL_CATALOG 中没有任何 provider: siliconflow 的条目，而 getProviderModels() 方法通过过滤此列表返回模型。

## 🔧 变更内容 (What)
- packages/core/src/llm/router.ts: 在 BUILTIN_MODEL_CATALOG 末尾添加 5 个 SiliconFlow 模型条目（与 packages/shared/src/models.ts 中定义的模型一致）

具体添加的模型：
1. Qwen/Qwen3.5-35B-A3B（推理模型, 131K context）
2. Qwen/Qwen3.5-32B-A3B（推理模型, 131K context）
3. deepseek-ai/DeepSeek-V3（推理模型, 65K context）
4. deepseek-ai/DeepSeek-Coder-V2（非推理, 65K context）
5. moonshotai/Kimi-K2.5（推理模型, 131K context）

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm test 通过（38 test files, 590 tests, all passed）
- [x] 代码审查确认 BUILTIN_MODEL_CATALOG 增加 6 行
- [ ] 重启服务后执行 llm_list_providers 应看到 siliconflow 有 5 个 availableModels

## 👤 评审人
- **Reviewer**: Code Reviewer
