### PR TITLE
[TASK-tsk_5f8d433055b23f2d1bf1891e][Frontend] fix: rename verifyToken → verificationToken in feishu integration UI

### DIFF
--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -1352,12 +1352,12 @@ export const api = {
     enableRemote: () => request<{ ok: boolean; status: RemoteStatus }>('/settings/remote/enable', { method: 'POST' }),
     disableRemote: () => request<{ ok: boolean }>('/settings/remote/disable', { method: 'POST' }),
     getFeishuIntegration: () => request<{
-      appId?: string; appSecret?: string; verifyToken?: string; encryptKey?: string;
+      appId?: string; appSecret?: string; verificationToken?: string; encryptKey?: string;
       webhookPath?: string; enabled: boolean; connected: boolean;
       notifyOnApproval: boolean; notifyOnNotification: boolean; notifyPriority: string[];
     }>('/settings/integrations/feishu'),
     saveFeishuIntegration: (config: {
-      appId: string; appSecret: string; verifyToken?: string; encryptKey?: string;
+      appId: string; appSecret: string; verificationToken?: string; encryptKey?: string;
       webhookPath?: string; enabled?: boolean;
       notifyOnApproval?: boolean; notifyOnNotification?: boolean; notifyPriority?: string[];
     }) => request<{

--- a/packages/web-ui/src/components/FeishuIntegrationSection.tsx
+++ b/packages/web-ui/src/components/FeishuIntegrationSection.tsx
@@ -5,7 +5,7 @@ import { api } from '../api.ts';
 export interface FeishuConfig {
   appId: string;
   appSecret: string;
-  verifyToken?: string;
+  verificationToken?: string;
   encryptKey?: string;
   webhookPath?: string;
   enabled: boolean;
@@ -18,7 +18,7 @@ export interface FeishuConfig {
 const DEFAULT_CONFIG: FeishuConfig = {
   appId: '',
   appSecret: '',
-  verifyToken: '',
+  verificationToken: '',
   encryptKey: '',
   webhookPath: '/webhook/feishu',
   enabled: false,
@@ -104,7 +104,7 @@ export function FeishuIntegrationSection() {
         setConfig({
           appId: data.appId ?? '',
           appSecret: data.appSecret ?? '',
-          verifyToken: data.verifyToken ?? '',
+          verificationToken: data.verificationToken ?? '',
           encryptKey: data.encryptKey ?? '',
           webhookPath: data.webhookPath ?? '/webhook/feishu',
           enabled: data.enabled ?? false,
@@ -148,7 +148,7 @@ export function FeishuIntegrationSection() {
       const result = await api.settings.saveFeishuIntegration({
         appId: config.appId,
         appSecret: config.appSecret,
-        verifyToken: config.verifyToken || undefined,
+        verificationToken: config.verificationToken || undefined,
         encryptKey: config.encryptKey || undefined,
         webhookPath: config.webhookPath || '/webhook/feishu',
         enabled: config.enabled,
@@ -284,13 +284,13 @@ export function FeishuIntegrationSection() {
           {/* Verify Token */}
           <div>
             <label className="block text-xs font-medium text-fg-secondary mb-1.5">
-              {t('settings:feishu.verifyToken', { defaultValue: 'Verify Token' })}
+              {t('settings:feishu.verificationToken', { defaultValue: 'Verify Token' })}
               <span className="text-fg-tertiary ml-1">({t('settings:feishu.optional', { defaultValue: 'optional' })})</span>
             </label>
             <input
               type="text"
-              value={config.verifyToken ?? ''}
-              onChange={e => updateField('verifyToken', e.target.value)}
+              value={config.verificationToken ?? ''}
+              onChange={e => updateField('verificationToken', e.target.value)}
               placeholder="Event verification token from Feishu"
               className="w-full px-3 py-2 text-sm bg-surface-primary border border-border-default rounded-lg text-fg-primary placeholder-fg-tertiary focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500 transition-colors font-mono"
             />

--- a/packages/web-ui/src/locales/en/settings.json
+++ b/packages/web-ui/src/locales/en/settings.json
@@ -605,7 +605,7 @@
   "feishu": {
     "description": "Configure Feishu integration for notifications and approvals",
     "connectionSettings": "Connection Settings",
-    "verifyToken": "Verify Token",
+    "verificationToken": "Verify Token",
     "encryptKey": "Encrypt Key",
     "optional": "optional",
     "webhookPath": "Webhook Path",

--- a/packages/web-ui/src/locales/zh-CN/settings.json
+++ b/packages/web-ui/src/locales/zh-CN/settings.json
@@ -605,7 +605,7 @@
   "feishu": {
     "description": "配置飞书集成，用于接收通知和审批请求",
     "connectionSettings": "连接设置",
-    "verifyToken": "验证令牌",
+    "verificationToken": "验证令牌",
     "encryptKey": "加密密钥",
     "optional": "可选",
     "webhookPath": "Webhook 路径",


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Frontend Developer (ID: agt_ca836fdc2c08b8e9ec1370a8)
- **关联任务**: TASK-tsk_5f8d433055b23f2d1bf1891e
- **目标分支**: feature/feishu-integration

## 🎯 背景与动机 (Why)
QA 发现 UI-API 字段名不一致：UI 使用 `verifyToken` 发送，但 API 端 (api-server.ts)、shared types (integration.ts)、feishu adapter 都使用 `verificationToken`。需要将 UI 侧字段名统一为 `verificationToken`，与后端保持一致。

## 🔧 变更内容 (What)
- **packages/web-ui/src/api.ts**: getFeishuIntegration 和 saveFeishuIntegration 的 verifyToken 字段类型改为 verificationToken
- **packages/web-ui/src/components/FeishuIntegrationSection.tsx**: interface、initial state、API 调用、表单绑定、i18n key 全部改为 verificationToken
- **packages/web-ui/src/locales/en/settings.json**: i18n key 从 verifyToken 改为 verificationToken
- **packages/web-ui/src/locales/zh-CN/settings.json**: 同上

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm lint 通过（仅预存警告）
- [x] pnpm test 通过（722 passed, 46 files）
- [x] grep 确认无残留 verifyToken 引用

## 👤 评审人
- **Reviewer**: Code Reviewer
