### PR TITLE
fix: chat stream stuck thinking, dashboard UX improvements, directory…

### DIFF
--- a/packages/core/src/agent-metrics.ts
+++ b/packages/core/src/agent-metrics.ts
@@ -33,6 +33,10 @@ export interface AgentMetricsSnapshot {
 
 interface AuditCounters {
   totalTokens: number;
+  promptTokens: number;
+  completionTokens: number;
+  estimatedCost: number;
+  costToday: number;
   requestCount: number;
   toolCalls: number;
   errorCount: number;
@@ -47,7 +51,9 @@ interface AuditCounters {
 
 function freshCounters(): AuditCounters {
   return {
-    totalTokens: 0, requestCount: 0, toolCalls: 0, errorCount: 0,
+    totalTokens: 0, promptTokens: 0, completionTokens: 0,
+    estimatedCost: 0, costToday: 0,
+    requestCount: 0, toolCalls: 0, errorCount: 0,
     totalEvents: 0, totalLlmDurationMs: 0, lastSuccessTimestamp: 0,
     tokensToday: 0, requestsToday: 0, toolCallsToday: 0,
     todayCutoffDate: new Date().toISOString().slice(0, 10),
@@ -97,6 +103,9 @@ export class AgentMetricsCollector {
     type: string;
     action: string;
     tokensUsed?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    cost?: number;
     durationMs?: number;
     success: boolean;
     detail?: string;
@@ -107,6 +116,7 @@ export class AgentMetricsCollector {
       c.tokensToday = 0;
       c.requestsToday = 0;
       c.toolCallsToday = 0;
+      c.costToday = 0;
       c.todayCutoffDate = today;
     }
 
@@ -117,6 +127,12 @@ export class AgentMetricsCollector {
     if (event.type === 'llm_request') {
       const tokens = event.tokensUsed ?? 0;
       c.totalTokens += tokens;
+      c.promptTokens += event.inputTokens ?? 0;
+      c.completionTokens += event.outputTokens ?? 0;
+      if (event.cost) {
+        c.estimatedCost += event.cost;
+        c.costToday += event.cost;
+      }
       c.requestCount++;
       c.tokensToday += tokens;
       c.requestsToday++;
@@ -196,22 +212,35 @@ export class AgentMetricsCollector {
     requestsToday: number;
     toolCallsToday: number;
     estimatedCost: number;
+    costToday: number;
   } {
     const c = this.counters;
-    const input = Math.round(c.totalTokens * 0.7);
-    const output = c.totalTokens - input;
-    const estimatedCost = (input / 1_000_000) * 3 + (output / 1_000_000) * 15;
+    let cost = c.estimatedCost;
+    let costToday = c.costToday;
+
+    // Fallback for pre-migration data without per-call cost tracking
+    if (cost === 0 && c.totalTokens > 0) {
+      const input = Math.round(c.totalTokens * 0.7);
+      const output = c.totalTokens - input;
+      cost = (input / 1_000_000) * 3 + (output / 1_000_000) * 15;
+    }
+    if (costToday === 0 && c.tokensToday > 0) {
+      const input = Math.round(c.tokensToday * 0.7);
+      const output = c.tokensToday - input;
+      costToday = (input / 1_000_000) * 3 + (output / 1_000_000) * 15;
+    }
 
     return {
       totalTokens: c.totalTokens,
-      promptTokens: input,
-      completionTokens: output,
+      promptTokens: c.promptTokens || Math.round(c.totalTokens * 0.7),
+      completionTokens: c.completionTokens || (c.totalTokens - Math.round(c.totalTokens * 0.7)),
       requestCount: c.requestCount,
       toolCalls: c.toolCalls,
       tokensToday: c.tokensToday,
       requestsToday: c.requestsToday,
       toolCallsToday: c.toolCallsToday,
-      estimatedCost: Math.round(estimatedCost * 10000) / 10000,
+      estimatedCost: Math.round(cost * 10000) / 10000,
+      costToday: Math.round(costToday * 10000) / 10000,
     };
   }
 
@@ -245,9 +274,12 @@ export class AgentMetricsCollector {
   }
 
   private computeTokenUsageFromCounters(c: AuditCounters): TokenUsage {
-    const input = Math.round(c.totalTokens * 0.7);
-    const output = c.totalTokens - input;
-    const cost = (input / 1_000_000) * 3 + (output / 1_000_000) * 15;
+    const input = c.promptTokens || Math.round(c.totalTokens * 0.7);
+    const output = c.completionTokens || (c.totalTokens - input);
+    let cost = c.estimatedCost;
+    if (cost === 0 && c.totalTokens > 0) {
+      cost = (input / 1_000_000) * 3 + (output / 1_000_000) * 15;
+    }
     return { input, output, cost: Math.round(cost * 10000) / 10000 };
   }
 

--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -1988,10 +1988,19 @@ export class Agent {
     return this.metricsCollector.getUsageStats();
   }
 
+  private computeCallCost(inputTokens: number, outputTokens: number): number {
+    const modelCost = this.llmRouter.getModelCost(this.getEffectiveProvider());
+    if (!modelCost) return 0;
+    return (inputTokens / 1_000_000) * modelCost.input + (outputTokens / 1_000_000) * modelCost.output;
+  }
+
   private emitAudit(event: {
     type: string;
     action: string;
     tokensUsed?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    cost?: number;
     durationMs?: number;
     success: boolean;
     detail?: string;
@@ -2485,6 +2494,9 @@ export class Agent {
         type: 'llm_request',
         action: 'chat',
         tokensUsed: tokensThisCall,
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+        cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens),
         durationMs: Date.now() - llmStart,
         success: true,
       });
@@ -2689,6 +2701,9 @@ export class Agent {
           type: 'llm_request',
           action: 'chat',
           tokensUsed: tokens2,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens),
           durationMs: Date.now() - llmStart2,
           success: true,
         });
@@ -3003,6 +3018,9 @@ export class Agent {
         type: 'llm_request',
         action: 'chat_stream',
         tokensUsed: tokensThisCall,
+        inputTokens: response.usage.inputTokens,
+        outputTokens: response.usage.outputTokens,
+        cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens),
         durationMs: Date.now() - llmStart,
         success: true,
       });
@@ -3208,6 +3226,9 @@ export class Agent {
           type: 'llm_request',
           action: 'chat_stream',
           tokensUsed: tokens2,
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens),
           durationMs: Date.now() - llmStart2,
           success: true,
         });
@@ -3618,7 +3639,7 @@ export class Agent {
       let taskLlmTokens = response.usage.inputTokens + response.usage.outputTokens;
       this.updateTokensUsed(taskLlmTokens);
       this.calibrateTokenCounter(response.usage.inputTokens);
-      this.emitAudit({ type: 'llm_request', action: 'task_execution', tokensUsed: taskLlmTokens, durationMs: Date.now() - taskLlmStart, success: true });
+      this.emitAudit({ type: 'llm_request', action: 'task_execution', tokensUsed: taskLlmTokens, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens, cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens), durationMs: Date.now() - taskLlmStart, success: true });
 
       while (
         (response.finishReason === 'tool_use' && response.toolCalls?.length) ||
@@ -3838,7 +3859,7 @@ export class Agent {
         taskLlmTokens = response.usage.inputTokens + response.usage.outputTokens;
         this.updateTokensUsed(taskLlmTokens);
         this.calibrateTokenCounter(response.usage.inputTokens);
-        this.emitAudit({ type: 'llm_request', action: 'task_execution', tokensUsed: taskLlmTokens, durationMs: Date.now() - taskLlmStart, success: true });
+        this.emitAudit({ type: 'llm_request', action: 'task_execution', tokensUsed: taskLlmTokens, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens, cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens), durationMs: Date.now() - taskLlmStart, success: true });
       }
 
       // Final cancel check after the tool loop exits
@@ -4132,7 +4153,7 @@ export class Agent {
       let risTokens = response.usage.inputTokens + response.usage.outputTokens;
       this.updateTokensUsed(risTokens);
       this.calibrateTokenCounter(response.usage.inputTokens);
-      this.emitAudit({ type: 'llm_request', action: 'respond_in_session', tokensUsed: risTokens, durationMs: Date.now() - risLlmStart, success: true });
+      this.emitAudit({ type: 'llm_request', action: 'respond_in_session', tokensUsed: risTokens, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens, cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens), durationMs: Date.now() - risLlmStart, success: true });
 
       let toolIter = 0;
       while (
@@ -4207,7 +4228,7 @@ export class Agent {
         risTokens = response.usage.inputTokens + response.usage.outputTokens;
         this.updateTokensUsed(risTokens);
         this.calibrateTokenCounter(response.usage.inputTokens);
-        this.emitAudit({ type: 'llm_request', action: 'respond_in_session', tokensUsed: risTokens, durationMs: Date.now() - risLlmStart, success: true });
+        this.emitAudit({ type: 'llm_request', action: 'respond_in_session', tokensUsed: risTokens, inputTokens: response.usage.inputTokens, outputTokens: response.usage.outputTokens, cost: this.computeCallCost(response.usage.inputTokens, response.usage.outputTokens), durationMs: Date.now() - risLlmStart, success: true });
       }
 
       flushText();

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -981,6 +981,18 @@ export class LLMRouter {
     return provider?.model ?? '';
   }
 
+  getModelCost(providerName?: string): ModelCostConfig | undefined {
+    const name = providerName ?? this.defaultProvider;
+    const provider = this.providers.get(name);
+    if (!provider) return undefined;
+    const custom = this.customModelConfigs.get(name);
+    if (custom?.cost) return custom.cost;
+    const catalogEntry = BUILTIN_MODEL_CATALOG.find(m => m.id === provider.model && m.provider === name)
+      ?? BUILTIN_MODEL_CATALOG.find(m => m.id === provider.model)
+      ?? this.customModelCatalog.get(name)?.find(m => m.id === provider.model);
+    return catalogEntry?.cost;
+  }
+
   getModelInputTypes(providerName?: string): Array<'text' | 'image'> {
     const name = providerName ?? this.defaultProvider;
     const provider = this.providers.get(name);

--- a/packages/core/src/tool-loop-detector.ts
+++ b/packages/core/src/tool-loop-detector.ts
@@ -18,6 +18,7 @@ export interface LoopDetectionConfig {
     genericRepeat: boolean;
     pingPong: boolean;
     noProgress: boolean;
+    sameToolBurst: boolean;
   };
 }
 
@@ -37,6 +38,7 @@ const DEFAULT_CONFIG: LoopDetectionConfig = {
     genericRepeat: true,
     pingPong: true,
     noProgress: true,
+    sameToolBurst: true,
   },
 };
 
@@ -92,6 +94,11 @@ export class ToolLoopDetector {
 
     if (this.config.detectors.noProgress) {
       const result = this.detectNoProgress();
+      if (result.detected) return result;
+    }
+
+    if (this.config.detectors.sameToolBurst) {
+      const result = this.detectSameToolBurst();
       if (result.detected) return result;
     }
 
@@ -200,6 +207,43 @@ export class ToolLoopDetector {
       const msg = `Warning: "${recent[recent.length - 1]!.name}" returned identical results ${sameResultStreak} times`;
       log.warn(msg);
       return { detected: true, severity: 'warning', pattern: 'noProgress', message: msg };
+    }
+
+    return noDetection();
+  }
+
+  /**
+   * Detects: a single tool called many times consecutively, even with different
+   * args/results each time. Catches "semantic loops" where the agent retries
+   * variations of the same approach (e.g., different shell commands to debug
+   * the same failing server) without switching strategy.
+   */
+  private detectSameToolBurst(): LoopDetectionResult {
+    if (this.history.length < this.config.warningThreshold) return noDetection();
+
+    const last = this.history[this.history.length - 1]!;
+    let streak = 1;
+    for (let i = this.history.length - 2; i >= 0; i--) {
+      if (this.history[i]!.name === last.name) {
+        streak++;
+      } else {
+        break;
+      }
+    }
+
+    const burstCritical = this.config.criticalThreshold + 2;
+    const burstWarning = this.config.warningThreshold + 2;
+
+    if (streak >= burstCritical) {
+      const msg = `Critical: "${last.name}" called ${streak} times consecutively (with varying arguments) — likely stuck in a retry loop`;
+      log.warn(msg);
+      return { detected: true, severity: 'critical', pattern: 'sameToolBurst', message: msg };
+    }
+
+    if (streak >= burstWarning) {
+      const msg = `Warning: "${last.name}" called ${streak} times consecutively — consider a different approach`;
+      log.warn(msg);
+      return { detected: true, severity: 'warning', pattern: 'sameToolBurst', message: msg };
     }
 
     return noDetection();

--- a/packages/core/test/agent-loop.test.ts
+++ b/packages/core/test/agent-loop.test.ts
@@ -36,6 +36,7 @@ function makeMockRouter(chatFn: (...args: unknown[]) => Promise<unknown>) {
     getActiveModelMaxOutput: () => 8000,
     getModelContextWindow: (model: string) => 200000,
     getModelMaxOutput: (model: string) => 8000,
+    getModelCost: () => undefined,
     isCompactionSupported: (model: string) => true,
     listProviders: () => ['test'],
     getProvider: () => undefined,

--- a/packages/core/test/manus-practices.test.ts
+++ b/packages/core/test/manus-practices.test.ts
@@ -135,15 +135,15 @@ describe('Manus Best Practices Integration', () => {
           };
         }),
         chatStream: vi.fn(),
-        getActiveModelName: () => 'gpt-4',
+        getActiveModelName: () => 'test-model',
         getActiveModelContextWindow: () => 200000,
         getActiveModelMaxOutput: () => 8000,
         getModelContextWindow: (model: string) => 200000,
         getModelMaxOutput: (model: string) => 8000,
+        getModelCost: () => undefined,
         listProviders: () => ['test'],
         getProvider: () => undefined,
         getDefaultProvider: () => 'test',
-        getActiveModelName: () => 'test-model',
         isCompactionSupported: () => false,
       };
 
@@ -217,15 +217,15 @@ describe('Manus Best Practices Integration', () => {
           };
         }),
         chatStream: vi.fn(),
-        getActiveModelName: () => 'gpt-4',
+        getActiveModelName: () => 'test-model',
         getActiveModelContextWindow: () => 200000,
         getActiveModelMaxOutput: () => 8000,
         getModelContextWindow: (model: string) => 200000,
         getModelMaxOutput: (model: string) => 8000,
+        getModelCost: () => undefined,
         listProviders: () => ['test'],
         getProvider: () => undefined,
         getDefaultProvider: () => 'test',
-        getActiveModelName: () => 'test-model',
         isCompactionSupported: () => false,
       };
 

