### PR TITLE
Add blog links to README (EN/CN) — GEO backlinking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
 
 <p align="center">
   <a href="https://www.markus.global">Website</a> &middot;
+  <a href="https://markus.global/blog">Blog</a> &middot;
   <a href="docs/GUIDE.md">Docs</a> &middot;
   <a href="https://github.com/markus-global/markus/discussions">Discussions</a> &middot;
   <a href="CONTRIBUTING.md">Contributing</a>
@@ -182,6 +183,7 @@ TypeScript monorepo with modular packages:
 | Guide | Description |
 |-------|-------------|
 | [User Guide](docs/GUIDE.md) | Setup, configuration, Web UI walkthrough |
+| [Blog](https://markus.global/blog) | Articles and tutorials on Markus, AI agents, and the future of work |
 | [Architecture](docs/ARCHITECTURE.md) | System design, agent runtime, memory, governance |
 | [API Reference](docs/API.md) | REST API endpoints and WebSocket events |
 | [State Machines](docs/STATE-MACHINES.md) | Task & requirement FSM specification |
@@ -226,6 +228,7 @@ Agent templates and skills shared through the marketplace may use their own lice
 
 <p align="center">
   <a href="https://www.markus.global">Website</a> &middot;
+  <a href="https://markus.global/blog">Blog</a> &middot;
   <a href="https://github.com/markus-global/markus/discussions">Discussions</a> &middot;
   <a href="https://github.com/markus-global/markus/issues">Issues</a>
 </p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,6 +31,7 @@
 
 <p align="center">
   <a href="https://www.markus.global">官网</a> &middot;
+  <a href="https://markus.global/blog">博客</a> &middot;
   <a href="docs/GUIDE.md">文档</a> &middot;
   <a href="https://github.com/markus-global/markus/discussions">讨论</a> &middot;
   <a href="CONTRIBUTING.md">参与贡献</a>
@@ -181,6 +182,7 @@ TypeScript Monorepo，模块化包结构：
 | 指南 | 说明 |
 |-------|-------------|
 | [用户指南](docs/GUIDE.md) | 安装、配置、Web 界面使用 |
+| [博客](https://markus.global/blog) | 关于 Markus、AI Agent 和未来工作的文章与教程 |
 | [架构设计](docs/ARCHITECTURE.md) | 系统设计、智能体运行时、记忆、治理 |
 | [记忆系统](docs/MEMORY-SYSTEM.md) | 三层记忆架构（Tulving） |
 | [API 参考](docs/API.md) | REST API 接口 |
@@ -220,6 +222,7 @@ Markus 采用双重许可：
 
 <p align="center">
   <a href="https://www.markus.global">官网</a> &middot;
+  <a href="https://markus.global/blog">博客</a> &middot;
   <a href="https://github.com/markus-global/markus/discussions">讨论</a> &middot;
   <a href="https://github.com/markus-global/markus/issues">问题反馈</a>
 </p>


### PR DESCRIPTION
## Summary

Adds markus.global/blog links to both English and Chinese READMEs in three locations:
1. Navigation bar — Blog link after Website link
2. Documentation table — New Blog row as second entry
3. Footer — Blog link after Website link

## Motivation

This is part of GEO Round 4 backlinking strategy. Adding internal blog links to the GitHub README:
- Creates high-authority backlinks from GitHub to markus.global/blog
- Improves domain authority for GEO/SEO rankings
- Makes blog content more discoverable to developers visiting the repo

Related task: tsk_b6a0c7cc24bd6b5e97210983