### PR TITLE
[tsk_c687d596][Backend Developer] feat: re-implement FeishuNotifier with api-server integration

### DIFF
--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -34,6 +34,7 @@ import type { OrganizationService } from './org-service.js';
 import { BuilderService } from './builder-service.js';
 import type { TaskService } from './task-service.js';
 import type { HITLService } from './hitl-service.js';
+import { FeishuNotifier, type FeishuNotifierConfig } from './feishu-notifier.js';
 import type { BillingService } from './billing-service.js';
 import type { AuditService, AuditEventType } from './audit-service.js';
 import type { LicenseService } from './license-service.js';
@@ -183,6 +184,7 @@ export class APIServer {
   private ws: WSBroadcaster;
   private skillRegistry?: SkillRegistry;
   private hitlService?: HITLService;
+  private feishuNotifier?: FeishuNotifier;
   private billingService?: BillingService;
   private auditService?: AuditService;
   private licenseService?: LicenseService;
@@ -569,10 +571,20 @@ export class APIServer {
       };
       this.ws.sendToUser(n.targetUserId, event);
     });
+    this.tryInitFeishuNotifier();
+  }
+
+  /** Update the Feishu notifier config at runtime (called when integration settings are saved). */
+  updateFeishuConfig(config: FeishuNotifierConfig): void {
+    if (!this.feishuNotifier) {
+      return;
+    }
+    this.feishuNotifier.updateConfig(config);
   }
 
   setStorage(storage: StorageBridge): void {
     this.storage = storage;
+    this.tryInitFeishuNotifier();
   }
 
   setRemoteAgent(agent: { getStatus(): unknown; start(): Promise<void>; stop(): Promise<void>; onStatus(cb: (s: unknown) => void): () => void }): void {
@@ -1424,10 +1436,55 @@ export class APIServer {
     this.server.listen(this.port, '0.0.0.0', () => {
       log.info(`API server listening on 0.0.0.0:${this.port} (HTTP + WebSocket)`);
     });
+    this.tryInitFeishuNotifier();
   }
 
   stop(): void {
     this.server?.close();
+    this.feishuNotifier?.stop();
+  }
+
+  /** Initialize FeishuNotifier once all dependencies are available. */
+  private async tryInitFeishuNotifier(): Promise<void> {
+    if (this.feishuNotifier) return;
+    if (!this.hitlService) return;
+    if (!this.storage) return;
+    try {
+      const agentManager = this.orgService.getAgentManager();
+      const eventBus = agentManager.getEventBus();
+
+      // Load Feishu integration config from storage (integrations table)
+      const rows = this.storage.integrationRepo.listByPlatform('default', 'feishu') as Array<Record<string, unknown>>;
+      const row = rows[0];
+      const cfgConfig = row?.['config'] as Record<string, unknown> | undefined;
+      const forwardRules = row?.['forwardRules'] as Array<Record<string, unknown>> | undefined;
+
+      let initialConfig: FeishuNotifierConfig | undefined;
+      if (cfgConfig?.appId && cfgConfig?.appSecret) {
+        initialConfig = {
+          appId: cfgConfig.appId as string,
+          appSecret: cfgConfig.appSecret as string,
+          domain: cfgConfig.domain as string | undefined,
+          forwardRules: (forwardRules ?? []) as unknown as FeishuNotifierConfig['forwardRules'],
+        };
+      }
+
+      this.feishuNotifier = new FeishuNotifier({
+        eventBus,
+        hitlService: this.hitlService,
+        orgId: 'default',
+        agentManager: {
+          getAgentName: (id: string) => {
+            try { return agentManager.getAgent(id)?.config?.name ?? id; } catch { return id; }
+          },
+        },
+        config: initialConfig,
+      });
+      this.feishuNotifier.start();
+      log.info('FeishuNotifier initialized');
+    } catch (err) {
+      log.warn('Failed to initialize FeishuNotifier', { error: String(err) });
+    }
   }
 
   getWSBroadcaster(): WSBroadcaster {
@@ -9022,6 +9079,13 @@ EXPLANATION_END`;
           userId: auth.userId,
           success: true,
         });
+        // Update the FeishuNotifier runtime config
+        this.updateFeishuConfig({
+          appId,
+          appSecret: appSecret,
+          domain: body['domain'] as string | undefined,
+          forwardRules: [],
+        });
         this.json(res, 200, { config: payload });
       } catch (e) {
         log.error('Failed to save feishu integration config', { error: String(e) });
@@ -9120,6 +9184,16 @@ EXPLANATION_END`;
             lastVerifiedAt: row['lastVerifiedAt'] ?? null,
             lastError: row['lastError'] ?? null,
           });
