### PR TITLE
fix: resolve OAuth login race condition and add missing i18n keys

### DIFF
--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -2026,34 +2026,63 @@ export function ensureHubAuth(method?: string): Promise<void> {
     }
 
     let settled = false;
+    let finalCheckTimer: ReturnType<typeof setInterval> | null = null;
+
+    const statusUrl = () =>
+      `/hub/auth/connect-status?session=${encodeURIComponent(sessionId)}&_t=${Date.now()}`;
+
     const cleanup = () => {
       clearInterval(pollTimer);
       clearInterval(closedTimer);
+      if (finalCheckTimer) clearInterval(finalCheckTimer);
+      document.removeEventListener('visibilitychange', onVisible);
       _hubAuthPromise = null;
     };
 
-    const pollTimer = setInterval(async () => {
+    const handleReady = (data: { token: string; user: HubUser }) => {
       if (settled) return;
+      settled = true;
+      saveHubAuth(data.token, data.user);
+      cleanup();
+      popup?.close();
+      resolve();
+    };
+
+    const pollStatus = async () => {
       try {
-        const data = await request<{ ready?: boolean; token?: string; user?: HubUser }>(
-          `/hub/auth/connect-status?session=${encodeURIComponent(sessionId)}`
-        );
+        const data = await request<{ ready?: boolean; token?: string; user?: HubUser }>(statusUrl());
         if (data.ready && data.token && data.user) {
-          settled = true;
-          saveHubAuth(data.token, data.user);
-          cleanup();
-          popup?.close();
-          resolve();
+          handleReady(data as { token: string; user: HubUser });
         }
       } catch { /* Hub might be offline, keep polling */ }
+    };
+
+    const pollTimer = setInterval(() => {
+      if (settled) return;
+      pollStatus();
     }, 1500);
+
+    const onVisible = () => {
+      if (settled || document.visibilityState !== 'visible') return;
+      pollStatus();
+    };
+    document.addEventListener('visibilitychange', onVisible);
 
     const closedTimer = setInterval(() => {
       if (settled) return;
       if (popup?.closed) {
-        settled = true;
-        cleanup();
-        if (getHubToken()) { resolve(); } else { reject(new Error('Hub login cancelled')); }
+        clearInterval(closedTimer);
+        let retries = 0;
+        finalCheckTimer = setInterval(async () => {
+          if (settled) { clearInterval(finalCheckTimer!); return; }
+          retries++;
+          await pollStatus();
+          if (retries >= 5 && !settled) {
+            settled = true;
+            cleanup();
+            if (getHubToken()) { resolve(); } else { reject(new Error('Hub login cancelled')); }
+          }
+        }, 1000);
       }
     }, 500);
   });

--- a/packages/web-ui/src/locales/en/common.json
+++ b/packages/web-ui/src/locales/en/common.json
@@ -103,6 +103,7 @@
     "hoursAgo": "{{count}}h",
     "daysAgo": "{{count}}d"
   },
+  "signOut": "Sign Out",
   "confirmDelete": "Confirm Delete",
   "userPlaceholder": "User",
   "profile": {

--- a/packages/web-ui/src/locales/zh-CN/common.json
+++ b/packages/web-ui/src/locales/zh-CN/common.json
@@ -103,6 +103,7 @@
     "hoursAgo": "{{count}} 小时前",
     "daysAgo": "{{count}} 天前"
   },
+  "signOut": "退出登录",
   "confirmDelete": "确认删除",
   "userPlaceholder": "用户",
   "profile": {

--- a/packages/web-ui/src/pages/Settings.tsx
+++ b/packages/web-ui/src/pages/Settings.tsx
@@ -943,7 +943,7 @@ export function Settings({ theme, onThemeChange, authUser, onLogout, onUserUpdat
                         className="w-full flex items-center gap-2.5 px-4 py-2 text-sm text-red-500 hover:bg-red-500/10 transition-colors"
                       >
                         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" y1="12" x2="9" y2="12" /></svg>
-                        {t('common:signOut', { defaultValue: 'Sign Out' })}
+                        {t('common:signOut')}
                       </button>
                     )}
                   </div>


### PR DESCRIPTION
Fix a race condition in ensureHubAuth where popup-close detection fires before polling can fetch the auth result, causing successful logins to be silently treated as cancellations. Add cache-busting to status polls, a grace period after popup close, and a visibilitychange listener for mobile tab-switching. Also add the missing common:signOut i18n key so the Settings logout button renders correctly in Chinese.