### PR TITLE
[TASK-tsk_a781a77f][Backend Developer] feat: add team_id support to package_install tool

### DIFF
--- a/packages/core/src/agent-manager.ts
+++ b/packages/core/src/agent-manager.ts
@@ -367,7 +367,7 @@ export class AgentManager {
   private _codingToolsEnabled = false;
   private _codingToolsConfigs?: Record<string, CodingToolConfig>;
   private templateRegistry?: TemplateRegistry;
-  private builderService?: { listArtifacts: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>; installArtifact: (type: 'agent' | 'team' | 'skill', name: string) => Promise<{ type: string; installed: unknown }> };
+  private builderService?: { listArtifacts: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>; installArtifact: (type: 'agent' | 'team' | 'skill', name: string, teamId?: string) => Promise<{ type: string; installed: unknown }> };
   private hubClient?: { search: (opts?: { type?: string; query?: string }) => Promise<Array<{ id: string; name: string; type: string; description: string; author: string; version?: string; downloads?: number }>>; downloadAndInstall: (itemId: string) => Promise<{ type: string; installed: unknown }> };
   private teamUpdater?: (teamId: string, data: { name?: string; description?: string }) => Promise<{ id: string; name: string; description?: string }>;
   private agentConfigPersister?: (agentId: string, data: Record<string, unknown>) => Promise<void>;
@@ -1573,18 +1573,18 @@ export class AgentManager {
       const pkgAh = this.approvalHandler;
       const packageTools = createPackageTools({
         installArtifact: () => this.builderService
-          ? (type: 'agent' | 'team' | 'skill', name: string) => this.builderService!.installArtifact(type, name)
+          ? (type: 'agent' | 'team' | 'skill', name: string, teamId?: string) => this.builderService!.installArtifact(type, name, teamId)
           : undefined,
         listArtifacts: () => this.builderService
           ? (type?: 'agent' | 'team' | 'skill') => this.builderService!.listArtifacts(type)
           : undefined,
         hireFromTemplate: () => this.templateRegistry
-          ? async (templateId: string, name: string, skills?: string[]) => {
+          ? async (templateId: string, name: string, skills?: string[], teamId?: string) => {
               const newAgent = await this.createAgentFromTemplate({
                 templateId,
                 name,
                 orgId: config.orgId ?? 'default',
-                teamId: config.teamId,
+                teamId: teamId || config.teamId,
                 overrides: skills ? { skills } : undefined,
               });
               await this.startAgent(newAgent.id);
@@ -2356,18 +2356,18 @@ export class AgentManager {
       const pkgAh2 = this.approvalHandler;
       const packageTools = createPackageTools({
         installArtifact: () => this.builderService
-          ? (type: 'agent' | 'team' | 'skill', name: string) => this.builderService!.installArtifact(type, name)
+          ? (type: 'agent' | 'team' | 'skill', name: string, teamId?: string) => this.builderService!.installArtifact(type, name, teamId)
           : undefined,
         listArtifacts: () => this.builderService
           ? (type?: 'agent' | 'team' | 'skill') => this.builderService!.listArtifacts(type)
           : undefined,
         hireFromTemplate: () => this.templateRegistry
-          ? async (templateId: string, name: string, skills?: string[]) => {
+          ? async (templateId: string, name: string, skills?: string[], teamId?: string) => {
               const newAgent = await this.createAgentFromTemplate({
                 templateId,
                 name,
                 orgId: config.orgId ?? 'default',
-                teamId: config.teamId,
+                teamId: teamId || config.teamId,
                 overrides: skills ? { skills } : undefined,
               });
               await this.startAgent(newAgent.id);
@@ -2784,7 +2784,7 @@ export class AgentManager {
     return this.templateRegistry;
   }
 
-  setBuilderService(service: { listArtifacts: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>; installArtifact: (type: 'agent' | 'team' | 'skill', name: string) => Promise<{ type: string; installed: unknown }> }): void {
+  setBuilderService(service: { listArtifacts: (type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>; installArtifact: (type: 'agent' | 'team' | 'skill', name: string, teamId?: string) => Promise<{ type: string; installed: unknown }> }): void {
     this.builderService = service;
   }
 

--- a/packages/core/src/tools/manager.ts
+++ b/packages/core/src/tools/manager.ts
@@ -23,9 +23,9 @@ export interface SecretaryToolsContext {
 }
 
 export interface PackageToolsContext {
-  installArtifact?: () => ((type: 'agent' | 'team' | 'skill', name: string) => Promise<{ type: string; installed: unknown }>) | undefined;
+  installArtifact?: () => ((type: 'agent' | 'team' | 'skill', name: string, teamId?: string) => Promise<{ type: string; installed: unknown }>) | undefined;
   listArtifacts?: () => ((type?: 'agent' | 'team' | 'skill') => Array<{ type: string; name: string; description?: string }>) | undefined;
-  hireFromTemplate?: () => ((templateId: string, name: string, skills?: string[]) => Promise<{ id: string; name: string; role: string }>) | undefined;
+  hireFromTemplate?: () => ((templateId: string, name: string, skills?: string[], teamId?: string) => Promise<{ id: string; name: string; role: string }>) | undefined;
   listTemplates?: () => (() => Array<{ id: string; name: string; description: string; roleId: string; category: string }>) | undefined;
   searchHub?: () => ((opts?: { type?: string; query?: string }) => Promise<Array<{ id: string; name: string; type: string; description: string; author: string; version?: string; downloads?: number }>>) | undefined;
   downloadAndInstall?: () => ((itemId: string) => Promise<{ type: string; installed: unknown }>) | undefined;
@@ -83,6 +83,10 @@ export function createPackageTools(ctx: PackageToolsContext): AgentToolHandler[]
           },
           name: { type: 'string', description: 'Package name (from package_list)' },
           agent_name: { type: 'string', description: 'Display name for the new agent (required when installing from a built-in role, e.g. "developer")' },
+          team_id: {
+            type: 'string',
+            description: 'Optional team ID to add the agent to after installation. If omitted, the agent is created without team membership.',
+          },
           skills: {
             type: 'array',
             items: { type: 'string' },
@@ -103,7 +107,7 @@ export function createPackageTools(ctx: PackageToolsContext): AgentToolHandler[]
           if (ctx.requestApproval) {
             const { approved, comment } = await ctx.requestApproval({
               toolName: 'package_install',
-              toolArgs: { type, name, agent_name: args['agent_name'] },
+              toolArgs: { type, name, agent_name: args['agent_name'], team_id: args['team_id'] },
               reason: `Agent wants to install ${type} "${name}" into the organization`,
             });
             if (!approved) return JSON.stringify({ status: 'rejected', reason: comment || 'User denied package installation' });
@@ -111,23 +115,25 @@ export function createPackageTools(ctx: PackageToolsContext): AgentToolHandler[]
 
           if (type === 'agent') {
             try {
-              const result = await installArtifact(type, name);
+              const teamId = (args['team_id'] as string | undefined)?.trim() || undefined;
+              const result = await installArtifact(type, name, teamId);
               return JSON.stringify({
                 status: 'success',
                 ...result,
-                next_steps: 'Installed successfully. Next: onboard new agent with project context via agent_send_message, then assign tasks via task_create.',
+                next_steps: teamId ? `Installed successfully. Agent added to team ${teamId}. Next: onboard with project context via agent_send_message, then assign tasks via task_create.` : 'Installed successfully. Next: onboard new agent with project context via agent_send_message, then assign tasks via task_create.',
               });
             } catch {
               const hireFromTemplate = ctx.hireFromTemplate?.();
               if (hireFromTemplate) {
                 const agentName = (args['agent_name'] as string | undefined)?.trim();
                 if (!agentName) return JSON.stringify({ status: 'error', error: 'agent_name is required when installing from a built-in role — provide a display name for the new agent' });
-                const result = await hireFromTemplate(name, agentName, args['skills'] as string[] | undefined);
+                const teamId = (args['team_id'] as string | undefined)?.trim() || undefined;
+                const result = await hireFromTemplate(name, agentName, args['skills'] as string[] | undefined, teamId);
                 return JSON.stringify({
                   status: 'success',
                   type: 'agent',
                   agent: result,
-                  next_steps: 'Agent hired and started. Next: onboard with project context via agent_send_message, then assign tasks via task_create.',
+                  next_steps: teamId ? `Agent hired and added to team ${teamId}. Next: onboard with project context via agent_send_message, then assign tasks via task_create.` : 'Agent hired and started. Next: onboard with project context via agent_send_message, then assign tasks via task_create.',
                 });
               }
               throw new Error(`Agent package not found: ${name}. Use package_list to see available packages.`);

--- a/packages/org-manager/src/builder-service.ts
+++ b/packages/org-manager/src/builder-service.ts
@@ -99,7 +99,7 @@ export class BuilderService {
     return artifacts;
   }
 
-  async installArtifact(type: 'agent' | 'team' | 'skill', name: string): Promise<InstallResult> {
+  async installArtifact(type: 'agent' | 'team' | 'skill', name: string, teamId?: string): Promise<InstallResult> {
     const typeDir = type === 'agent' ? 'agents' : type === 'team' ? 'teams' : 'skills';
     let artDir = join(this.baseDir, typeDir, name);
 
@@ -130,7 +130,7 @@ export class BuilderService {
     const mfName = manifestFilename(installType);
 
     if (type === 'agent') {
-      return this.installAgent(artDir, manifest, mfName, name);
+      return this.installAgent(artDir, manifest, mfName, name, teamId);
     } else if (type === 'team') {
       return this.installTeam(artDir, manifest, mfName, name);
     } else {
@@ -143,6 +143,7 @@ export class BuilderService {
     manifest: MarkusPackageManifest,
     mfName: string,
     artifactName: string,
+    teamId?: string,
   ): Promise<InstallResult> {
     const agentManager = this.orgService.getAgentManager();
     const agentName = manifest.displayName ?? manifest.name ?? artifactName;
@@ -154,6 +155,7 @@ export class BuilderService {
       name: agentName,
       roleName: manifest.agent?.roleName || (hasCustomRole ? 'custom' : 'developer'),
       orgId: 'default',
+      teamId,
       agentRole,
       skills,
       skipAutoStart: true,


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: tsk_a781a77f
- **目标分支**: main

## 🎯 背景与动机
Currently `package_install` creates agents without team membership. Users must make a separate call to add the agent to a team after installation. This adds an optional `team_id` parameter so the agent can be directly placed into a team.

## 🔧 变更内容
3 files modified (+25/-17):
- `packages/org-manager/src/builder-service.ts`: `installArtifact`/`installAgent` accept optional `teamId`, forward to `hireAgent`
- `packages/core/src/agent-manager.ts`: All `installArtifact`/`hireFromTemplate` getters forward `teamId`
- `packages/core/src/tools/manager.ts`: `package_install` tool schema + both code paths pass `team_id`

## ✅ 验证
- [x] pnpm typecheck: ✅ Clean (no new errors from changed files)
- [x] All changes are backward-compatible (optional parameter)

## 👤 评审人
- **Reviewer**: Code Reviewer (agt_42fc22d8cd79900a089eea09)