+          // Update the FeishuNotifier runtime config with new rules
+          const cfgConfig = row['config'] as Record<string, unknown> | undefined;
+          if (cfgConfig?.appId && cfgConfig?.appSecret && this.feishuNotifier) {
+            this.feishuNotifier.updateConfig({
+              appId: cfgConfig.appId as string,
+              appSecret: cfgConfig.appSecret as string,
+              domain: cfgConfig.domain as string | undefined,
+              forwardRules: rules as unknown as FeishuNotifierConfig['forwardRules'],
+            });
+          }
           log.info('Feishu notification rules updated', { orgId: auth.orgId, ruleCount: rules.length });
           this.auditService?.record({
             orgId: auth.orgId,

--- a/packages/org-manager/src/feishu-api-client.ts
+++ b/packages/org-manager/src/feishu-api-client.ts
@@ -1,0 +1,100 @@
+import { createLogger } from '@markus/shared';
+
+const log = createLogger('feishu-api-client');
+
+/** Minimal HTTP client for the Feishu Open API — used by FeishuNotifier. */
+export class FeishuApiClient {
+  private token: string | null = null;
+  private tokenExpiresAt = 0;
+  private appId: string;
+  private appSecret: string;
+  private domain: string;
+
+  constructor(opts: {
+    appId: string;
+    appSecret: string;
+    domain?: string;
+  }) {
+    this.appId = opts.appId;
+    this.appSecret = opts.appSecret;
+    this.domain = opts.domain ?? 'https://open.feishu.cn';
+  }
+
+  /** Ensure a valid tenant access token is cached. */
+  private async ensureToken(): Promise<string> {
+    // 5 min buffer before expiry
+    if (this.token && Date.now() < this.tokenExpiresAt - 300_000) {
+      return this.token;
+    }
+    const resp = await fetch(`${this.domain}/open-apis/auth/v3/tenant_access_token/internal`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ app_id: this.appId, app_secret: this.appSecret }),
+    });
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Feishu auth failed (${resp.status}): ${text}`);
+    }
+    const data = (await resp.json()) as { tenant_access_token: string; expire: number };
+    this.token = data.tenant_access_token;
+    this.tokenExpiresAt = Date.now() + data.expire * 1000;
+    log.info('Feishu tenant token refreshed');
+    return this.token!;
+  }
+
+  /** Send a text message to a Feishu chat by chat_id. */
+  async sendText(chatId: string, text: string): Promise<void> {
+    const token = await this.ensureToken();
+    const body = {
+      receive_id: chatId,
+      msg_type: 'text',
+      content: JSON.stringify({ text }),
+    };
+    const resp = await fetch(
+      `${this.domain}/open-apis/im/v1/messages?receive_id_type=chat_id`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Feishu sendText failed (${resp.status}): ${text}`);
+    }
+  }
+
+  /** Send an interactive card to a Feishu chat by chat_id. */
+  async sendCard(chatId: string, card: Record<string, unknown>): Promise<void> {
+    const token = await this.ensureToken();
+    const body = {
+      receive_id: chatId,
+      msg_type: 'interactive',
+      content: JSON.stringify(card),
+    };
+    const resp = await fetch(
+      `${this.domain}/open-apis/im/v1/messages?receive_id_type=chat_id`,
+      {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      },
+    );
+    if (!resp.ok) {
+      const text = await resp.text();
+      throw new Error(`Feishu sendCard failed (${resp.status}): ${text}`);
+    }
+  }
+
+  /** Clear the cached token (e.g. on config update). */
+  clearToken(): void {
+    this.token = null;
+    this.tokenExpiresAt = 0;
+  }
+}

