### PR TITLE
[TASK-tsk_ea72d06d13682596067c6689][Frontend] fix: 纯文本流式输出完成后从 committedSegments 构建 segments 回退

### DIFF
--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -2223,6 +2223,28 @@ export function TeamPage({ initialAgentId, authUser }: { initialAgentId?: string
             });
           }
 
+          // Fallback for pure text responses where the server sends text_commit
+          // events (no text_delta, no done.segments) — build final segments
+          // from the committedSegments that were accumulated during streaming.
+          if (!streamResult.segments?.length) {
+            updateConvMsgs(sendKey, prev => {
+              const u = [...prev];
+              const idx = u.findIndex(m => m.id === agentMsgId);
+              if (idx < 0) return prev;
+              const msg = u[idx]!;
+              const committed = msg.committedSegments ?? [];
+              const committedText = committed
+                .filter((s): s is MsgSegment & { type: 'text' } => s.type === 'text' && !!s.content)
+                .map(s => s.content)
+                .join('');
+              const finalText = committedText || streamResult.content || msg.text;
+              if (committed.length > 0 || finalText) {
+                u[idx] = { ...msg, text: finalText, segments: committed.length > 0 ? committed : msg.segments };
+              }
+              return u;
+            });
+          }
+
           if (streamResult.sessionId) {
             setActiveSessionId(streamResult.sessionId);
             setOpenSessionTabs(prev =>


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Front Dev Expert (ID: agt_0830d6a1e0215899e72492b1)
- **关联任务**: TASK-tsk_ea72d06d13682596067c6689
- **关联需求**: req_5f42e680f312fdc0f3b90239
- **目标分支**: main

## 🎯 背景与动机
Agent 纯文本流式响应（无工具调用）完成后，聊天气泡变空白，需手动刷新才能看到内容。
根因：服务端对纯文本响应使用 `text_commit` SSE 事件（而非 `text_delta`），
`handleCommitEvent` 只更新 `committedSegments` 不更新 `segments`/`text`，
且 `done` 事件的 `segments` 字段为 undefined，导致最终更新块被跳过。

## 🔧 变更内容
- packages/web-ui/src/pages/Team.tsx: 在 done 事件处理器中新增纯文本回退路径（+22 行）
  - 当 `streamResult.segments?.length` 为空时，从 `committedSegments` 提取文本
  - 回退顺序：committedSegments 拼接文本 → streamResult.content → msg.text
  - 与现有 `streamResult.segments?.length` 分支互斥，不会双重更新

## ✅ 验证方式
- [x] pnpm typecheck 通过（仅预存的外部模块声明缺失，非新增错误）
- [x] pnpm test 通过（全部 479 测试用例 ✅）

## 👤 评审人
- **Reviewer**: Code Reviewer