### PR TITLE
[fix] 后端 Critical 修复 — WS事件API + DELETE await

### DIFF
--- a/packages/comms/src/feishu/adapter.ts
+++ b/packages/comms/src/feishu/adapter.ts
@@ -201,23 +201,23 @@ export class FeishuAdapter implements CommAdapter {
     // Step 2: Connect WebSocket
     this.ws = new (globalThis as any).WebSocket(wsUrl);
 
-    this.ws.on('open', () => {
+    this.ws.onopen = () => {
       log.info('Feishu WebSocket connected');
-    });
+    };
 
-    this.ws.on('message', (raw: Buffer) => {
+    this.ws.onmessage = (event: { data: Buffer }) => {
       try {
-        const payload = JSON.parse(raw.toString()) as FeishuEvent;
+        const payload = JSON.parse(event.data.toString()) as FeishuEvent;
         this.handleWsEvent(payload).catch((err) => {
           log.error('Failed to handle WS event', { error: err.message });
         });
       } catch (err) {
         log.error('Failed to parse WS message', { error: err instanceof Error ? err.message : String(err) });
       }
-    });
+    };
 
-    this.ws.on('close', (code: number, reason: Buffer) => {
-      log.warn(`Feishu WebSocket closed: code=${code}, reason=${reason.toString()}`);
+    this.ws.onclose = (event: { code: number; reason: Buffer }) => {
+      log.warn(`Feishu WebSocket closed: code=${event.code}, reason=${event.reason.toString()}`);
       // Auto-reconnect after 5 seconds
       setTimeout(() => {
         if (this.connected) {
@@ -227,11 +227,11 @@ export class FeishuAdapter implements CommAdapter {
           });
         }
       }, 5000);
-    });
+    };
 
-    this.ws.on('error', (err: Error) => {
-      log.error('Feishu WebSocket error', { error: err.message });
-    });
+    this.ws.onerror = () => {
+      log.error('Feishu WebSocket error occurred');
+    };
 
     // Step 3: Heartbeat at 30s intervals (Feishu WS requirement)
     this.wsHeartbeatTimer = setInterval(() => {

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -9036,7 +9036,7 @@ EXPLANATION_END`;
       try {
         const row = findFeishuConfig(auth.orgId);
         if (row) {
-          this.storage?.integrationRepo?.delete(row['id'] as string);
+          await this.storage?.integrationRepo?.delete(row['id'] as string);
         }
         log.info('Feishu integration config deleted', { orgId: auth.orgId });
         this.auditService?.record({


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: tsk_150ac7d54c5ca577a77816bc
- **目标分支**: feature/feishu-integration

## 🎯 背景与动机
QA 发现 2 个 CRITICAL 问题，必须修复后才能合并 feature/feishu-integration 到 main。

## 🔧 变更内容
### C1: WebSocket 事件 API 不匹配
- 文件: `packages/comms/src/feishu/adapter.ts:202`
- 问题: Node 内置 WebSocket 使用属性风格 API (`onopen`/`onmessage`/`onclose`/`onerror`)，但代码使用了 EventEmitter 的 `.on('event', handler)` 模式，事件永远不会触发
- 修复: 全部改为属性赋值模式

### C2: DELETE 路由未 await
- 文件: `packages/org-manager/src/api-server.ts:9039`
- 问题: `integrationRepo?.delete()` 返回 Promise 但未 await，HTTP 200 在删除完成前返回
- 修复: 添加 `await` 关键字

## ✅ 验证方式
- [x] pnpm typecheck 通过
- [x] pnpm test: 722/722 passed (46 files)
- [x] 变更范围仅限于任务指定的两个文件

## 👤 评审人
- **Reviewer**: Code Reviewer (agt_42fc22d8cd79900a089eea09)