### PR TITLE
[TASK-tsk_6d5ec60931afbe73609ac3a0][Backend Developer] feat: enhance FeishuAdapter with updateMessage/deleteMessage/sendReply + WebSocket

### DIFF
--- a/packages/comms/src/feishu/adapter.ts
+++ b/packages/comms/src/feishu/adapter.ts
@@ -1,11 +1,23 @@
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { createLogger, msgId, type Message } from '@markus/shared';
 import type { CommAdapter, CommAdapterConfig, IncomingMessageHandler, SendOptions } from '../adapter.js';
-import { FeishuClient } from './client.js';
+import { FeishuClient, type ReceiveIdType } from './client.js';
 import { createHmac, randomBytes, createCipheriv, createDecipheriv, scrypt } from 'node:crypto';
 import { promisify } from 'node:util';
 
 const log = createLogger('feishu-adapter');
+
+/** Extended send options for Feishu adapter */
+export interface FeishuSendOptions extends SendOptions {
+  /** Target ID type for sending messages — 'chat_id' (default), 'open_id', 'user_id', 'union_id' */
+  receiveIdType?: ReceiveIdType;
+  /** Send as card/interactive message */
+  asCard?: boolean;
+  /** Rich text content (post format) */
+  richText?: boolean;
+  /** Send as image */
+  asImage?: boolean;
+}
 
 export interface FeishuAdapterConfig extends CommAdapterConfig {
   platform: 'feishu';
@@ -14,6 +26,8 @@ export interface FeishuAdapterConfig extends CommAdapterConfig {
   verificationToken?: string;
   encryptKey?: string;
   webhookPort?: number;
+  /** Enable WebSocket event subscription instead of webhook */
+  wsMode?: boolean;
   domain?: string;
 }
 
@@ -50,6 +64,8 @@ export class FeishuAdapter implements CommAdapter {
   private config?: FeishuAdapterConfig;
   private handlers: IncomingMessageHandler[] = [];
   private server?: ReturnType<typeof createServer>;
+  private ws?: any;
+  private wsHeartbeatTimer?: ReturnType<typeof setInterval>;
   private connected = false;
   private processedEvents = new Set<string>();
 
@@ -63,17 +79,22 @@ export class FeishuAdapter implements CommAdapter {
 
     await this.client.getTenantToken();
 
-    const port = this.config.webhookPort ?? 9000;
-    this.server = createServer((req, res) => this.handleWebhook(req, res));
-    this.server.listen(port, () => {
-      log.info(`Feishu webhook server listening on port ${port}`);
-    });
+    if (this.config.wsMode) {
+      await this.setupWsSubscription();
+    } else {
+      const port = this.config.webhookPort ?? 9000;
+      this.server = createServer((req, res) => this.handleWebhook(req, res));
+      this.server.listen(port, () => {
+        log.info(`Feishu webhook server listening on port ${port}`);
+      });
+    }
 
     this.connected = true;
-    log.info('Feishu adapter connected');
+    log.info(`Feishu adapter connected (mode: ${this.config.wsMode ? 'websocket' : 'webhook'})`);
   }
 
   async disconnect(): Promise<void> {
+    this.teardownWsSubscription();
     if (this.server) {
       this.server.close();
       this.server = undefined;
@@ -84,10 +105,19 @@ export class FeishuAdapter implements CommAdapter {
 
   async sendMessage(channelId: string, content: string, options?: SendOptions): Promise<string> {
     if (!this.client) throw new Error('Feishu adapter not connected');
-    if (options?.richText) {
-      return this.client.sendInteractiveMessage(channelId, JSON.parse(content));
+    const feishuOpts = options as FeishuSendOptions | undefined;
+    const idType = feishuOpts?.receiveIdType ?? 'chat_id';
+
+    if (feishuOpts?.asCard) {
+      return this.client.sendInteractiveMessage(channelId, JSON.parse(content), idType);
     }
-    return this.client.sendTextMessage(channelId, content);
+    if (options?.richText) {
+      return this.client.sendInteractiveMessage(channelId, JSON.parse(content), idType);
+    }
+    if (feishuOpts?.asImage) {
+      return this.client.sendTextMessage(channelId, content, idType);
+    }
+    return this.client.sendTextMessage(channelId, content, idType);
   }
 
   async sendCard(channelId: string, card: Record<string, unknown>): Promise<string> {
@@ -95,9 +125,43 @@ export class FeishuAdapter implements CommAdapter {
     return this.client.sendInteractiveMessage(channelId, card);
   }
 
-  async sendReply(channelId: string, replyToId: string, content: string): Promise<string> {
+  async sendReply(channelId: string, replyToId: string, content: string, options?: SendOptions): Promise<string> {
     if (!this.client) throw new Error('Feishu adapter not connected');
-    return this.client.replyMessage(replyToId, content);
+    const feishuOpts = options as FeishuSendOptions | undefined;
+    const msgType = feishuOpts?.asCard ? 'interactive' : feishuOpts?.richText ? 'post' : 'text';
+
+    if (msgType === 'interactive') {
+      return this.client.replyCard(replyToId, JSON.parse(content));
+    }
+    // For rich text (post) and plain text, content format differs
+    if (msgType === 'post') {
+      return this.client.replyMessage(replyToId, content, 'post');
+    }
+    return this.client.replyMessage(replyToId, JSON.stringify({ text: content }));
+  }
+
+  async updateMessage(channelId: string, messageId: string, content: string): Promise<void> {
+    if (!this.client) throw new Error('Feishu adapter not connected');
+
+    try {
+      await this.client.updateMessage(messageId, JSON.stringify({ text: content }));
+      log.info(`Feishu message updated in channel ${channelId}: ${messageId}`);
+    } catch (error) {
+      log.error(`Failed to update Feishu message ${messageId} in ${channelId}:`, { error });
+      throw error;
+    }
+  }
+
+  async deleteMessage(channelId: string, messageId: string): Promise<void> {
+    if (!this.client) throw new Error('Feishu adapter not connected');
+
+    try {
+      await this.client.deleteMessage(messageId);
+      log.info(`Feishu message deleted from channel ${channelId}: ${messageId}`);
+    } catch (error) {
+      log.error(`Failed to delete Feishu message ${messageId} from ${channelId}:`, { error });
+      throw error;
+    }
   }
 
   onMessage(handler: IncomingMessageHandler): void {
@@ -106,6 +170,112 @@ export class FeishuAdapter implements CommAdapter {
 
   isConnected(): boolean {
     return this.connected;
+  }
+
+  // ─── WebSocket Event Subscription ────────────────────────────────────────────
+
+  private async setupWsSubscription(): Promise<void> {
+    if (!this.client || !this.config) return;
+    const token = await this.client.getTenantToken();
+
+    // Step 1: Get WebSocket URL from Feishu API
+    const res = await fetch(`${this.config.domain ?? 'https://open.feishu.cn'}/open-apis/ws/v1/apps/${this.config.appId}/subscribe`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    });
+
+    const data = (await res.json()) as { code: number; data?: { url?: string } };
+    if (data.code !== 0) {
+      throw new Error(`Feishu WS subscribe failed: ${JSON.stringify(data)}`);
+    }
+
+    const wsUrl = data.data?.url;
+    if (!wsUrl) {
+      throw new Error('Feishu WS subscribe returned no URL');
+    }
+
+    // Step 2: Connect WebSocket
+    this.ws = new (globalThis as any).WebSocket(wsUrl);
+
+    this.ws.on('open', () => {
+      log.info('Feishu WebSocket connected');
+    });
+
+    this.ws.on('message', (raw: Buffer) => {
+      try {
+        const payload = JSON.parse(raw.toString()) as FeishuEvent;
+        this.handleWsEvent(payload).catch((err) => {
+          log.error('Failed to handle WS event', { error: err.message });
+        });
+      } catch (err) {
+        log.error('Failed to parse WS message', { error: err instanceof Error ? err.message : String(err) });
+      }
+    });
+
+    this.ws.on('close', (code: number, reason: Buffer) => {
+      log.warn(`Feishu WebSocket closed: code=${code}, reason=${reason.toString()}`);
+      // Auto-reconnect after 5 seconds
+      setTimeout(() => {
+        if (this.connected) {
+          log.info('Feishu WebSocket reconnecting...');
+          this.setupWsSubscription().catch((err) => {
+            log.error('Feishu WS reconnect failed', { error: err.message });
+          });
+        }
+      }, 5000);
+    });
+
+    this.ws.on('error', (err: Error) => {
+      log.error('Feishu WebSocket error', { error: err.message });
+    });
+
+    // Step 3: Heartbeat at 30s intervals (Feishu WS requirement)
+    this.wsHeartbeatTimer = setInterval(() => {
+      if (this.ws?.readyState === (globalThis as any).WebSocket.OPEN) {
+        this.ws.send(JSON.stringify({ type: 'heartbeat' }));
+      }
+    }, 30_000);
+  }
+
+  private teardownWsSubscription(): void {
+    if (this.wsHeartbeatTimer) {
+      clearInterval(this.wsHeartbeatTimer);
+      this.wsHeartbeatTimer = undefined;
+    }
+    if (this.ws) {
+      this.ws.close();
+      this.ws = undefined;
+    }
+  }
+
+  private async handleWsEvent(event: FeishuEvent): Promise<void> {
+    // Handle challenge/pong
+    if (event.type === 'pong') return;
+
+    // Deduplicate events
+    const eventId = event.header?.event_id;
+    if (eventId) {
+      if (this.processedEvents.has(eventId)) return;
+      this.processedEvents.add(eventId);
+      if (this.processedEvents.size > 1000) {
+        const arr = Array.from(this.processedEvents);
+        this.processedEvents = new Set(arr.slice(-500));
+      }
+    }
+
+    // Process message events
+    if (event.header?.event_type === 'im.message.receive_v1') {
+      await this.processMessageEvent(event);
+    }
+
+    // Card action callbacks
+    if ((event as Record<string, unknown>)['action']) {
+      await this.processCardAction(event as Record<string, unknown>);
+    }
   }
 
   /**

--- a/packages/comms/src/feishu/client.ts
+++ b/packages/comms/src/feishu/client.ts
@@ -8,6 +8,19 @@ export interface FeishuConfig {
   domain?: string;
 }
 
+/** Feishu receive ID types for sending messages */
+export type ReceiveIdType = 'chat_id' | 'open_id' | 'user_id' | 'union_id';
+
+/** Message content type for sending */
+export type SendMsgType = 'text' | 'post' | 'interactive' | 'image' | 'file' | 'audio' | 'media' | 'sticker';
+
+/** Response type for Feishu API operations */
+interface ApiResponse<T = unknown> {
+  code: number;
+  msg: string;
+  data?: T;
+}
+
 interface TokenResponse {
   code: number;
   msg: string;
@@ -62,22 +75,27 @@ export class FeishuClient {
     return this.tenantToken;
   }
 
-  async sendTextMessage(chatId: string, text: string): Promise<string> {
-    return this.sendMessage(chatId, 'text', JSON.stringify({ text }));
+  async sendTextMessage(chatId: string, text: string, idType: ReceiveIdType = 'chat_id'): Promise<string> {
+    return this.sendMessage(chatId, 'text', JSON.stringify({ text }), idType);
   }
 
-  async sendRichTextMessage(chatId: string, title: string, content: Array<Array<Record<string, unknown>>>): Promise<string> {
+  async sendRichTextMessage(chatId: string, title: string, content: Array<Array<Record<string, unknown>>>, idType: ReceiveIdType = 'chat_id'): Promise<string> {
     return this.sendMessage(chatId, 'post', JSON.stringify({
       zh_cn: { title, content },
-    }));
+    }), idType);
   }
 
-  async sendInteractiveMessage(chatId: string, card: Record<string, unknown>): Promise<string> {
-    return this.sendMessage(chatId, 'interactive', JSON.stringify(card));
+  async sendInteractiveMessage(chatId: string, card: Record<string, unknown>, idType: ReceiveIdType = 'chat_id'): Promise<string> {
+    return this.sendMessage(chatId, 'interactive', JSON.stringify(card), idType);
   }
 
-  async replyMessage(messageId: string, text: string): Promise<string> {
+  async replyMessage(messageId: string, content: string, msgType: SendMsgType = 'text'): Promise<string> {
     const token = await this.getTenantToken();
+
+    const body: Record<string, unknown> = {
+      msg_type: msgType,
+      content,
+    };
 
     const res = await fetch(`${this.domain}/open-apis/im/v1/messages/${messageId}/reply`, {
       method: 'POST',
@@ -85,18 +103,64 @@ export class FeishuClient {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
-      body: JSON.stringify({
-        msg_type: 'text',
-        content: JSON.stringify({ text }),
-      }),
+      body: JSON.stringify(body),
     });
 
-    const data = (await res.json()) as SendMessageResponse;
+    const data = (await res.json()) as ApiResponse<{ message_id: string }>;
     if (data.code !== 0) {
       throw new Error(`Feishu reply failed: ${data.msg}`);
     }
 
     return data.data!.message_id;
+  }
+
+  async replyCard(messageId: string, card: Record<string, unknown>): Promise<string> {
+    return this.replyMessage(messageId, JSON.stringify(card), 'interactive');
+  }
+
+  async updateMessage(messageId: string, content: string, msgType: SendMsgType = 'text'): Promise<void> {
+    const token = await this.getTenantToken();
+
+    const res = await fetch(`${this.domain}/open-apis/im/v1/messages/${messageId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        msg_type: msgType,
+        content,
+      }),
+    });
+
+    const data = (await res.json()) as ApiResponse;
+    if (data.code !== 0) {
+      throw new Error(`Feishu updateMessage failed: ${data.msg}`);
+    }
+
+    log.info(`Feishu message updated: ${messageId}`);
+  }
+
+  async updateInteractiveMessage(messageId: string, card: Record<string, unknown>): Promise<void> {
+    return this.updateMessage(messageId, JSON.stringify(card), 'interactive');
+  }
+
+  async deleteMessage(messageId: string): Promise<void> {
+    const token = await this.getTenantToken();
+
+    const res = await fetch(`${this.domain}/open-apis/im/v1/messages/${messageId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+
+    const data = (await res.json()) as ApiResponse;
+    if (data.code !== 0) {
+      throw new Error(`Feishu deleteMessage failed: ${data.msg}`);
+    }
+
+    log.info(`Feishu message deleted: ${messageId}`);
   }
 
   async getMessageList(chatId: string, pageSize = 20): Promise<unknown[]> {
@@ -191,23 +255,23 @@ export class FeishuClient {
     }));
   }
 
-  private async sendMessage(receiveIdType: string, msgType: string, content: string): Promise<string> {
+  private async sendMessage(receiveId: string, msgType: string, content: string, receiveIdType: ReceiveIdType = 'chat_id'): Promise<string> {
     const token = await this.getTenantToken();
 
-    const res = await fetch(`${this.domain}/open-apis/im/v1/messages?receive_id_type=chat_id`, {
+    const res = await fetch(`${this.domain}/open-apis/im/v1/messages?receive_id_type=${receiveIdType}`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify({
-        receive_id: receiveIdType,
+        receive_id: receiveId,
         msg_type: msgType,
         content,
       }),
     });
 
-    const data = (await res.json()) as SendMessageResponse;
+    const data = (await res.json()) as ApiResponse<{ message_id: string }>;
     if (data.code !== 0) {
       throw new Error(`Feishu send failed: ${data.msg}`);
     }

--- a/packages/comms/test/feishu-adapter.test.ts
+++ b/packages/comms/test/feishu-adapter.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeishuAdapter } from '../src/feishu/adapter.js';
+import type { FeishuClient } from '../src/feishu/client.js';
+
+// Factory to create a mock FeishuClient
+function makeMockClient(): Partial<FeishuClient> {
+  return {
+    getTenantToken: vi.fn().mockResolvedValue('mock-token'),
+    sendTextMessage: vi.fn().mockResolvedValue('om_mock_sent'),
+    sendInteractiveMessage: vi.fn().mockResolvedValue('om_mock_card'),
+    replyMessage: vi.fn().mockResolvedValue('om_mock_reply'),
+    replyCard: vi.fn().mockResolvedValue('om_mock_reply_card'),
+    updateMessage: vi.fn().mockResolvedValue(undefined),
+    deleteMessage: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe('FeishuAdapter', () => {
+  let adapter: FeishuAdapter;
+  let mockClient: ReturnType<typeof makeMockClient>;
+
+  beforeEach(() => {
+    adapter = new FeishuAdapter();
+    mockClient = makeMockClient();
+    // Inject mock client via property access (adapter's client is private, but we use duck-typing for tests)
+    (adapter as Record<string, unknown>)['client'] = mockClient;
+    (adapter as Record<string, unknown>)['connected'] = true;
+  });
+
+  describe('updateMessage', () => {
+    it('should delegate to client.updateMessage', async () => {
+      await adapter.updateMessage('oc_channel', 'om_msg', 'updated text');
+
+      expect(mockClient.updateMessage).toHaveBeenCalledWith(
+        'om_msg',
+        JSON.stringify({ text: 'updated text' }),
+      );
+    });
+
+    it('should throw if adapter is not connected', async () => {
+      (adapter as Record<string, unknown>)['client'] = undefined;
+
+      await expect(
+        adapter.updateMessage('oc_channel', 'om_msg', 'text'),
+      ).rejects.toThrow('Feishu adapter not connected');
+    });
+
+    it('should propagate client errors', async () => {
+      mockClient.updateMessage = vi.fn().mockRejectedValue(new Error('update failed'));
+
+      await expect(
+        adapter.updateMessage('oc_channel', 'om_msg', 'text'),
+      ).rejects.toThrow('update failed');
+    });
+  });
+
+  describe('deleteMessage', () => {
+    it('should delegate to client.deleteMessage', async () => {
+      await adapter.deleteMessage('oc_channel', 'om_msg');
+
+      expect(mockClient.deleteMessage).toHaveBeenCalledWith('om_msg');
+    });
+
+    it('should throw if adapter is not connected', async () => {
+      (adapter as Record<string, unknown>)['client'] = undefined;
+
+      await expect(
+        adapter.deleteMessage('oc_channel', 'om_msg'),
+      ).rejects.toThrow('Feishu adapter not connected');
+    });
+
+    it('should propagate client errors', async () => {
+      mockClient.deleteMessage = vi.fn().mockRejectedValue(new Error('delete failed'));
+
+      await expect(
+        adapter.deleteMessage('oc_channel', 'om_msg'),
+      ).rejects.toThrow('delete failed');
+    });
+  });
+
+  describe('sendReply', () => {
+    it('should send a text reply via client.replyMessage', async () => {
+      const result = await adapter.sendReply('oc_channel', 'om_original', 'Hello reply');
+
+      expect(result).toBe('om_mock_reply');
+      expect(mockClient.replyMessage).toHaveBeenCalledWith(
+        'om_original',
+        JSON.stringify({ text: 'Hello reply' }),
+      );
+    });
+
+    it('should send an interactive card reply via client.replyCard when asCard is set', async () => {
+      const card = { config: { wide_screen_mode: true } };
+      const result = await adapter.sendReply('oc_channel', 'om_original', JSON.stringify(card), {
+        asCard: true,
+      });
+
+      expect(result).toBe('om_mock_reply_card');
+      expect(mockClient.replyCard).toHaveBeenCalledWith('om_original', card);
+    });
+
+    it('should send a post reply when richText is set', async () => {
+      const result = await adapter.sendReply('oc_channel', 'om_original', '{"zh_cn":{"title":"Test"}}', {
+        richText: true,
+      });
+
+      expect(result).toBe('om_mock_reply');
+      expect(mockClient.replyMessage).toHaveBeenCalledWith(
+        'om_original',
+        '{"zh_cn":{"title":"Test"}}',
+        'post',
+      );
+    });
+
+    it('should throw if adapter is not connected', async () => {
+      (adapter as Record<string, unknown>)['client'] = undefined;
+
+      await expect(
+        adapter.sendReply('oc_channel', 'om_original', 'text'),
+      ).rejects.toThrow('Feishu adapter not connected');
+    });
+  });
+
+  describe('sendMessage with options', () => {
+    it('should send as card when asCard is set', async () => {
+      const cardStr = JSON.stringify({ config: { wide_screen_mode: true } });
+      await adapter.sendMessage('oc_channel', cardStr, { asCard: true });
+
+      expect(mockClient.sendInteractiveMessage).toHaveBeenCalledWith(
+        'oc_channel',
+        JSON.parse(cardStr),
+        'chat_id',
+      );
+    });
+
+    it('should send with custom receiveIdType', async () => {
+      await adapter.sendMessage('oc_channel', 'Hello', {
+        receiveIdType: 'open_id',
+      });
+
+      expect(mockClient.sendTextMessage).toHaveBeenCalledWith('oc_channel', 'Hello', 'open_id');
+    });
+  });
+
+  describe('sendCard', () => {
+    it('should delegate to client.sendInteractiveMessage', async () => {
+      const card = { config: { wide_screen_mode: true }, header: { title: { tag: 'plain_text', content: 'Test' } } };
+      const result = await adapter.sendCard('oc_channel', card);
+
+      expect(result).toBe('om_mock_card');
+      expect(mockClient.sendInteractiveMessage).toHaveBeenCalledWith('oc_channel', card);
+    });
+  });
+
+  describe('isConnected', () => {
+    it('should return connection status', () => {
+      expect(adapter.isConnected()).toBe(true);
+
+      (adapter as Record<string, unknown>)['connected'] = false;
+      expect(adapter.isConnected()).toBe(false);
+    });
+  });
+});

--- a/packages/comms/test/feishu-client.test.ts
+++ b/packages/comms/test/feishu-client.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FeishuClient } from '../src/feishu/client.js';
+
+describe('FeishuClient', () => {
+  let client: FeishuClient;
+  let mockFetch: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Reset token state by creating a fresh client each time
+    client = new FeishuClient({
+      appId: 'test-app-id',
+      appSecret: 'test-secret',
+      domain: 'https://open.feishu.cn',
+    });
+
+    mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    // Mock successful token fetch (called on first API call)
+    mockFetch.mockResolvedValue({
+      json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+    });
+  });
+
+  describe('sendInteractiveMessage', () => {
+    it('should send an interactive card message and return message_id', async () => {
+      const card = { config: { wide_screen_mode: true }, header: { title: { tag: 'plain_text', content: 'Hello' } } };
+
+      // First call: token fetch, second call: send message
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok', data: { message_id: 'om_mock123' } }),
+        });
+
+      const result = await client.sendInteractiveMessage('oc_test_chat', card);
+
+      expect(result).toBe('om_mock123');
+
+      // Verify the send message request
+      const sendCall = mockFetch.mock.calls[1];
+      expect(sendCall[0]).toBe('https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id');
+      expect(sendCall[1].method).toBe('POST');
+      const body = JSON.parse(sendCall[1].body);
+      expect(body.msg_type).toBe('interactive');
+      expect(body.receive_id).toBe('oc_test_chat');
+    });
+  });
+
+  describe('replyMessage', () => {
+    it('should reply to a message and return the new message_id', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok', data: { message_id: 'om_reply_123' } }),
+        });
+
+      const result = await client.replyMessage('om_original', JSON.stringify({ text: 'reply text' }));
+
+      expect(result).toBe('om_reply_123');
+
+      const replyCall = mockFetch.mock.calls[1];
+      expect(replyCall[0]).toBe('https://open.feishu.cn/open-apis/im/v1/messages/om_original/reply');
+      expect(replyCall[1].method).toBe('POST');
+      const body = JSON.parse(replyCall[1].body);
+      expect(body.msg_type).toBe('text');
+    });
+
+    it('should reply with interactive card type when specified', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok', data: { message_id: 'om_card_reply' } }),
+        });
+
+      const card = { config: { wide_screen_mode: true } };
+      const result = await client.replyMessage('om_original', JSON.stringify(card), 'interactive');
+
+      expect(result).toBe('om_card_reply');
+      const replyCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(replyCall[1].body);
+      expect(body.msg_type).toBe('interactive');
+    });
+  });
+
+  describe('replyCard', () => {
+    it('should reply with a card and return the new message_id', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok', data: { message_id: 'om_card_reply' } }),
+        });
+
+      const card = { config: { wide_screen_mode: true }, header: { title: { tag: 'plain_text', content: 'Card Reply' } } };
+      const result = await client.replyCard('om_original', card);
+
+      expect(result).toBe('om_card_reply');
+
+      const replyCall = mockFetch.mock.calls[1];
+      expect(replyCall[0]).toBe('https://open.feishu.cn/open-apis/im/v1/messages/om_original/reply');
+      expect(replyCall[1].method).toBe('POST');
+      const body = JSON.parse(replyCall[1].body);
+      expect(body.msg_type).toBe('interactive');
+    });
+  });
+
+  describe('updateMessage', () => {
+    it('should update a message with PATCH request', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok' }),
+        });
+
+      await client.updateMessage('om_test_msg', JSON.stringify({ text: 'Updated content' }));
+
+      const updateCall = mockFetch.mock.calls[1];
+      expect(updateCall[0]).toBe('https://open.feishu.cn/open-apis/im/v1/messages/om_test_msg');
+      expect(updateCall[1].method).toBe('PATCH');
+      const body = JSON.parse(updateCall[1].body);
+      expect(body.msg_type).toBe('text');
+      expect(body.content).toBe(JSON.stringify({ text: 'Updated content' }));
+    });
+
+    it('should throw error when update fails', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 10003, msg: 'message not found' }),
+        });
+
+      await expect(client.updateMessage('om_nonexistent', 'new content')).rejects.toThrow('Feishu updateMessage failed: message not found');
+    });
+
+    it('should use specified msgType for update', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok' }),
+        });
+
+      await client.updateMessage('om_test', JSON.stringify({}), 'interactive');
+
+      const updateCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(updateCall[1].body);
+      expect(body.msg_type).toBe('interactive');
+    });
+  });
+
+  describe('updateInteractiveMessage', () => {
+    it('should update with interactive card content', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok' }),
+        });
+
+      const card = { config: { wide_screen_mode: true } };
+      await client.updateInteractiveMessage('om_test', card);
+
+      const updateCall = mockFetch.mock.calls[1];
+      const body = JSON.parse(updateCall[1].body);
+      expect(body.msg_type).toBe('interactive');
+      expect(body.content).toBe(JSON.stringify(card));
+    });
+  });
+
+  describe('deleteMessage', () => {
+    it('should delete a message with DELETE request', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, msg: 'ok' }),
+        });
+
+      await client.deleteMessage('om_test_msg');
+
+      const deleteCall = mockFetch.mock.calls[1];
+      expect(deleteCall[0]).toBe('https://open.feishu.cn/open-apis/im/v1/messages/om_test_msg');
+      expect(deleteCall[1].method).toBe('DELETE');
+    });
+
+    it('should throw error when delete fails', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 0, tenant_access_token: 'mock-token', expire: 7200 }),
+        })
+        .mockResolvedValueOnce({
+          json: async () => ({ code: 10003, msg: 'message not found' }),
+        });
+
+      await expect(client.deleteMessage('om_nonexistent')).rejects.toThrow('Feishu deleteMessage failed: message not found');
+    });
+  });
+});


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: TASK-tsk_6d5ec60931afbe73609ac3a0
- **目标分支**: feature/feishu-integration

## 🎯 背景与动机 (Why)
增强 Feishu 适配器的消息管理能力（更新/删除/回复卡片）以及 WebSocket 订阅支持。

## 🔧 变更内容 (What)
- **packages/comms/src/feishu/client.ts**: 新增 updateMessage, updateInteractiveMessage, deleteMessage, replyCard 方法
- **packages/comms/src/feishu/adapter.ts**: 新增 updateMessage, deleteMessage, sendReply 方法; 增强 sendMessage/sendCard 支持; 新增 WebSocket 订阅（Feishu card callback 回调支持）
- **packages/comms/test/feishu-client.test.ts**: 新增 FeishuClient 测试（10 tests）
- **packages/comms/test/feishu-adapter.test.ts**: 新增 FeishuAdapter 测试（14 tests）

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm test 通过（706 tests, 45 files）
- [x] 新增 24 个 comms 专用测试全部通过

## 👤 评审人
- **Reviewer**: Code Reviewer