--- a/packages/core/test/tool-loop-detector.test.ts
+++ b/packages/core/test/tool-loop-detector.test.ts
@@ -76,8 +76,39 @@ describe('ToolLoopDetector', () => {
     expect(result.detected).toBe(false);
   });
 
+  it('should detect sameToolBurst pattern with varying args', () => {
+    const d = new ToolLoopDetector({ enabled: true, historySize: 30, warningThreshold: 3, criticalThreshold: 5, detectors: { genericRepeat: false, pingPong: false, noProgress: false, sameToolBurst: true } });
+
+    // Simulate an agent retrying different shell commands to debug same issue
+    d.record('shell_execute', { command: 'pnpm dev:server' }, 'started pid 1234');
+    d.record('shell_execute', { command: 'lsof -i :3000' }, 'No port 3000');
+    d.record('shell_execute', { command: 'lsof -p 1234 -i -P' }, 'no listening ports');
+    d.record('shell_execute', { command: 'cat server.log' }, 'Error: EADDRINUSE');
+    d.record('shell_execute', { command: 'kill 1234 && pnpm dev:server' }, 'started pid 1235');
+    d.record('shell_execute', { command: 'lsof -i :3000' }, 'No port 3000 (2)');
+    d.record('shell_execute', { command: 'curl localhost:3000' }, 'Connection refused');
+
+    const result = d.check();
+    expect(result.detected).toBe(true);
+    expect(result.pattern).toBe('sameToolBurst');
+    expect(result.severity).toBe('critical');
+  });
+
+  it('should not trigger sameToolBurst when tools are mixed', () => {
+    const d = new ToolLoopDetector({ enabled: true, historySize: 30, warningThreshold: 3, criticalThreshold: 5, detectors: { genericRepeat: false, pingPong: false, noProgress: false, sameToolBurst: true } });
+
+    d.record('shell_execute', { command: 'npm test' }, 'fail');
+    d.record('file_read', { path: 'src/index.ts' }, 'code...');
+    d.record('shell_execute', { command: 'npm test' }, 'fail');
+    d.record('file_edit', { path: 'src/index.ts' }, 'edited');
+    d.record('shell_execute', { command: 'npm test' }, 'pass');
+
+    const result = d.check();
+    expect(result.detected).toBe(false);
+  });
+
   it('should not detect when disabled', () => {
-    const d = new ToolLoopDetector({ enabled: false, historySize: 30, warningThreshold: 3, criticalThreshold: 5, detectors: { genericRepeat: true, pingPong: true, noProgress: true } });
+    const d = new ToolLoopDetector({ enabled: false, historySize: 30, warningThreshold: 3, criticalThreshold: 5, detectors: { genericRepeat: true, pingPong: true, noProgress: true, sameToolBurst: true } });
 
     for (let i = 0; i < 10; i++) {
       d.record('file_read', { path: 'config.json' }, 'same result');

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -6443,14 +6443,6 @@ EXPLANATION_END`;
         } catch { /* agent not loaded */ }
       }
 
-      // Supplement with billing service data if available (for current-session records)
-      const billingSummary = this.billingService?.getUsageSummary(orgId);
-      if (billingSummary) {
-        llmTokens = Math.max(llmTokens, billingSummary.llmTokens);
-        toolCalls = Math.max(toolCalls, billingSummary.toolCalls);
-        messages = Math.max(messages, billingSummary.messages);
-      }
-
       this.json(res, 200, {
         usage: {
           orgId,
@@ -6458,7 +6450,7 @@ EXPLANATION_END`;
           llmTokens,
           toolCalls,
           messages,
-          storageBytes: billingSummary?.storageBytes ?? 0,
+          storageBytes: this.billingService?.getUsageSummary(orgId)?.storageBytes ?? 0,
         },
         plan,
       });
@@ -6487,6 +6479,7 @@ EXPLANATION_END`;
             toolCalls: stats.toolCalls,
             messages: stats.requestsToday,
             estimatedCost: stats.estimatedCost,
+            costToday: stats.costToday,
           };
         } catch {
           return {
@@ -6502,6 +6495,7 @@ EXPLANATION_END`;
             toolCalls: 0,
             messages: 0,
             estimatedCost: 0,