--- a/packages/org-manager/src/feishu-notifier.ts
+++ b/packages/org-manager/src/feishu-notifier.ts
@@ -1,0 +1,365 @@
+import { createLogger } from '@markus/shared';
+import type { EventBus } from '@markus/core';
+import type { HITLService, Notification as HITLNotification } from './hitl-service.js';
+import { FeishuApiClient } from './feishu-api-client.js';
+
+const log = createLogger('feishu-notifier');
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface ForwardTarget {
+  channelId: string;
+  type: 'chat' | 'webhook';
+}
+
+export interface NotificationForwardRule {
+  id: string;
+  name: string;
+  enabled: boolean;
+  type: string;
+  priorityFilter: string;
+  targets: ForwardTarget[];
+  keywordFilter?: string;
+  includeApprovalActions?: boolean;
+}
+
+export interface FeishuNotifierConfig {
+  appId: string;
+  appSecret: string;
+  domain?: string;
+  forwardRules: NotificationForwardRule[];
+}
+
+// EventBus event → FeishuForwardEventType mapping
+const EVENT_MAP: Record<string, string> = {
+  'task:completed': 'task_completed',
+  'system:announcement': 'notification',
+  'agent:started': 'notification',
+  'agent:stopped': 'notification',
+  'agent:paused': 'notification',
+  'agent:resumed': 'notification',
+  'agent:created': 'notification',
+  'agent:removed': 'notification',
+};
+
+// ── Card Building Helpers ───────────────────────────────────────────
+
+/** Build a Feishu interactive card from notification data. */
+function buildNotificationCard(
+  title: string,
+  body: string,
+  priority: string,
+  eventType: string,
+  metadata?: Record<string, unknown>,
+): Record<string, unknown> {
+  const color = priority === 'urgent' ? 'red' : priority === 'high' ? 'orange' : 'blue';
+  const elements: Record<string, unknown>[] = [
+    {
+      tag: 'markdown',
+      content: body,
+    },
+    {
+      tag: 'hr',
+    },
+    {
+      tag: 'note',
+      elements: [
+        {
+          tag: 'plain_text',
+          content: `Type: ${eventType} | ${new Date().toLocaleString('zh-CN', { timeZone: 'Asia/Shanghai' })}`,
+        },
+      ],
+    },
+  ];
+
+  // Add action buttons for approval events
+  if (metadata?.approvalId) {
+    elements.push({
+      tag: 'action',
+      actions: [
+        {
+          tag: 'button',
+          text: { tag: 'plain_text', content: '✅ Approve' },
+          type: 'primary',
+          value: { action: 'approve', approval_id: metadata.approvalId as string },
+        },
+        {
+          tag: 'button',
+          text: { tag: 'plain_text', content: '❌ Reject' },
+          type: 'danger',
+          value: { action: 'reject', approval_id: metadata.approvalId as string },
+        },
+      ],
+    });
+  }
+
+  return {
+    config: { wide_screen_mode: true },
+    header: { title: { tag: 'plain_text', content: title }, template: color },
+    elements,
+  };
+}
+
+function buildSimpleCard(title: string, body: string, priority: string, eventType: string): Record<string, unknown> {
+  return buildNotificationCard(title, body, priority, eventType, undefined);
+}
+
+// ── FeishuNotifier ──────────────────────────────────────────────────
+
+export class FeishuNotifier {
+  private eventBus: EventBus;
+  private hitlService: HITLService;
+  private orgId: string;
+  private agentManager?: { getAgentName?: (id: string) => string | undefined };
+  private apiClient: FeishuApiClient | null = null;
+  private config: FeishuNotifierConfig | null = null;
+  private unsubscribes: Array<() => void> = [];
+  private hitlUnsubscribe: (() => void) | null = null;
+
+  constructor(opts: {
+    eventBus: EventBus;
+    hitlService: HITLService;
+    orgId: string;
+    agentManager?: { getAgentName?: (id: string) => string | undefined };
+    /** Optional initial config — can be set later via updateConfig(). */
+    config?: FeishuNotifierConfig;
+  }) {
+    this.eventBus = opts.eventBus;
+    this.hitlService = opts.hitlService;
+    this.orgId = opts.orgId;
+    this.agentManager = opts.agentManager;
+    if (opts.config?.appId && opts.config?.appSecret) {
+      this.config = opts.config;
+    }
+  }
+
+  /** Start listening — subscribe to EventBus events and HITL notifications. */
+  start(): void {
+    // Subscribe to EventBus events
+    for (const [eventName] of Object.entries(EVENT_MAP)) {
+      const unsub = this.eventBus.on(eventName, (...args: unknown[]) => {
+        this.handleEventBusEvent(eventName, args).catch((err) => {
+          log.error('Failed to handle EventBus event', { event: eventName, error: String(err) });
+        });
+      });
+      this.unsubscribes.push(unsub);
+    }
+
+    // Subscribe to HITL notifications
+    this.hitlUnsubscribe = this.hitlService.onNotification((notification: HITLNotification) => {
+      this.handleHITLNotification(notification).catch((err) => {
+        log.error('Failed to handle HITL notification', { error: String(err) });
+      });
+    });
+
+    log.info('FeishuNotifier started');
+  }
+
+  /** Stop listening and clean up. */
+  stop(): void {
+    for (const unsub of this.unsubscribes) {
+      try { unsub(); } catch { /* ignore */ }
+    }
+    this.unsubscribes = [];
+    if (this.hitlUnsubscribe) {
+      try { this.hitlUnsubscribe(); } catch { /* ignore */ }
+      this.hitlUnsubscribe = null;
+    }
+    this.apiClient = null;
+    this.config = null;
+    log.info('FeishuNotifier stopped');
+  }
+
+  /** Update the Feishu integration config at runtime (e.g. when settings are saved). */
+  updateConfig(config: FeishuNotifierConfig): void {
+    this.config = config;
+    if (config.appId && config.appSecret) {
+      if (!this.apiClient) {
+        this.apiClient = new FeishuApiClient({
+          appId: config.appId,
+          appSecret: config.appSecret,
+          domain: config.domain,
+        });
+      } else {
+        this.apiClient.clearToken();
+      }
+    } else {
+      this.apiClient = null;
+    }
+    log.info('FeishuNotifier config updated');
+  }
+
+  /** Handle an EventBus event. */
+  private async handleEventBusEvent(eventName: string, args: unknown[]): Promise<void> {
+    if (!this.apiClient || !this.config) return;
+
+    const forwardType = EVENT_MAP[eventName];
+    if (!forwardType) return;
+
+    const payload = args[0] as Record<string, unknown> | undefined;
+    if (!payload) return;
+
+    let title = '';
+    let body = '';
+    let priority = 'normal';
+
+    switch (eventName) {
+      case 'task:completed': {
+        const agentName = payload['agentId']
+          ? this.agentManager?.getAgentName?.(payload['agentId'] as string) ?? payload['agentId'] as string
+          : 'Unknown';
+        title = '✅ 任务完成';
+        body = `Agent: ${agentName}\nTask ID: ${payload['taskId'] as string}`;
+        break;
+      }
+      case 'system:announcement': {
+        title = '📢 系统公告';
+        body = (payload['content'] as string) ?? payload['message'] as string ?? '';
+        priority = payload['priority'] as string ?? 'high';
+        break;
+      }
+      case 'agent:started': {
+        title = '▶️ Agent 启动';
+        body = `Agent: ${payload['agentId'] as string}`;
+        break;
+      }
+      case 'agent:stopped': {
+        title = '⏹️ Agent 停止';
+        body = `Agent: ${payload['agentId'] as string}`;
+        priority = 'high';
+        break;
+      }
+      case 'agent:paused': {
+        title = '⏸️ Agent 暂停';
+        const reason = payload['reason'] as string | undefined;
+        body = `Agent: ${payload['agentId'] as string}${reason ? `\n原因: ${reason}` : ''}`;
+        priority = 'high';
+        break;
+      }
+      case 'agent:resumed': {
+        title = '▶️ Agent 恢复';
+        body = `Agent: ${payload['agentId'] as string}`;
+        break;
+      }
+      case 'agent:created': {
+        title = '🆕 Agent 创建';
+        body = `Agent: ${(payload['name'] as string) ?? payload['agentId'] as string}`;
+        break;
+      }
+      case 'agent:removed': {
+        title = '🗑️ Agent 删除';
+        body = `Agent ID: ${payload['agentId'] as string}`;
+        priority = 'high';
+        break;
+      }
+      default: {
+        title = eventName;
+        body = JSON.stringify(payload);
+      }
+    }
+
+    await this.routeNotification(forwardType, priority, title, body, payload['metadata'] as Record<string, unknown> | undefined);
+  }
+
+  /** Handle a HITL notification. */
+  private async handleHITLNotification(notification: HITLNotification): Promise<void> {
+    if (!this.apiClient || !this.config) return;
+
+    const typeMap: Record<string, string> = {
+      'approval_request': 'approval_requested',
+      'task_created': 'task_assigned',
+      'task_completed': 'task_completed',
+      'task_review': 'task_assigned',
+      'task_failed': 'notification',
+      'requirement_created': 'notification',
+      'requirement_decision': 'notification',
+      'agent_report': 'report_ready',
+      'direct_message': 'mention',
+      'group_message': 'mention',
+      'system': 'notification',
+    };
+
+    const forwardType = typeMap[notification.type] ?? 'notification';
+    const title = notification.title;
+    const body = notification.body;
+    const priority = notification.priority;
+
+    const metadata: Record<string, unknown> = {};
+    if (notification.type === 'approval_request' && notification.metadata?.approvalId) {
+      metadata['approvalId'] = notification.metadata.approvalId;
+    }
+
+    await this.routeNotification(forwardType, priority, title, body, metadata);
+  }
+
+  /** Match rules and send to all matched targets. */
+  private async routeNotification(
+    eventType: string,
+    priority: string,
+    title: string,
+    body: string,
+    metadata?: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.config) return;
+
+    const rules = this.config.forwardRules ?? [];
+    const matchedTargets: ForwardTarget[] = [];
+
+    for (const rule of rules) {
+      if (!rule.enabled) continue;
+
+      if (rule.type !== '*' && rule.type !== eventType) continue;
+
+      if (rule.priorityFilter === 'urgent' && priority !== 'urgent') continue;
+      if (rule.priorityFilter === 'high' && priority !== 'high' && priority !== 'urgent') continue;
+
+      if (rule.keywordFilter) {
+        const kw = rule.keywordFilter.toLowerCase();
+        const haystack = `${title} ${body}`.toLowerCase();
+        if (!haystack.includes(kw)) continue;
+      }
+
+      matchedTargets.push(...rule.targets);
+    }
+
+    // Deduplicate by channelId
+    const seen = new Set<string>();
+    const uniqueTargets = matchedTargets.filter(t => {
+      if (seen.has(t.channelId)) return false;
+      seen.add(t.channelId);
+      return true;
+    });
+
+    if (uniqueTargets.length === 0) return;
+
+    const includeActions = rules.some(
+      r => r.type === eventType && r.enabled && r.includeApprovalActions && metadata?.approvalId,
+    );
+
+    const card = includeActions
+      ? buildNotificationCard(title, body, priority, eventType, metadata)
+      : buildSimpleCard(title, body, priority, eventType);
+
+    for (const target of uniqueTargets) {
+      try {
+        if (target.type === 'webhook') {
+          const resp = await fetch(target.channelId, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ msg_type: 'interactive', card }),
+          });
+          if (!resp.ok) {
+            log.warn('Feishu webhook send failed', { channelId: target.channelId, status: resp.status });
+          }
+        } else {
+          await this.apiClient!.sendCard(target.channelId, card);
+        }
+      } catch (err) {
+        log.error('Failed to send Feishu notification', {
+          channelId: target.channelId,
+          error: String(err),
+        });
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: tsk_c687d596
- **关联需求**: req_cc7b4d6313bd66a9500a67e0
- **目标分支**: feature/feishu-integration

## 🎯 背景与动机 (Why)
FeishuNotifier 需要重新实现，将通知推送逻辑从外部 git 仓库迁入 org-manager 包内，直接集成到 api-server 运行时。

## 🔧 变更内容 (What)
- **packages/org-manager/src/feishu-api-client.ts** (new): Feishu Open API 客户端，支持 tenant_access_token 管理 + sendText/sendCard
- **packages/org-manager/src/feishu-notifier.ts** (new): 事件驱动的 Feishu 通知推送器
  - 订阅 EventBus 事件（task:completed, system:announcement, agent lifecycle）
  - 订阅 HITLService 通知（approval_request, task_created 等）
  - 可配置的 forwardRules 路由
  - 支持 chat_id (tenant) 和 webhook 两种目标类型
  - Feishu 交互式卡片（含审批按钮）
- **packages/org-manager/src/api-server.ts** (modified):
  - `tryInitFeishuNotifier()` — 从 integrations 表加载配置并初始化
  - `updateFeishuConfig()` — 运行时更新配置
  - 集成到 setHITLService/setStorage/start/stop 生命周期
  - POST /api/integrations/feishu/config — 同时更新 notifier 运行时配置
  - PUT /api/organizations/:orgId/integrations/feishu/notifications — 同时更新 notifier 规则

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm test 通过（46 files, 722 tests）
- [x] pnpm build 通过

## 👤 评审人
- **Reviewer**: Code Reviewer