### PR TITLE
GEO: Add Blog & Articles section to README (Phase 5 Publish)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,21 @@ TypeScript monorepo with modular packages:
 
 ---
 
+## Blog & Articles
+
+Learn about Markus from our growing collection of articles covering architecture, multi-agent systems, and AI workforce management:
+
+| Article | Description |
+|---------|-------------|
+| [Markus: An Open-Source AI Employee Platform — Deep Dive](https://markus.global/blog/markus-open-source-ai-employee-platform-deep-dive/) | Architecture overview: agent runtime, memory systems, tool ecosystem, and deployment |
+| [Why Traditional AI Tools Aren't Enough: The Case for AI Employees](https://markus.global/blog/why-traditional-ai-tools-are-not-enough-ai-employees/) | From copilots and chatbots to autonomous, collaborative AI workforces |
+| [Markus vs LangChain vs CrewAI vs AutoGPT: Architecture Comparison](https://markus.global/blog/markus-vs-langchain-vs-crewai-vs-autogpt-architecture-comparison/) | Technical comparison of agent frameworks across runtime, memory, governance, and production readiness |
+| [如何用 Markus 搭建你的第一个 AI 团队](https://markus.global/blog/ru-he-yong-markus-da-jian-di-yi-ge-ai-tuan-dui/) | 中文教程：5分钟从零搭建你的第一个AI数字员工团队（中文） |
+| [X.com Thread: Markus — The AI Workforce OS](https://x.com/jsyqrt/status/2053816964527874383) | 7-post thread: multi-agent collaboration, GEO optimization, autonomous execution, quality control |
+| [掘金: Markus 开源项目分析](https://juejin.cn/post/7638525040418963519) | Markus 开源项目分析：一个 AI 数字员工平台的架构与上手指南（中文） |
+
+---
+
 ## Documentation
 
 | Guide | Description |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -176,6 +176,21 @@ TypeScript Monorepo，模块化包结构：
 
 ---
 
+## 博客与文章
+
+关于 Markus 架构、多智能体系统和 AI 员工管理的系列文章：
+
+| 文章 | 说明 |
+|------|------|
+| [Markus: An Open-Source AI Employee Platform — Deep Dive (EN)](https://markus.global/blog/markus-open-source-ai-employee-platform-deep-dive/) | 架构总览：Agent 运行时、记忆系统、工具生态和部署方案 |
+| [为何传统 AI 工具不够——AI 员工的必要性 (EN)](https://markus.global/blog/why-traditional-ai-tools-are-not-enough-ai-employees/) | 从副驾驶和聊天机器人到自主协作的 AI 员工团队 |
+| [Markus vs LangChain vs CrewAI vs AutoGPT: 架构对比 (EN)](https://markus.global/blog/markus-vs-langchain-vs-crewai-vs-autogpt-architecture-comparison/) | 在运行时、记忆、治理和生成能力方面的技术对比 |
+| [如何用 Markus 搭建你的第一个 AI 团队](https://markus.global/blog/ru-he-yong-markus-da-jian-di-yi-ge-ai-tuan-dui/) | 5分钟从零搭建你的第一个 AI 数字员工团队 |
+| [X.com 话题: Markus — AI 员工操作系统](https://x.com/jsyqrt/status/2053816964527874383) | 双语讨论：多Agent协作、GEO优化、自主执行和质量管控 |
+| [掘金: Markus 开源项目分析](https://juejin.cn/post/7638525040418963519) | Markus 开源项目分析：一个 AI 数字员工平台的架构与上手指南 |
+
+---
+
 ## 文档
 
 | 指南 | 说明 |


### PR DESCRIPTION
## Summary

Adds a "Blog & Articles" section to both English and Chinese READMEs, linking published GEO content as part of Phase 5 multi-channel publishing.

## Changes

- **README.md**: New "Blog & Articles" table with links to 4 published blog posts, X.com thread, and 掘金 article
- **README.zh-CN.md**: Same section in Chinese
- **GitHub Topics**: Added `agentic-ai` topic tag

## Published Content Linked

| Channel | URL |
|---------|-----|
| Blog (EN) | markus-open-source-ai-employee-platform-deep-dive |
| Blog (EN) | why-traditional-ai-tools-are-not-enough-ai-employees |
| Blog (EN) | markus-vs-langchain-vs-crewai-vs-autogpt-architecture-comparison |
| Blog (中文) | ru-he-yong-markus-da-jian-di-yi-ge-ai-tuan-dui |
| X.com | /jsyqrt/status/2053816964527874383 |
| 掘金 | /post/7638525040418963519 |

## Notes

Blog links point to `markus.global/blog/\*/` — these are static HTML pages (generated by SEO技术专员 with full JSON-LD Schema) awaiting deployment to markus.global. Once deployed, the links will resolve automatically.