+            costToday: 0,
           };
         }
       });

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -8371,6 +8371,25 @@ EXPLANATION_END`;
         }
 
         const stat = statSync(resolved);
+        if (stat.isDirectory()) {
+          const { readdirSync } = await import('node:fs');
+          const { join, extname: extDir } = await import('node:path');
+          const entries = readdirSync(resolved, { withFileTypes: true })
+            .filter(e => !e.name.startsWith('.'))
+            .map(e => {
+              const full = join(resolved, e.name);
+              const isDir = e.isDirectory();
+              let size: number | undefined;
+              try { if (!isDir) size = statSync(full).size; } catch { /* skip */ }
+              return { name: e.name, path: full, isDirectory: isDir, size, ext: isDir ? '' : extDir(e.name).toLowerCase() };
+            })
+            .sort((a, b) => {
+              if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+              return a.name.localeCompare(b.name);
+            });
+          this.json(res, 200, { type: 'directory', name: resolved.split('/').pop(), path: resolved, entries });
+          return;
+        }
         if (!stat.isFile()) {
           this.json(res, 400, { error: 'Path is not a file' });
           return;
@@ -9667,6 +9686,7 @@ EXPLANATION_END`;
         statusCounts: taskDashboard.statusCounts,
         successRate: taskSuccessRate,
         blockedCount: blockedTasks,
+        stuckBlockedCount: taskDashboard.stuckBlockedCount,
         averageCompletionTimeMs: taskDashboard.averageCompletionTimeMs,
         recentActivity: taskDashboard.recentActivity.slice(0, 10),
       },

--- a/packages/org-manager/src/report-service.ts
+++ b/packages/org-manager/src/report-service.ts
@@ -305,12 +305,16 @@ export class ReportService {
 
   private buildCostSummary(scopeId: string, start: Date, end: Date): ReportCostSummary {
     const usage = this.billingService.getUsageSummaryForPeriod(scopeId, start, end);
+    const input = Math.round(usage.llmTokens * 0.7);
+    const output = usage.llmTokens - input;
+    const estimatedCost = (input / 1_000_000) * 3 + (output / 1_000_000) * 15;
+    const cost = Math.round(estimatedCost * 10000) / 10000;
     return {
       totalTokens: usage.llmTokens,
-      totalEstimatedCost: usage.llmTokens * 0.000003,
+      totalEstimatedCost: cost,
       byAgent: [],
       byCategory: [
-        { category: 'llm_tokens', tokens: usage.llmTokens, cost: usage.llmTokens * 0.000003 },
+        { category: 'llm_tokens', tokens: usage.llmTokens, cost },
         { category: 'tool_calls', tokens: 0, cost: 0 },
       ],
       trend: 'stable',

--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -2133,6 +2133,9 @@ export class TaskService {
       ],
       allowFreeform: true,
     }).then(result => {
+      const current = this.tasks.get(task.id);
+      if (!current || current.status !== 'review') return;
+
       if (result.approved) {
         this.updateTaskStatus(task.id, 'completed', task.reviewerId, false, false, 'human', 'Review approved');
       } else {

--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -2417,6 +2417,7 @@ export class TaskService {
   getDashboard(orgId?: string): {
     statusCounts: Record<TaskStatus, number>;
     totalTasks: number;
+    stuckBlockedCount: number;
     agentWorkload: Array<{
       agentId: string;
       agentName?: string;
@@ -2442,6 +2443,12 @@ export class TaskService {
       archived: 0,
     };
     for (const t of tasks) statusCounts[t.status]++;
+
+    // Stuck blocked = blocked but all dependencies satisfied (or no dependencies at all).
+    // Normal blocked tasks (waiting on unfinished deps) are expected in DAG workflows.
+    const stuckBlockedCount = tasks.filter(
+      t => t.status === 'blocked' && this.areBlockersSatisfied(t)
+    ).length;
 
     const agentMap = new Map<string, { active: number; completed: number }>();
     for (const t of tasks) {
@@ -2483,6 +2490,7 @@ export class TaskService {
     return {
       statusCounts,
       totalTasks: tasks.length,
+      stuckBlockedCount,
       agentWorkload,
       recentActivity,
       averageCompletionTimeMs,

--- a/packages/web-ui/src/App.tsx
+++ b/packages/web-ui/src/App.tsx
@@ -36,10 +36,10 @@ export function App() {
   const theme = useTheme();
   const sidebar = useResizablePanel({
     side: 'left',
-    defaultWidth: 240,
+    defaultWidth: 180,
     minWidth: 180,
     maxWidth: 400,
-    collapsedWidth: 48,
+    collapsedWidth: 64,
     storageKey: 'markus_sidebar',
   });
   const [mountedPages, setMountedPages] = useState<Set<PageId>>(() => new Set([getPageFromHash()]));

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -804,6 +804,7 @@ export interface AgentUsageInfo {
   toolCalls: number;
   messages: number;
   estimatedCost: number;
+  costToday: number;
 }
 
 export const api = {

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -763,6 +763,7 @@ export interface OpsDashboard {
     statusCounts: Record<string, number>;
     successRate: number;
     blockedCount: number;
+    stuckBlockedCount?: number;
     averageCompletionTimeMs: number;
     recentActivity: Array<{ taskId: string; title: string; status: string; updatedAt: string }>;
   };
@@ -917,6 +918,9 @@ export const api = {
                   if (event.sessionId) resultSessionId = event.sessionId;
                   const doneSegments = (event as Record<string, unknown>).segments as StoredSegment[] | undefined;
                   if (doneSegments?.length) resultSegments = doneSegments;
+                  resolve({ content: fullContent, sessionId: resultSessionId, segments: resultSegments });
+                  reader.cancel().catch(() => {});
+                  return;
                 } else if (event.type === 'error') {
                   const errEvent = event as { type: string; message?: string; error?: string; sessionId?: string };
                   if (errEvent.sessionId) resultSessionId = errEvent.sessionId;

--- a/packages/web-ui/src/components/ChatTeamSidebar.tsx
+++ b/packages/web-ui/src/components/ChatTeamSidebar.tsx
@@ -589,26 +589,26 @@ export function ChatTeamSidebar({
             const pos = clampMenuPos(e);
             setAgentMenu({ agentId: a.id, teamId, ...pos });
           }}
-          className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-xs transition-colors select-none ${
+          className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-xs transition-colors select-none text-fg-primary ${
             isMobile ? '' : 'touch-none'
           } ${
-            selected ? 'bg-brand-600/20 text-brand-500' : 'text-fg-secondary hover:bg-surface-elevated'
+            selected ? 'bg-brand-600/15' : 'hover:bg-white/[0.08]'
           }`}
         >
           <Avatar
             name={a.name}
             avatarUrl={a.avatarUrl}
-            size={24}
-            bgClass={selected ? 'bg-brand-600' : 'bg-surface-overlay text-fg-secondary'}
+            size={28}
+            bgClass="bg-surface-overlay text-fg-primary"
           />
           <div className="flex-1 min-w-0 text-left">
             <div className="flex items-center gap-1">
-              <span className="truncate font-medium text-[11px] leading-tight">{a.name}</span>
-              {showRole && <span className="text-[9px] text-fg-tertiary shrink-0 truncate max-w-[60px]">({a.role})</span>}
-              {isManager && <svg width="9" height="9" viewBox="0 0 24 24" fill="currentColor" className="text-amber-600 shrink-0"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" /></svg>}
-              {isExt && <span className="text-[8px] px-1 py-0 rounded bg-brand-500/20 text-brand-500 font-medium shrink-0 leading-relaxed">EXT</span>}
+              <span className="truncate font-medium text-[12px] leading-tight">{a.name}</span>
+              {showRole && <span className="text-[9px] text-fg-secondary shrink-0 truncate max-w-[80px]">({a.role})</span>}
+              {isManager && <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor" className="text-amber-500 shrink-0"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" /></svg>}
+              {isExt && <span className="text-[8px] px-1 py-0 rounded bg-brand-500/20 text-brand-400 font-medium shrink-0 leading-relaxed">EXT</span>}
             </div>
-            <div className="truncate text-[10px] leading-tight mt-0.5 text-fg-tertiary">
+            <div className="truncate text-[10px] leading-tight mt-0.5 text-fg-secondary">
               {subtitle || '\u00A0'}
             </div>
           </div>
@@ -672,21 +672,19 @@ export function ChatTeamSidebar({
               const pos = clampMenuPos(e);
               setTeamMenu({ teamId: tid, ...pos });
             }}
-            className={`flex-1 flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs transition-colors min-w-0 ${
+            className={`flex-1 flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-xs transition-colors min-w-0 text-fg-primary ${
               isGcActive
-                ? 'bg-brand-600/20 text-brand-500'
-                : 'text-fg-secondary hover:bg-surface-elevated'
+                ? 'bg-brand-600/15'
+                : 'hover:bg-white/[0.08]'
             }`}
           >
-            <div className={`w-6 h-6 rounded-full flex items-center justify-center shrink-0 ${
-              isGcActive ? 'bg-brand-600 text-white' : 'bg-surface-overlay text-fg-secondary'
-            }`}>
-              <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>
+            <div className="w-7 h-7 rounded-full flex items-center justify-center shrink-0 bg-surface-overlay text-fg-primary">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 0 0-3-3.87" /><path d="M16 3.13a4 4 0 0 1 0 7.75" /></svg>
             </div>
             <div className="flex-1 min-w-0 text-left">
               {editingTeam === tid ? (
                 <input
-                  className="bg-transparent border-b border-brand-500 text-fg-secondary text-[11px] font-medium outline-none w-full"
+                  className="bg-transparent border-b border-brand-500 text-fg-primary text-[12px] font-medium outline-none w-full"
                   value={editTeamName}
                   onChange={e => setEditTeamName(e.target.value)}
                   onBlur={() => handleRenameTeam(tid)}
@@ -695,16 +693,16 @@ export function ChatTeamSidebar({
                   autoFocus
                 />
               ) : (
-                <span className="truncate font-medium text-[11px] leading-tight block">{label}</span>
+                <span className="truncate font-medium text-[12px] leading-tight block">{label}</span>
               )}
-              <div className="text-[10px] text-fg-tertiary leading-tight mt-0.5">{t('chat.members_other', { count: agentList.length })}</div>
+              <div className="text-[10px] text-fg-secondary leading-tight mt-0.5">{t('chat.members_other', { count: agentList.length })}</div>
             </div>
           </button>
 
           {/* Expand / collapse toggle */}
           <button
             onClick={() => toggleTeam(tid)}
-            className="w-7 h-7 flex items-center justify-center text-fg-secondary hover:text-fg-primary rounded-md hover:bg-surface-overlay transition-colors shrink-0"
+            className="w-7 h-7 flex items-center justify-center text-fg-muted hover:text-fg-primary rounded-md hover:bg-white/[0.08] transition-colors shrink-0"
             title={isCollapsed ? t('common:showMore') : t('common:close')}
           >
             <svg
@@ -719,7 +717,7 @@ export function ChatTeamSidebar({
           {isAdmin && team && (
             <button
               onClick={e => { e.stopPropagation(); if (teamMenu?.teamId === tid) { setTeamMenu(null); } else { const pos = clampMenuPos(e); setTeamMenu({ teamId: tid, ...pos }); } }}
-              className="w-7 h-7 flex items-center justify-center text-fg-secondary hover:text-fg-primary rounded-md hover:bg-surface-overlay transition-colors shrink-0"
+              className="w-7 h-7 flex items-center justify-center text-fg-muted hover:text-fg-primary rounded-md hover:bg-white/[0.08] transition-colors shrink-0"
               title={t('chat.moreOptions')}
             >
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="1" /><circle cx="12" cy="5" r="1" /><circle cx="12" cy="19" r="1" /></svg>
@@ -865,28 +863,28 @@ export function ChatTeamSidebar({
 
           {/* People — shown first, flat list */}
           <div className="mb-2">
-            <p className="text-[10px] font-semibold text-fg-tertiary uppercase tracking-wider mb-1.5 px-2">{t('chat.people')}</p>
+            <p className="text-[10px] font-semibold text-fg-muted uppercase tracking-wider mb-1.5 px-2.5">{t('chat.people')}</p>
 
             {authUser && (
               <button
                 onClick={() => onSelectDm(authUser.id)}
-                className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-xs mb-0.5 transition-colors ${
+                className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-xs mb-0.5 transition-colors text-fg-primary ${
                   chatMode === 'dm' && (activeDmUserId === authUser.id || !activeDmUserId)
-                    ? 'bg-brand-600/20 text-brand-500'
-                    : 'text-fg-secondary hover:bg-surface-elevated'
+                    ? 'bg-brand-600/15'
+                    : 'hover:bg-white/[0.08]'
                 }`}
               >
                 <Avatar
                   name={authUser.name}
                   avatarUrl={authUser.avatarUrl}
-                  size={24}
-                  bgClass={chatMode === 'dm' && (activeDmUserId === authUser.id || !activeDmUserId) ? 'bg-brand-600' : 'bg-brand-500/15 text-brand-500'}
+                  size={28}
+                  bgClass="bg-brand-500/15 text-brand-400"
                 />
                 <div className="flex-1 min-w-0 text-left">
-                  <div className="truncate font-medium text-[11px] leading-tight">{authUser.name}</div>
-                  <div className="text-fg-tertiary truncate text-[10px] leading-tight mt-0.5">{t('chat.myNotes')}</div>
+                  <div className="truncate font-medium text-[12px] leading-tight">{authUser.name}</div>
+                  <div className="text-fg-secondary truncate text-[10px] leading-tight mt-0.5">{t('chat.myNotes')}</div>
                 </div>
-                <span className="text-fg-tertiary shrink-0"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg></span>
+                <span className="text-fg-secondary shrink-0"><svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" /><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" /></svg></span>
               </button>
             )}
 
@@ -900,23 +898,23 @@ export function ChatTeamSidebar({
                   const pos = clampMenuPos(e);
                   setHumanMenu({ userId: h.id, ...pos });
                 }}
-                className={`w-full flex items-center gap-2.5 px-2 py-1.5 rounded-lg text-xs mb-0.5 transition-colors ${
+                className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-xs mb-0.5 transition-colors text-fg-primary ${
                   chatMode === 'dm' && activeDmUserId === h.id
-                    ? 'bg-green-500/10 text-green-600'
-                    : 'text-fg-secondary hover:bg-surface-elevated'
+                    ? 'bg-green-500/15'
+                    : 'hover:bg-white/[0.08]'
                 }`}
               >
                 <Avatar
                   name={h.name}
                   avatarUrl={h.avatarUrl}
-                  size={24}
-                  bgClass={chatMode === 'dm' && activeDmUserId === h.id ? 'bg-green-600' : 'bg-green-500/10 text-green-600'}
+                  size={28}
+                  bgClass="bg-green-500/10 text-green-500"
                 />
                 <div className="flex-1 min-w-0 text-left">
-                  <div className="truncate font-medium text-[11px] leading-tight">{h.name}</div>
-                  <div className="text-fg-tertiary truncate text-[10px] leading-tight mt-0.5">{h.email || h.role}</div>
+                  <div className="truncate font-medium text-[12px] leading-tight">{h.name}</div>
+                  <div className="text-fg-secondary truncate text-[10px] leading-tight mt-0.5">{h.email || h.role}</div>
                 </div>
-                <span className="w-1.5 h-1.5 rounded-full bg-green-500 shrink-0" />
+                <span className="w-2 h-2 rounded-full bg-green-500 shrink-0" />
               </button>
             ))}
           </div>
@@ -924,7 +922,7 @@ export function ChatTeamSidebar({
           {/* Custom group chats */}
           {groupChatsByTeam.custom.length > 0 && (
             <div className="mb-2">
-              <p className="text-[10px] font-semibold text-fg-tertiary uppercase tracking-wider mb-1 px-2">{t('chat.groups')}</p>
+              <p className="text-[10px] font-semibold text-fg-muted uppercase tracking-wider mb-1 px-2.5">{t('chat.groups')}</p>
               {groupChatsByTeam.custom.map(gc => {
                 const isActive = chatMode === 'channel' && activeChannel === gc.channelKey;
                 return (
@@ -936,18 +934,16 @@ export function ChatTeamSidebar({
                       const pos = clampMenuPos(e);
                       setGcMenu({ gcId: gc.id, ...pos });
                     }}
-                    className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs mb-0.5 transition-colors ${
-                      isActive ? 'bg-brand-600/20 text-brand-500' : 'text-fg-secondary hover:bg-surface-elevated'
+                    className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-xs mb-0.5 transition-colors text-fg-primary ${
+                      isActive ? 'bg-brand-600/15' : 'hover:bg-white/[0.08]'
                     }`}
                   >
-                    <div className={`w-6 h-6 rounded-lg flex items-center justify-center shrink-0 ${
-                      isActive ? 'bg-brand-600 text-white' : 'bg-surface-overlay text-fg-secondary'
-                    }`}>
-                      <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
+                    <div className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0 bg-surface-overlay text-fg-primary">
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
                     </div>
                     <div className="flex-1 min-w-0 text-left">
-                      <span className="truncate font-medium text-[11px] leading-tight block">{gc.name}</span>
-                      <div className="text-[10px] text-fg-tertiary leading-tight mt-0.5">{t('chat.members_other', { count: gc.memberCount ?? 0 })}</div>
+                      <span className="truncate font-medium text-[12px] leading-tight block">{gc.name}</span>
+                      <div className="text-[10px] text-fg-secondary leading-tight mt-0.5">{t('chat.members_other', { count: gc.memberCount ?? 0 })}</div>
                     </div>
                   </button>
                 );
@@ -978,23 +974,21 @@ export function ChatTeamSidebar({
             <button
               key={gc.id}
               onClick={() => onSelectChannel(gc.channelKey)}
-              className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-xs mb-0.5 transition-colors ${
+              className={`w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg text-xs mb-0.5 transition-colors text-fg-primary ${
                 chatMode === 'channel' && activeChannel === gc.channelKey
-                  ? 'bg-brand-600/20 text-brand-500'
-                  : 'text-fg-secondary hover:bg-surface-elevated'
+                  ? 'bg-brand-600/15'
+                  : 'hover:bg-white/[0.08]'
               }`}
             >
-              <div className={`w-6 h-6 rounded-full flex items-center justify-center shrink-0 ${
-                chatMode === 'channel' && activeChannel === gc.channelKey ? 'bg-brand-600 text-white' : 'bg-surface-overlay text-fg-secondary'
-              }`}>
-                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
+              <div className="w-7 h-7 rounded-full flex items-center justify-center shrink-0 bg-surface-overlay text-fg-primary">
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" /></svg>
               </div>
               <div className="flex-1 min-w-0 text-left">
-                <span className="truncate font-medium text-[11px] leading-tight block">{gc.name}</span>
-                <div className="text-[10px] text-fg-tertiary leading-tight mt-0.5">{t('chat.groupChat')}</div>
+                <span className="truncate font-medium text-[12px] leading-tight block">{gc.name}</span>
+                <div className="text-[10px] text-fg-secondary leading-tight mt-0.5">{t('chat.groupChat')}</div>
               </div>
               {gc.memberCount !== undefined && gc.memberCount > 0 && (
-                <span className="text-[9px] text-fg-tertiary shrink-0">{gc.memberCount}</span>
+                <span className="text-[9px] text-fg-secondary shrink-0">{gc.memberCount}</span>
               )}
             </button>
           ))}

--- a/packages/web-ui/src/components/NotificationBell.tsx
+++ b/packages/web-ui/src/components/NotificationBell.tsx
@@ -12,6 +12,10 @@ interface Props {
   userId?: string;
   embeddedMode?: boolean;
   onClose?: () => void;
+  sidebarMode?: boolean;
+  isActive?: boolean;
+  label?: string;
+  iconPath?: string;
 }
 
 const PRIORITY_DOT: Record<string, string> = {
@@ -107,7 +111,7 @@ function playNotificationSound() {
   } catch { /* audio not available */ }
 }
 
-export function NotificationBell({ collapsed, userId, embeddedMode, onClose }: Props) {
+export function NotificationBell({ collapsed, userId, embeddedMode, onClose, sidebarMode, isActive, label, iconPath }: Props) {
   const { t } = useTranslation(['team', 'common']);
   const [open, setOpen] = useState(false);
   const [tab, setTab] = useState<'approvals' | 'notifications'>('approvals');
@@ -835,6 +839,44 @@ export function NotificationBell({ collapsed, userId, embeddedMode, onClose }: P
           </div>
         </div>
       </div>
+    );
+  }
+
+  if (sidebarMode) {
+    const d = iconPath || 'M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9 M13.73 21a2 2 0 0 1-3.46 0';
+    return (
+      <>
+        <button
+          ref={btnRef}
+          onClick={() => { setOpen(!open); if (!open) fetchData(); }}
+          title={collapsed ? (label || t('team:notifications.bellTitle')) : undefined}
+          className={`w-full flex items-center ${collapsed ? 'flex-col justify-center px-1 py-1.5 gap-0.5' : 'gap-3 px-3 py-[7px]'} rounded-xl text-[13px] mb-0.5 transition-all relative ${
+            open || isActive
+              ? 'bg-brand-600 text-white shadow-sm shadow-brand-900/30 font-medium'
+              : 'text-fg-secondary hover:bg-surface-overlay hover:text-fg-primary'
+          }`}
+        >
+          <svg width={collapsed ? 16 : 18} height={collapsed ? 16 : 18} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+            <path d={d} />
+          </svg>
+          {collapsed
+            ? <span className="text-[9px] leading-tight truncate w-full text-center">{label}</span>
+            : <span className="truncate">{label}</span>
+          }
+          {badgeCount > 0 && (
+            <span className={`absolute ${collapsed ? 'top-0.5 right-1' : 'top-1 left-[22px]'} min-w-[16px] h-4 px-1 rounded-full bg-red-500 text-white text-[10px] font-bold flex items-center justify-center leading-none`}>
+              {badgeCount > 99 ? t('common:badgeOverLimit') : badgeCount}
+            </span>
+          )}
+        </button>
+
+        {open && createPortal(
+          <div ref={panelRef} className="fixed bg-surface-secondary border border-border-default rounded-xl shadow-2xl z-[9999] flex flex-col overflow-hidden" style={{ top: pos.top, left: pos.left, width: pos.width, maxHeight: pos.maxHeight }}>
+            {panelContent}
+          </div>,
+          document.body
+        )}
+      </>
     );
   }
 

--- a/packages/web-ui/src/components/Sidebar.tsx
+++ b/packages/web-ui/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { type PageId, PAGE_ICONS, SIDEBAR_NAV, SIDEBAR_SECTIONS } from '../routes.ts';
+import { type PageId, PAGE, PAGE_ICONS, SIDEBAR_NAV, SIDEBAR_SECTIONS } from '../routes.ts';
 import { api, type AuthUser } from '../api.ts';
 import { NotificationBell } from './NotificationBell.tsx';
 import { Avatar, AvatarUpload } from './Avatar.tsx';
@@ -182,63 +182,61 @@ export function Sidebar({ currentPage, onNavigate, authUser, onLogout, onUserUpd
   return (
     <aside className="h-dvh bg-surface-secondary flex flex-col shrink-0 overflow-hidden border-r border-border-subtle">
       <div className={`flex items-center ${collapsed ? 'px-2 py-3.5 justify-center' : 'px-4 h-14 justify-between'}`}>
-        {collapsed ? (
-          <div className="flex flex-col items-center gap-2">
-            <button onClick={onToggleCollapse} title={t('sidebar.expandSidebar')} className="group">
-              <img src="/logo.png" alt="Markus" className="w-8 h-8 rounded-lg group-hover:ring-2 group-hover:ring-brand-500/40 transition-all" />
-            </button>
-            <NotificationBell collapsed userId={authUser?.id} />
-          </div>
-        ) : (
-          <>
-            <button onClick={onToggleCollapse} className="flex items-center gap-2.5 min-w-0 group" title={t('sidebar.collapseSidebar')}>
-              <img src="/logo.png" alt="Markus" className="w-8 h-8 rounded-lg shadow-md shadow-black/30 shrink-0 group-hover:ring-2 group-hover:ring-brand-500/40 transition-all" />
-              <span className="text-[15px] font-bold tracking-tight text-fg-primary whitespace-nowrap">Markus</span>
-            </button>
-            <div className="flex items-center gap-1 shrink-0">
-              <NotificationBell userId={authUser?.id} />
-              <button
-                onClick={onToggleCollapse}
-                className="text-fg-tertiary hover:text-fg-secondary transition-colors p-1 rounded-md hover:bg-surface-overlay"
-                title={t('sidebar.collapseSidebar')}
-              >
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="11 17 6 12 11 7" /><polyline points="18 17 13 12 18 7" /></svg>
-              </button>
-            </div>
-          </>
-        )}
+        <button onClick={onToggleCollapse} title={collapsed ? t('sidebar.expandSidebar') : t('sidebar.collapseSidebar')} className="flex items-center gap-2.5 min-w-0 group">
+          <img src="/logo.png" alt="Markus" className="w-8 h-8 rounded-lg shadow-md shadow-black/30 shrink-0 group-hover:ring-2 group-hover:ring-brand-500/40 transition-all" />
+          {!collapsed && <span className="text-[15px] font-bold tracking-tight text-fg-primary whitespace-nowrap">Markus</span>}
+        </button>
       </div>
-      <nav className={`${collapsed ? 'p-1.5' : 'px-3 py-2'} flex-1 overflow-y-auto scrollbar-thin`}>
-        {SIDEBAR_SECTIONS.map((section, si) => (
-          <div key={section.key}>
-            <div className={si > 0 ? 'mt-4' : ''}>
-              {!collapsed && (
-                <div className="px-3 py-1.5 mb-1 text-[10px] font-semibold text-fg-muted uppercase tracking-[0.1em]">
-                  {t(`sections.${section.key}`)}
-                </div>
-              )}
-              {collapsed && si > 0 && <div className="my-3 mx-2 border-t border-border-subtle" />}
-              {SIDEBAR_NAV.filter(i => i.section === section.key).map((item) => {
-                const isActive = currentPage === item.id;
-                return (
-                  <button
-                    key={item.id}
-                    onClick={() => onNavigate(item.id)}
-                    title={collapsed ? t(item.id) : undefined}
-                    className={`w-full flex items-center ${collapsed ? 'justify-center px-2 py-2' : 'gap-3 px-3 py-[7px]'} rounded-xl text-[13px] mb-0.5 transition-all ${
-                      isActive
-                        ? 'bg-brand-600 text-white shadow-sm shadow-brand-900/30 font-medium'
-                        : 'text-fg-secondary hover:bg-surface-overlay hover:text-fg-primary'
-                    }`}
-                  >
-                    <Icon d={PAGE_ICONS[item.id] ?? ''} />
-                    {!collapsed && <span className="truncate">{t(item.id)}</span>}
-                  </button>
-                );
-              })}
+      <nav className={`${collapsed ? 'p-1' : 'px-3 py-2'} flex-1 overflow-y-auto scrollbar-thin`}>
+        {SIDEBAR_SECTIONS.map((section, si) => {
+          const sectionLabel = t(`sections.${section.key}`);
+          return (
+            <div key={section.key}>
+              <div className={si > 0 ? 'mt-3' : ''}>
+                {!collapsed && sectionLabel && (
+                  <div className="px-3 py-1.5 mb-1 text-[10px] font-semibold text-fg-muted uppercase tracking-[0.1em]">
+                    {sectionLabel}
+                  </div>
+                )}
+                {collapsed && si > 0 && <div className="my-2 mx-2 border-t border-border-subtle" />}
+                {SIDEBAR_NAV.filter(i => i.section === section.key).map((item) => {
+                  if (item.id === PAGE.NOTIFICATIONS) {
+                    return (
+                      <NotificationBell
+                        key={item.id}
+                        sidebarMode
+                        collapsed={collapsed}
+                        userId={authUser?.id}
+                        label={t(item.id)}
+                        iconPath={PAGE_ICONS[item.id]}
+                        isActive={currentPage === item.id}
+                      />
+                    );
+                  }
+                  const isActive = currentPage === item.id;
+                  return (
+                    <button
+                      key={item.id}
+                      onClick={() => onNavigate(item.id)}
+                      title={collapsed ? t(item.id) : undefined}
+                      className={`w-full flex items-center ${collapsed ? 'flex-col justify-center px-1 py-1.5 gap-0.5' : 'gap-3 px-3 py-[7px]'} rounded-xl text-[13px] mb-0.5 transition-all ${
+                        isActive
+                          ? 'bg-brand-600 text-white shadow-sm shadow-brand-900/30 font-medium'
+                          : 'text-fg-secondary hover:bg-surface-overlay hover:text-fg-primary'
+                      }`}
+                    >
+                      <Icon d={PAGE_ICONS[item.id] ?? ''} size={collapsed ? 16 : 18} />
+                      {collapsed
+                        ? <span className="text-[9px] leading-tight truncate w-full text-center">{t(item.id)}</span>
+                        : <span className="truncate">{t(item.id)}</span>
+                      }
+                    </button>
+                  );
+                })}
+              </div>
             </div>
-          </div>
-        ))}
+          );
+        })}
       </nav>
       <UserMenu authUser={authUser} collapsed={collapsed} onLogout={handleLogout} onUserUpdated={onUserUpdated} />
       {!collapsed && <div className="px-4 pb-2 text-[10px] text-fg-muted">v{__APP_VERSION__}</div>}

--- a/packages/web-ui/src/locales/en/home.json
+++ b/packages/web-ui/src/locales/en/home.json
@@ -38,7 +38,8 @@
   },
   "taskOverview": {
     "title": "Task Overview",
-    "subtitle": "{{total}} tasks total"
+    "subtitle": "{{total}} tasks total",
+    "stuckBlocked": "{{count}} task(s) blocked without pending dependencies — may need attention"
   },
   "teamStatus": {
     "title": "Team Status",

--- a/packages/web-ui/src/locales/en/nav.json
+++ b/packages/web-ui/src/locales/en/nav.json
@@ -9,6 +9,7 @@
   "notifications": "Notifications",
   "settings": "Settings",
   "sections": {
+    "quick": "",
     "workspace": "WORKSPACE",
     "build": "BUILD",
     "system": "SYSTEM"

--- a/packages/web-ui/src/locales/en/reports.json
+++ b/packages/web-ui/src/locales/en/reports.json
@@ -13,7 +13,7 @@
     "thisMonth": "This Month"
   },
   "usage": {
-    "llmTokens": "LLM Tokens (this month)",
+    "llmTokens": "LLM Tokens (all time)",
     "toolCalls": "Tool Calls (today)",
     "messages": "Messages (today)",
     "storage": "Storage"
@@ -30,8 +30,7 @@
     "title": "Cost Overview",
     "estCostAllTime": "Est. Cost (all time)",
     "tokensToday": "Tokens Today",
-    "tokensPeriod": "Tokens ({{period}})",
-    "costPeriod": "Cost ({{period}})",
+    "costToday": "Cost Today",
     "totalTokens": "Total Tokens",
     "estimatedCost": "Estimated Cost",
     "trend": "Trend",

--- a/packages/web-ui/src/locales/en/work.json
+++ b/packages/web-ui/src/locales/en/work.json
@@ -296,6 +296,8 @@
     "offline": "Offline",
     "paused": "Paused",
     "filePreviewLoading": "Loading...",
+    "emptyDirectory": "Empty directory",
+    "openInFinder": "Open in file browser",
     "requirementDetailDescription": "Description",
     "requirementNoDescription": "No description",
     "createdByLabel": "Created by",

--- a/packages/web-ui/src/locales/zh-CN/home.json
+++ b/packages/web-ui/src/locales/zh-CN/home.json
@@ -38,7 +38,8 @@
   },
   "taskOverview": {
     "title": "任务总览",
-    "subtitle": "共 {{total}} 个任务"
+    "subtitle": "共 {{total}} 个任务",
+    "stuckBlocked": "{{count}} 个任务阻塞但无未完成依赖，可能需要关注"
   },
   "teamStatus": {
     "title": "团队状态",

--- a/packages/web-ui/src/locales/zh-CN/nav.json
+++ b/packages/web-ui/src/locales/zh-CN/nav.json
@@ -9,6 +9,7 @@
   "notifications": "通知",
   "settings": "设置",
   "sections": {
+    "quick": "",
     "workspace": "工作区",
     "build": "资产",
     "system": "系统"

--- a/packages/web-ui/src/locales/zh-CN/reports.json
+++ b/packages/web-ui/src/locales/zh-CN/reports.json
@@ -13,7 +13,7 @@
     "thisMonth": "本月"
   },
   "usage": {
-    "llmTokens": "LLM Token（本月）",
+    "llmTokens": "LLM Token（累计）",
     "toolCalls": "工具调用（今天）",
     "messages": "消息（今天）",
     "storage": "存储"
@@ -30,8 +30,7 @@
     "title": "费用概览",
     "estCostAllTime": "预估费用（累计）",
     "tokensToday": "今日 Token",
-    "tokensPeriod": "Token（{{period}}）",
-    "costPeriod": "费用（{{period}}）",
+    "costToday": "今日费用",
     "totalTokens": "Token 总计",
     "estimatedCost": "预估费用",
     "trend": "趋势"

--- a/packages/web-ui/src/locales/zh-CN/work.json
+++ b/packages/web-ui/src/locales/zh-CN/work.json
@@ -296,6 +296,8 @@
     "offline": "离线",
     "paused": "已暂停",
     "filePreviewLoading": "加载中…",
+    "emptyDirectory": "空目录",
+    "openInFinder": "在文件管理器中打开",
     "requirementDetailDescription": "描述",
     "requirementNoDescription": "暂无描述",
     "createdByLabel": "创建者",

--- a/packages/web-ui/src/pages/Home.tsx
+++ b/packages/web-ui/src/pages/Home.tsx
@@ -10,13 +10,13 @@ const SHOW_HERO_BANNER = false;
 
 const DONUT_COLORS: Record<string, string> = {
   completed: '#22c55e', in_progress: '#8b5cf6', review: '#3b82f6',
-  pending: '#f59e0b', failed: '#ef4444', blocked: '#f87171',
+  pending: '#f59e0b', failed: '#ef4444', blocked: '#f59e0b',
   rejected: '#fb7185', cancelled: '#6b7280',
 };
 
 const STATUS_COLORS_BG: Record<string, string> = {
   completed: 'bg-green-500', in_progress: 'bg-brand-500', review: 'bg-blue-500',
-  pending: 'bg-amber-500', failed: 'bg-red-500', blocked: 'bg-red-400',
+  pending: 'bg-amber-500', failed: 'bg-red-500', blocked: 'bg-amber-500',
   rejected: 'bg-rose-400', cancelled: 'bg-gray-500',
 };
 
@@ -97,7 +97,15 @@ export function HomePage({ authUser }: { authUser?: { id: string; name: string; 
 
   const allRankedAgents = useMemo(() => {
     if (!ops) return [];
-    return [...ops.agentEfficiency].sort((a, b) => b.healthScore - a.healthScore);
+    const rankScore = (a: typeof ops.agentEfficiency[0]) => {
+      const tasks = a.taskMetrics.completed + a.taskMetrics.failed;
+      // Health score is modulated by activity: without actual work,
+      // an agent only gets 30% credit for its health score.
+      // Reaches full credit at 3+ completed/failed tasks.
+      const activityWeight = 0.3 + 0.7 * Math.min(1, tasks / 3);
+      return a.healthScore * activityWeight + a.taskMetrics.completed * 0.5;
+    };
+    return [...ops.agentEfficiency].sort((a, b) => rankScore(b) - rankScore(a));
   }, [ops]);
 
   const completionRate = totalRootTasks > 0 ? Math.round((completed / totalRootTasks) * 100) : 0;
@@ -237,6 +245,13 @@ export function HomePage({ authUser }: { authUser?: { id: string; name: string; 
                     ))}
                   </div>
                 </div>
+                {ops && (ops.taskKPI.stuckBlockedCount ?? 0) > 0 && (
+                  <div className="mt-3 flex items-center gap-2 px-3 py-2 bg-red-500/10 border border-red-500/20 rounded-xl text-xs text-red-400"
+                    onClick={e => { e.stopPropagation(); navBus.navigate(PAGE.WORK, { filter: 'blocked' }); }}>
+                    <span className="w-2 h-2 bg-red-500 rounded-full animate-pulse shrink-0" />
+                    {t('taskOverview.stuckBlocked', { count: ops.taskKPI.stuckBlockedCount })}
+                  </div>
+                )}
               </div>
             )}
 
@@ -383,7 +398,7 @@ export function HomePage({ authUser }: { authUser?: { id: string; name: string; 
                   <HealthRow label={t('systemHealth.successRate')} value={ops.taskKPI.successRate} max={100} suffix="%" />
                   <HealthRow label={t('systemHealth.activeTotal')} value={activeAgents} max={agents.length || 1} suffix={`/${agents.length}`} />
                   <HealthRow label={t('systemHealth.tokenUsage')} value={totalTokens} max={totalTokens || 1} displayValue={fmtNumber(totalTokens)} alwaysGreen />
-                  <HealthRow label={t('systemHealth.workingNow')} value={workingAgents} max={agents.length || 1} suffix={`/${agents.length}`} />
+                  <HealthRow label={t('systemHealth.workingNow')} value={workingAgents} max={agents.length || 1} suffix={`/${agents.length}`} neutral />
                 </div>
 
                 {ops.systemHealth.criticalAgents.length > 0 && (
@@ -621,7 +636,7 @@ function DonutLegendItem({ color, label, count }: { color: string; label: string
 
 const ACTIVITY_ICON_BG: Record<string, string> = {
   completed: 'bg-green-500/15', in_progress: 'bg-brand-500/15', pending: 'bg-amber-500/15',
-  review: 'bg-blue-500/15', failed: 'bg-red-500/15', blocked: 'bg-red-500/15',
+  review: 'bg-blue-500/15', failed: 'bg-red-500/15', blocked: 'bg-amber-500/15',
   rejected: 'bg-red-500/15', cancelled: 'bg-gray-500/15',
 };
 
@@ -629,7 +644,7 @@ function ActivityIcon({ status }: { status: string }) {
   const sz = 12;
   const colorMap: Record<string, string> = {
     completed: '#22c55e', in_progress: '#8b5cf6', pending: '#f59e0b',
-    review: '#3b82f6', failed: '#ef4444', blocked: '#ef4444', rejected: '#ef4444', cancelled: '#6b7280',
+    review: '#3b82f6', failed: '#ef4444', blocked: '#f59e0b', rejected: '#ef4444', cancelled: '#6b7280',
   };
   const color = colorMap[status] ?? '#6b7280';
   return (
@@ -658,12 +673,12 @@ function formatRelativeTime(dateStr: string, t: TFunction): string {
 
 // ─── Health Row ──────────────────────────────────────────────────────────────
 
-function HealthRow({ label, value, max, suffix, displayValue, alwaysGreen }: {
-  label: string; value: number; max: number; suffix?: string; displayValue?: string; alwaysGreen?: boolean;
+function HealthRow({ label, value, max, suffix, displayValue, alwaysGreen, neutral }: {
+  label: string; value: number; max: number; suffix?: string; displayValue?: string; alwaysGreen?: boolean; neutral?: boolean;
 }) {
   const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
-  const barColor = alwaysGreen ? 'bg-brand-500' : pct >= 80 ? 'bg-green-500' : pct >= 50 ? 'bg-amber-500' : 'bg-red-500';
-  const textColor = alwaysGreen ? 'text-brand-400' : pct >= 80 ? 'text-green-500' : pct >= 50 ? 'text-amber-500' : 'text-red-500';
+  const barColor = neutral ? 'bg-blue-500' : alwaysGreen ? 'bg-brand-500' : pct >= 80 ? 'bg-green-500' : pct >= 50 ? 'bg-amber-500' : 'bg-red-500';
+  const textColor = neutral ? 'text-blue-400' : alwaysGreen ? 'text-brand-400' : pct >= 80 ? 'text-green-500' : pct >= 50 ? 'text-amber-500' : 'text-red-500';
 
   return (
     <div>

--- a/packages/web-ui/src/pages/Reports.tsx
+++ b/packages/web-ui/src/pages/Reports.tsx
@@ -100,6 +100,7 @@ export function ReportsPage({ authUser }: ReportsPageProps) {
 
   const totalCost = agents.reduce((s, a) => s + a.estimatedCost, 0);
   const totalTokensToday = agents.reduce((s, a) => s + a.tokensUsedToday, 0);
+  const totalCostToday = agents.reduce((s, a) => s + (a.costToday ?? 0), 0);
   const maxAgentTokens = Math.max(1, ...agents.map(a => a.totalTokens));
 
   const handleSort = (col: typeof sortBy) => {
@@ -382,11 +383,13 @@ export function ReportsPage({ authUser }: ReportsPageProps) {
 
         {/* Generate Tab Content */}
         {tab === 'generate' && usageSummary && (
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+          <div className={`grid gap-4 ${usageSummary.storageBytes > 0 ? 'grid-cols-2 lg:grid-cols-4' : 'grid-cols-3'}`}>
             <UsageCard label={t('usage.llmTokens')} value={formatNumber(usageSummary.llmTokens)} color="text-brand-500" />
             <UsageCard label={t('usage.toolCalls')} value={formatNumber(usageSummary.toolCalls)} color="text-blue-600" />
             <UsageCard label={t('usage.messages')} value={formatNumber(usageSummary.messages)} color="text-green-600" />
-            <UsageCard label={t('usage.storage')} value={formatBytes(usageSummary.storageBytes)} color="text-amber-600" />
+            {usageSummary.storageBytes > 0 && (
+              <UsageCard label={t('usage.storage')} value={formatBytes(usageSummary.storageBytes)} color="text-amber-600" />
+            )}
           </div>
         )}
 
@@ -418,7 +421,7 @@ export function ReportsPage({ authUser }: ReportsPageProps) {
             {/* Cost Summary */}
             <section className="bg-surface-secondary border border-border-default rounded-xl p-5">
               <h3 className="text-xs font-semibold text-fg-secondary mb-3">{t('costOverview.title')}</h3>
-              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+              <div className="grid grid-cols-3 gap-4">
                 <div>
                   <div className="text-2xl font-bold text-fg-primary">{formatCost(totalCost)}</div>
                   <div className="text-xs text-fg-tertiary">{t('costOverview.estCostAllTime')}</div>
@@ -427,18 +430,10 @@ export function ReportsPage({ authUser }: ReportsPageProps) {
                   <div className="text-2xl font-bold text-fg-primary">{formatNumber(totalTokensToday)}</div>
                   <div className="text-xs text-fg-tertiary">{t('costOverview.tokensToday')}</div>
                 </div>
-                {report.costSummary && (
-                  <>
-                    <div>
-                      <div className="text-2xl font-bold text-fg-primary">{report.costSummary.totalTokens.toLocaleString()}</div>
-                      <div className="text-xs text-fg-tertiary">{t('costOverview.tokensPeriod', { period: periodLabel[period] })}</div>
-                    </div>
-                    <div>
-                      <div className="text-2xl font-bold text-fg-primary">{formatCost(report.costSummary.totalEstimatedCost)}</div>
-                      <div className="text-xs text-fg-tertiary">{t('costOverview.costPeriod', { period: periodLabel[period] })}</div>
-                    </div>
-                  </>
-                )}
+                <div>
+                  <div className="text-2xl font-bold text-fg-primary">{formatCost(totalCostToday)}</div>
+                  <div className="text-xs text-fg-tertiary">{t('costOverview.costToday')}</div>
+                </div>
               </div>
             </section>
 

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -798,6 +798,27 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
     }
     return () => { if (streamingTimerRef.current) clearTimeout(streamingTimerRef.current); };
   }, [sending]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Safety net: if the agent is no longer "working" but `sending` is still true,
+  // the SSE stream may have stalled (done event lost, connection silently dead, etc.).
+  // Force-end the streaming state after a grace period.
+  useEffect(() => {
+    if (!sending || chatMode !== 'direct' || !selectedAgent) return;
+    const agent = agents.find(a => a.id === selectedAgent);
+    if (!agent || agent.status === 'working') return;
+    const timer = setTimeout(() => {
+      if (!sendingConvs.current.has(currentConvKeyRef.current)) return;
+      abortControllerRef.current?.abort();
+      abortControllerRef.current = null;
+      const key = currentConvKeyRef.current;
+      sendingConvs.current.delete(key);
+      actBuffers.current.delete(key);
+      setSending(false);
+      setActivities([]);
+    }, 5000);
+    return () => clearTimeout(timer);
+  }, [sending, chatMode, selectedAgent, agents]); // eslint-disable-line react-hooks/exhaustive-deps
+
   const [activities, setActivities] = useState<ActivityStep[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
@@ -2003,13 +2024,18 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
       }
     }
 
-    // Clear abort controller and sending state for this conv
-    abortControllerRef.current = null;
-    sendingConvs.current.delete(sendKey);
-    actBuffers.current.delete(sendKey);
-    if (currentConvKeyRef.current === sendKey) {
-      setSending(false);
-      setActivities([]);
+    // Only clean up if this invocation is still the active sender.
+    // When a newer send() has taken over (user interrupted), abortControllerRef
+    // already points to the new controller — skip cleanup to avoid killing
+    // the new stream's state.
+    if (abortControllerRef.current === abortCtrl || abortControllerRef.current === null) {
+      abortControllerRef.current = null;
+      sendingConvs.current.delete(sendKey);
+      actBuffers.current.delete(sendKey);
+      if (currentConvKeyRef.current === sendKey) {
+        setSending(false);
+        setActivities([]);
+      }
     }
   };
   sendRef.current = send;

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -723,9 +723,9 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
   // Resizable chat left sidebar
   const chatSidebar = useResizablePanel({
     side: 'left',
-    defaultWidth: 224,
-    minWidth: 160,
-    maxWidth: 360,
+    defaultWidth: 400,
+    minWidth: 340,
+    maxWidth: 500,
     storageKey: 'markus_chat_sidebar',
   });
 

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -2022,19 +2022,19 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
         // remains visible) while we recover the reply from the DB.
         await pollForReply(5, 3000);
       }
-    }
 
-    // Only clean up if this invocation is still the active sender.
-    // When a newer send() has taken over (user interrupted), abortControllerRef
-    // already points to the new controller — skip cleanup to avoid killing
-    // the new stream's state.
-    if (abortControllerRef.current === abortCtrl || abortControllerRef.current === null) {
-      abortControllerRef.current = null;
-      sendingConvs.current.delete(sendKey);
-      actBuffers.current.delete(sendKey);
-      if (currentConvKeyRef.current === sendKey) {
-        setSending(false);
-        setActivities([]);
+      // Only clean up if this invocation is still the active sender.
+      // When a newer send() has taken over (user interrupted), abortControllerRef
+      // already points to the new controller — skip cleanup to avoid killing
+      // the new stream's state.
+      if (abortControllerRef.current === abortCtrl || abortControllerRef.current === null) {
+        abortControllerRef.current = null;
+        sendingConvs.current.delete(sendKey);
+        actBuffers.current.delete(sendKey);
+        if (currentConvKeyRef.current === sendKey) {
+          setSending(false);
+          setActivities([]);
+        }
       }
     }
   };

--- a/packages/web-ui/src/pages/Work.tsx
+++ b/packages/web-ui/src/pages/Work.tsx
@@ -1469,49 +1469,142 @@ function TaskExecutionLogs({ task, isRunning, authUser, agents }: { task: TaskIn
 
 // ─── File Preview Modal ─────────────────────────────────────────────────────────
 
-function FilePreviewModal({ filePath, onClose }: { filePath: string; onClose: () => void }) {
+type DirEntry = { name: string; path: string; isDirectory: boolean; size?: number; ext: string };
+type PreviewData = { type: string; name: string; content: string; mimeType?: string; entries?: DirEntry[]; path?: string };
+
+const PREVIEWABLE_EXTS = new Set(['.md', '.markdown', '.txt', '.json', '.yaml', '.yml', '.toml', '.csv', '.xml', '.html', '.css', '.js', '.ts', '.jsx', '.tsx', '.py', '.sh', '.log', '.env', '.cfg', '.ini', '.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg']);
+
+function fmtSize(bytes?: number): string {
+  if (bytes == null) return '';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function FilePreviewModal({ filePath: initialPath, onClose }: { filePath: string; onClose: () => void }) {
   const { t } = useTranslation(['work', 'common']);
-  const [data, setData] = useState<{ type: string; name: string; content: string; mimeType?: string } | null>(null);
+  const [pathStack, setPathStack] = useState<string[]>([initialPath]);
+  const currentPath = pathStack[pathStack.length - 1]!;
+  const [data, setData] = useState<PreviewData | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     setLoading(true);
     setError(null);
-    api.files.preview(filePath)
-      .then(d => setData(d))
+    setData(null);
+    api.files.preview(currentPath)
+      .then(d => setData(d as PreviewData))
       .catch(err => setError(String(err)))
       .finally(() => setLoading(false));
-  }, [filePath]);
+  }, [currentPath]);
 
-  const fileName = filePath.split('/').pop() ?? filePath;
+  const navigateTo = (p: string) => setPathStack(prev => [...prev, p]);
+  const goBack = () => setPathStack(prev => prev.length > 1 ? prev.slice(0, -1) : prev);
+  const canGoBack = pathStack.length > 1;
+
+  const openInFinder = (p: string) => {
+    api.files.reveal(p).catch(() => {});
+  };
+
+  const handleEntryClick = (entry: DirEntry) => {
+    if (entry.isDirectory) {
+      navigateTo(entry.path);
+    } else if (PREVIEWABLE_EXTS.has(entry.ext)) {
+      navigateTo(entry.path);
+    } else {
+      openInFinder(entry.path);
+    }
+  };
+
+  const fileName = currentPath.split('/').pop() ?? currentPath;
+  const isDir = data?.type === 'directory';
+
+  const extIcon = (ext: string, isDirectory: boolean) => {
+    if (isDirectory) return '📁';
+    const mdExts = ['.md', '.markdown'];
+    const imgExts = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'];
+    if (mdExts.includes(ext)) return '📝';
+    if (imgExts.includes(ext)) return '🖼';
+    if (['.json', '.yaml', '.yml', '.toml', '.xml'].includes(ext)) return '⚙';
+    if (['.js', '.ts', '.jsx', '.tsx', '.py', '.sh'].includes(ext)) return '💻';
+    return '📄';
+  };
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-[60]" onClick={onClose}>
       <div className="bg-surface-secondary border border-border-default rounded-xl w-[720px] max-w-[92vw] max-h-[85vh] flex flex-col shadow-2xl" onClick={e => e.stopPropagation()}>
         <div className="flex items-center justify-between px-5 py-3 border-b border-border-default shrink-0">
           <div className="flex items-center gap-2 min-w-0">
-            <svg className="w-4 h-4 text-fg-tertiary shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M3 1h7l4 4v10H3V1zm7 1H4v12h10V5.5L10 2z"/><path d="M10 1v4h4" fill="none" stroke="currentColor" strokeWidth="1"/></svg>
+            {canGoBack && (
+              <button onClick={goBack} className="text-fg-tertiary hover:text-fg-primary text-sm shrink-0 p-1 -ml-1 rounded hover:bg-surface-elevated/60 transition-colors" title={t('common:back')}>
+                <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+              </button>
+            )}
+            {isDir
+              ? <svg className="w-4 h-4 text-amber-500 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M1 3.5A1.5 1.5 0 012.5 2h3.879a1.5 1.5 0 011.06.44l.872.87A.5.5 0 008.665 3.5H13.5A1.5 1.5 0 0115 5v8.5a1.5 1.5 0 01-1.5 1.5h-11A1.5 1.5 0 011 13.5v-10z"/></svg>
+              : <svg className="w-4 h-4 text-fg-tertiary shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M3 1h7l4 4v10H3V1zm7 1H4v12h10V5.5L10 2z"/><path d="M10 1v4h4" fill="none" stroke="currentColor" strokeWidth="1"/></svg>
+            }
             <span className="text-sm font-medium text-fg-primary truncate">{fileName}</span>
+            {isDir && data.entries && <span className="text-[10px] text-fg-tertiary shrink-0">({data.entries.length})</span>}
           </div>
-          <button onClick={onClose} className="text-fg-tertiary hover:text-fg-secondary text-lg shrink-0 ml-3">×</button>
+          <div className="flex items-center gap-1 shrink-0 ml-3">
+            <button onClick={() => openInFinder(currentPath)} className="text-fg-tertiary hover:text-fg-primary p-1.5 rounded hover:bg-surface-elevated/60 transition-colors" title={t('work:task.openInFinder')}>
+              <svg className="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" /></svg>
+            </button>
+            <button onClick={onClose} className="text-fg-tertiary hover:text-fg-secondary text-lg shrink-0">×</button>
+          </div>
         </div>
         <div className="px-4 py-1 border-b border-border-default/60">
-          <p className="text-[10px] text-fg-tertiary font-mono truncate">{filePath}</p>
+          <p className="text-[10px] text-fg-tertiary font-mono truncate">{currentPath}</p>
         </div>
-        <div className="flex-1 overflow-auto min-h-0 p-5">
+        <div className="flex-1 overflow-auto min-h-0">
           {loading && <div className="text-sm text-fg-tertiary text-center py-8">{t('work:task.filePreviewLoading')}</div>}
           {error && <div className="text-sm text-red-500 text-center py-8">{error}</div>}
-          {data && data.type === 'image' && (
-            <div className="flex justify-center">
-              <img src={`data:${data.mimeType};base64,${data.content}`} alt={data.name} className="max-w-full max-h-[60vh] rounded-lg" />
+
+          {/* Directory listing */}
+          {data?.type === 'directory' && data.entries && (
+            <div className="divide-y divide-border-default/50">
+              {data.entries.length === 0 && (
+                <div className="text-sm text-fg-tertiary text-center py-8">{t('work:task.emptyDirectory')}</div>
+              )}
+              {data.entries.map(entry => (
+                <button
+                  key={entry.path}
+                  onClick={() => handleEntryClick(entry)}
+                  className="w-full flex items-center gap-3 px-5 py-2.5 hover:bg-surface-elevated/40 transition-colors text-left group"
+                >
+                  <span className="text-sm shrink-0">{extIcon(entry.ext, entry.isDirectory)}</span>
+                  <span className="flex-1 min-w-0 truncate text-sm text-fg-primary group-hover:text-brand-400 transition-colors">{entry.name}</span>
+                  {!entry.isDirectory && entry.size != null && (
+                    <span className="text-[10px] text-fg-tertiary shrink-0">{fmtSize(entry.size)}</span>
+                  )}
+                  {entry.isDirectory && (
+                    <svg className="w-3.5 h-3.5 text-fg-tertiary shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+                  )}
+                  {!entry.isDirectory && !PREVIEWABLE_EXTS.has(entry.ext) && (
+                    <svg className="w-3 h-3 text-fg-tertiary shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" /><polyline points="15 3 21 3 21 9" /><line x1="10" y1="14" x2="21" y2="3" /></svg>
+                  )}
+                </button>
+              ))}
             </div>
           )}
-          {data && data.type === 'markdown' && (
-            <MarkdownMessage content={data.content} className="text-sm text-fg-secondary leading-relaxed" />
-          )}
-          {data && data.type === 'text' && (
-            <pre className="text-xs text-fg-secondary font-mono whitespace-pre-wrap break-words bg-surface-primary/50 rounded-lg p-4 leading-relaxed">{data.content}</pre>
+
+          {/* File preview */}
+          {data && data.type !== 'directory' && (
+            <div className="p-5">
+              {data.type === 'image' && (
+                <div className="flex justify-center">
+                  <img src={`data:${data.mimeType};base64,${data.content}`} alt={data.name} className="max-w-full max-h-[60vh] rounded-lg" />
+                </div>
+              )}
+              {data.type === 'markdown' && (
+                <MarkdownMessage content={data.content} className="text-sm text-fg-secondary leading-relaxed" />
+              )}
+              {data.type === 'text' && (
+                <pre className="text-xs text-fg-secondary font-mono whitespace-pre-wrap break-words bg-surface-primary/50 rounded-lg p-4 leading-relaxed">{data.content}</pre>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/packages/web-ui/src/routes.ts
+++ b/packages/web-ui/src/routes.ts
@@ -80,12 +80,14 @@ export const PAGE_ICONS: Record<string, string> = {
 // ── Desktop sidebar structure ───────────────────────────────────────────────
 
 export const SIDEBAR_SECTIONS = [
+  { key: 'quick',     label: 'QUICK' },
   { key: 'workspace', label: 'WORKSPACE' },
   { key: 'build',     label: 'BUILD' },
   { key: 'system',    label: 'SYSTEM' },
 ] as const;
 
 export const SIDEBAR_NAV: Array<{ id: PageId; label: string; section: string }> = [
+  { id: PAGE.NOTIFICATIONS, label: 'Notifications', section: 'quick' },
   { id: PAGE.HOME,         label: 'Home',         section: 'workspace' },
   { id: PAGE.TEAM,         label: 'Team',         section: 'workspace' },
   { id: PAGE.WORK,         label: 'Work',         section: 'workspace' },


### PR DESCRIPTION
… deliverable preview

- Fix SSE stream: resolve messageStream promise on 'done' event instead of waiting for HTTP close
- Fix send() race condition: guard cleanup so interrupted stream doesn't kill new stream's state
- Add safety net: force-end streaming if agent becomes idle while sending is still true
- Dashboard: blocked tasks use amber (waiting state), only stuck-blocked shown as red alert
- Dashboard: agent ranking uses activity-weighted health score (idle agents ranked lower)
- Dashboard: "working now" metric uses neutral blue color instead of red-green threshold
- Deliverable preview: directories show file listing with navigation, render-or-reveal per file