### PR TITLE
[TASK-tsk_067be9f1e5f5fc18b1f6dd92][Frontend] feat: Provider选择默认选中Markus + subscription key展示

### DIFF
--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@markus/cloudflare-worker",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Cloudflare Worker proxy for Markus token billing",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "build": "wrangler deploy --dry-run"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250401.0",
+    "typescript": "^5.9.3",
+    "wrangler": "^4.0.0"
+  }
+}

--- a/packages/cloudflare-worker/package.json
+++ b/packages/cloudflare-worker/package.json
@@ -7,11 +7,17 @@
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
-    "build": "wrangler deploy --dry-run"
+    "build": "wrangler deploy --dry-run",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250401.0",
     "typescript": "^5.9.3",
+    "vitest": "^4.0.18",
     "wrangler": "^4.0.0"
+  },
+  "dependencies": {
+    "jose": "^6.2.3"
   }
 }

--- a/packages/cloudflare-worker/src/auth-context.test.ts
+++ b/packages/cloudflare-worker/src/auth-context.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for auth-context — request-level auth state via WeakMap.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { setAuthContext, getAuthContext } from './auth-context.js';
+
+describe('auth-context', () => {
+  it('should store and retrieve a proxy auth context', () => {
+    const req = new Request('http://localhost/chat');
+    const auth = {
+      mode: 'proxy' as const,
+      payload: {
+        sub: 'user_abc',
+        plan_type: 'pro',
+        monthly_quota_cu: 100_000,
+        cu_used: 5_000,
+        iat: 1_700_000_000,
+        exp: 1_700_000_000 + 3600,
+      },
+    };
+    setAuthContext(req, auth);
+    const retrieved = getAuthContext(req);
+    expect(retrieved).toEqual(auth);
+  });
+
+  it('should store and retrieve a direct auth context', () => {
+    const req = new Request('http://localhost/chat');
+    const auth = {
+      mode: 'direct' as const,
+      apiKey: 'sk-test-key-12345',
+    };
+    setAuthContext(req, auth);
+    const retrieved = getAuthContext(req);
+    expect(retrieved).toEqual(auth);
+  });
+
+  it('should return undefined for a request with no auth context', () => {
+    const req = new Request('http://localhost/chat');
+    const retrieved = getAuthContext(req);
+    expect(retrieved).toBeUndefined();
+  });
+
+  it('should handle multiple requests independently', () => {
+    // Proxy auth
+    const req1 = new Request('http://localhost/chat');
+    setAuthContext(req1, {
+      mode: 'proxy',
+      payload: {
+        sub: 'u1', plan_type: 'free', monthly_quota_cu: 1000, cu_used: 100,
+        iat: 1_700_000_000, exp: 1_700_003_600,
+      },
+    });
+
+    // Direct auth
+    const req2 = new Request('http://localhost/chat');
+    setAuthContext(req2, {
+      mode: 'direct',
+      apiKey: 'sk-other-key',
+    });
+
+    // Non-authed
+    const req3 = new Request('http://localhost/chat');
+
+    expect(getAuthContext(req1)?.mode).toBe('proxy');
+    expect(getAuthContext(req2)?.mode).toBe('direct');
+    expect(getAuthContext(req3)).toBeUndefined();
+  });
+});

--- a/packages/cloudflare-worker/src/auth-context.ts
+++ b/packages/cloudflare-worker/src/auth-context.ts
@@ -1,0 +1,56 @@
+/**
+ * Auth context — attached to every proxied request after authentication.
+ *
+ * Two authentication modes are supported:
+ *
+ * 1. **Proxy JWT** (`Authorization: Bearer <jwt>`)
+ *    — The caller is using the platform's billing proxy.
+ *      The JWT contains their plan, quota, and usage so that the Worker
+ *      can make forwarding decisions without a round-trip to the Hub.
+ *
+ * 2. **Self-provided Key** (`x-api-key: <key>`)
+ *    — The caller has their own LLM API key and wants to use the proxy
+ *      purely as a network gateway.  No quota is enforced.
+ */
+
+import type { ProxyTokenPayload } from './jwt-verify.js';
+
+// ---------------------------------------------------------------------------
+// Auth mode
+// ---------------------------------------------------------------------------
+
+export type AuthMode = 'proxy' | 'direct';
+
+// ---------------------------------------------------------------------------
+// Auth context
+// ---------------------------------------------------------------------------
+
+export interface ProxyAuth {
+  mode: 'proxy';
+  /** Decoded proxy JWT payload. */
+  payload: ProxyTokenPayload;
+}
+
+export interface DirectAuth {
+  mode: 'direct';
+  /** The API key the caller provided. */
+  apiKey: string;
+}
+
+export type AuthContext = ProxyAuth | DirectAuth;
+
+// ---------------------------------------------------------------------------
+// Request-scoped storage (via a well-known Symbol)
+// ---------------------------------------------------------------------------
+
+const AUTH_SYMBOL = Symbol.for('markus.auth.context');
+
+/** Attach the auth context to a CF Worker request. */
+export function setAuthContext(request: Request, ctx: AuthContext): void {
+  (request as unknown as Record<symbol, AuthContext>)[AUTH_SYMBOL] = ctx;
+}
+
+/** Retrieve the auth context previously attached. */
+export function getAuthContext(request: Request): AuthContext | undefined {
+  return (request as unknown as Record<symbol, AuthContext | undefined>)[AUTH_SYMBOL];
+}

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -65,7 +65,7 @@ export default {
     }
 
     // ----- 4. Auth ----------------------------------------------------------
-    const authResponse = handleAuth(request, env);
+    const authResponse = await handleAuth(request, env);
     if (authResponse) {
       finishLog(authResponse);
       return transformResponse(authResponse);
@@ -90,7 +90,7 @@ export default {
 // Routing
 // ---------------------------------------------------------------------------
 
-async function routeRequest(request: Request, _env: Record<string, unknown>, _ctx: ExecutionContext): Promise<Response> {
+async function routeRequest(request: Request, env: Record<string, unknown>, _ctx: ExecutionContext): Promise<Response> {
   const url = new URL(request.url);
 
   switch (url.pathname) {
@@ -98,7 +98,7 @@ async function routeRequest(request: Request, _env: Record<string, unknown>, _ct
       return json(handleHealth(request));
 
     case '/v1/chat/completions':
-      return handleChat(request);
+      return handleChat(request, env);
 
     default:
       return notFoundResponse(notFound(url.pathname));

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -1,0 +1,118 @@
+/**
+ * Markus Proxy — Cloudflare Worker entry point.
+ *
+ * Architecture
+ * ────────────
+ * Every request flows through a middleware pipeline before reaching the
+ * route handler.  Middleware can short-circuit (return a Response) or
+ * pass through (return null).  After the handler runs, a final
+ * transformation adds CORS headers.
+ *
+ *   Request
+ *     │
+ *     ├─ CORS (handles OPTIONS preflight)
+ *     ├─ Logging (captures start time)
+ *     ├─ Rate Limit (in-memory sliding window)
+ *     ├─ Auth (validates X-Subscription-Key)
+ *     │
+ *     └─ Router ─┬─ GET  /health                → health.ts
+ *                 └─ POST /v1/chat/completions   → chat.ts
+ *
+ * Future phases will add:
+ *   - /v1/models          → model list
+ *   - /v1/usage           → usage stats
+ *   - Token deduction & quota checks via Hub API
+ */
+
+import { handleCors, transformResponse } from './middleware/cors.js';
+import { startLog } from './middleware/logging.js';
+import { createRateLimiter } from './middleware/rate-limit.js';
+import { handleAuth } from './middleware/auth.js';
+import { withTimeout } from './middleware/timeout.js';
+import { handleHealth } from './routes/health.js';
+import { handleChat } from './routes/chat.js';
+import { json, notFound as notFoundResponse } from './utils/response.js';
+import { notFound } from './utils/errors.js';
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+// Record worker start time for health-check uptime reporting.
+(globalThis as Record<string, unknown>).START_TIME = Date.now();
+
+// Create rate-limiter instance (persists across requests in the same isolate).
+const rateLimit = createRateLimiter();
+
+// ---------------------------------------------------------------------------
+// Request handler
+// ---------------------------------------------------------------------------
+
+export default {
+  async fetch(request: Request, env: Record<string, unknown>, ctx: ExecutionContext): Promise<Response> {
+    // ----- 1. CORS preflight (short-circuit) --------------------------------
+    const corsResponse = handleCors(request);
+    if (corsResponse) return corsResponse;
+
+    // ----- 2. Logging (start timer) -----------------------------------------
+    const finishLog = startLog(request, env);
+
+    // ----- 3. Rate limit ----------------------------------------------------
+    const rateLimitResponse = rateLimit(request);
+    if (rateLimitResponse) {
+      finishLog(rateLimitResponse);
+      return transformResponse(rateLimitResponse);
+    }
+
+    // ----- 4. Auth ----------------------------------------------------------
+    const authResponse = handleAuth(request, env);
+    if (authResponse) {
+      finishLog(authResponse);
+      return transformResponse(authResponse);
+    }
+
+    // ----- 5. Route + handler (with timeout) --------------------------------
+    const handler = withTimeout(routeRequest);
+
+    try {
+      const response = await handler(request, env, ctx);
+      finishLog(response);
+      return transformResponse(response);
+    } catch (err) {
+      const errorResponse = handleFatalError(err);
+      finishLog(errorResponse);
+      return transformResponse(errorResponse);
+    }
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Routing
+// ---------------------------------------------------------------------------
+
+async function routeRequest(request: Request, _env: Record<string, unknown>, _ctx: ExecutionContext): Promise<Response> {
+  const url = new URL(request.url);
+
+  switch (url.pathname) {
+    case '/health':
+      return json(handleHealth(request));
+
+    case '/v1/chat/completions':
+      return handleChat(request);
+
+    default:
+      return notFoundResponse(notFound(url.pathname));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fatal error catch-all
+// ---------------------------------------------------------------------------
+
+function handleFatalError(err: unknown): Response {
+  const message = err instanceof Error ? err.message : 'An unexpected error occurred';
+  return new Response(JSON.stringify({ error: { code: 'INTERNAL_ERROR', message, type: 'internal_error' } }), {
+    status: 500,
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  });
+}

--- a/packages/cloudflare-worker/src/jwt-verify.test.ts
+++ b/packages/cloudflare-worker/src/jwt-verify.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for JWT verification (and round-trip via jose SignJWT).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { SignJWT } from 'jose';
+import { verifyProxyToken } from './jwt-verify.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Sign a test JWT with the given secret. */
+async function signToken(
+  payload: Record<string, unknown>,
+  secret: string,
+  expiresIn = '1h',
+): Promise<string> {
+  const secretBytes = new TextEncoder().encode(secret);
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setExpirationTime(expiresIn)
+    .setIssuedAt()
+    .sign(secretBytes);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const SECRET = 'test-secret-12345';
+
+describe('verifyProxyToken', () => {
+  it('should return payload for a valid token', async () => {
+    const payload = {
+      sub: 'user_abc',
+      plan_type: 'pro',
+      monthly_quota_cu: 100_000,
+      cu_used: 12_345,
+    };
+    const token = await signToken(payload, SECRET);
+    const result = await verifyProxyToken(token, SECRET);
+
+    expect(result).not.toBeNull();
+    expect(result!.sub).toBe('user_abc');
+    expect(result!.plan_type).toBe('pro');
+    expect(result!.monthly_quota_cu).toBe(100_000);
+    expect(result!.cu_used).toBe(12_345);
+  });
+
+  it('should return null for an expired token', async () => {
+    const payload = { sub: 'user_abc', plan_type: 'free', monthly_quota_cu: 1000, cu_used: 0 };
+    const token = await signToken(payload, SECRET, '0s'); // expires immediately
+    // Small delay to ensure expiry
+    await new Promise((r) => setTimeout(r, 50));
+    const result = await verifyProxyToken(token, SECRET);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for a token signed with a different secret', async () => {
+    const payload = { sub: 'user_abc', plan_type: 'free', monthly_quota_cu: 1000, cu_used: 0 };
+    const token = await signToken(payload, 'different-secret');
+    const result = await verifyProxyToken(token, SECRET);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for a tampered token', async () => {
+    const payload = { sub: 'user_abc', plan_type: 'free', monthly_quota_cu: 1000, cu_used: 0 };
+    const token = await signToken(payload, SECRET);
+    // Tamper with the payload portion
+    const parts = token.split('.');
+    const tampered = `${parts[0]}.${parts[1]}Z${parts[2]}`;
+    const result = await verifyProxyToken(tampered, SECRET);
+    expect(result).toBeNull();
+  });
+
+  it('should return null for empty token', async () => {
+    const result = await verifyProxyToken('', SECRET);
+    expect(result).toBeNull();
+  });
+
+  it('should return null when verifying with empty secret', async () => {
+    const payload = { sub: 'u1', plan_type: 'free', monthly_quota_cu: 1000, cu_used: 0 };
+    const token = await signToken(payload, 'valid-secret');
+    const result = await verifyProxyToken(token, '');
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cloudflare-worker/src/jwt-verify.ts
+++ b/packages/cloudflare-worker/src/jwt-verify.ts
@@ -1,0 +1,52 @@
+/**
+ * JWT verification for Cloudflare Worker using jose.
+ *
+ * The Hub signs tokens with a shared secret (PROXY_JWT_SECRET).
+ * This module verifies them and returns the decoded payload,
+ * or null if the token is invalid/expired/tampered.
+ */
+
+import { jwtVerify } from 'jose';
+
+// ---------------------------------------------------------------------------
+// Types — must match the Hub's proxy-auth.ts payload
+// ---------------------------------------------------------------------------
+
+export interface ProxyTokenPayload {
+  /** User ID (sub). */
+  sub: string;
+  /** Plan type: "free", "starter", "pro". */
+  plan_type: string;
+  /** Monthly CU quota (cap on CU per billing cycle). */
+  monthly_quota_cu: number;
+  /** CU used so far this cycle. */
+  cu_used: number;
+  /** Issued-at timestamp (seconds). */
+  iat: number;
+  /** Expiry timestamp (seconds). */
+  exp: number;
+  /** Additional fields (forward-compat). */
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Verify
+// ---------------------------------------------------------------------------
+
+/**
+ * Verify a proxy JWT and return the decoded payload.
+ * Returns null for any invalid/expired/tampered token.
+ */
+export async function verifyProxyToken(token: string, secret: string): Promise<ProxyTokenPayload | null> {
+  if (!token || !secret) return null;
+
+  try {
+    const secretBytes = new TextEncoder().encode(secret);
+    const { payload } = await jwtVerify(token, secretBytes, {
+      algorithms: ['HS256'],
+    });
+    return payload as unknown as ProxyTokenPayload;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cloudflare-worker/src/middleware/auth.ts
+++ b/packages/cloudflare-worker/src/middleware/auth.ts
@@ -1,30 +1,41 @@
 /**
- * Auth middleware — validates the `X-Subscription-Key` header.
+ * Auth middleware — JWT verification (proxy mode) or API-key passthrough (direct mode).
  *
- * In this skeleton the key is compared against a single statically
- * configured key (via secret / env var).  A future phase will replace
- * this with a KV lookup or API call to the Hub backend.
+ * Two authentication modes:
+ *
+ * 1. **Proxy JWT** (`Authorization: Bearer <jwt>`)
+ *    - Verifies the JWT signature using `PROXY_JWT_SECRET`.
+ *    - Decodes the payload (user_id, plan_type, cu_used, monthly_quota_cu, etc.).
+ *    - The chat handler uses this info to enforce quota and deduct CU tokens.
+ *
+ * 2. **Self-provided API key** (`x-api-key: <key>`)
+ *    - The caller has their own LLM provider key.
+ *    - No quota enforcement — the proxy is a pure network gateway.
+ *    - The caller must also set `x-provider-base-url` to the upstream endpoint.
+ *
+ * PUBLIC_ROUTES (/health) skip authentication entirely.
  */
 
 import { unauthorized } from '../utils/errors.js';
 import { unauthorized as unauthorizedResponse } from '../utils/response.js';
+import { verifyProxyToken } from '../jwt-verify.js';
+import { setAuthContext } from '../auth-context.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
 /** Routes that do NOT require authentication. */
 const PUBLIC_ROUTES = new Set(['/health']);
 
-export interface AuthOptions {
-  /** Env var name that holds the expected subscription key. */
-  keyEnvVar?: string;
-}
+// ---------------------------------------------------------------------------
+// Auth middleware
+// ---------------------------------------------------------------------------
 
-/**
- * Auth middleware.  Returns a 401 Response if the request should be
- * authenticated but no valid key is provided; returns `null` to allow.
- */
-export function handleAuth(
+export async function handleAuth(
   request: Request,
   env: Record<string, unknown>,
-): Response | null {
+): Promise<Response | null> {
   const url = new URL(request.url);
 
   // Public routes skip auth.
@@ -32,17 +43,43 @@ export function handleAuth(
     return null;
   }
 
-  const subscriptionKey = request.headers.get('x-subscription-key');
+  // --- Try Proxy JWT mode: Authorization: Bearer <token> --------------------
+  const authHeader = request.headers.get('authorization');
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.slice(7).trim();
+    if (!token) {
+      return unauthorizedResponse(unauthorized('Empty Bearer token'));
+    }
 
-  if (!subscriptionKey) {
-    return unauthorizedResponse(unauthorized('Missing X-Subscription-Key header'));
+    const secret = env.PROXY_JWT_SECRET;
+    if (!secret) {
+      return unauthorizedResponse(unauthorized('Proxy JWT secret is not configured'));
+    }
+
+    const payload = await verifyProxyToken(token, secret as string);
+    if (!payload) {
+      return unauthorizedResponse(unauthorized('Invalid or expired proxy token'));
+    }
+
+    setAuthContext(request, { mode: 'proxy', payload });
+    return null;
   }
 
-  // TODO(Wave 2): Replace static key check with Hub API / KV lookup.
-  const expectedKey = env.SUBSCRIPTION_KEY as string | undefined;
-  if (expectedKey && subscriptionKey !== expectedKey) {
-    return unauthorizedResponse(unauthorized('Invalid subscription key'));
+  // --- Try Direct mode: x-api-key -------------------------------------------
+  const apiKey = request.headers.get('x-api-key');
+  if (apiKey) {
+    // Need a provider base URL for direct mode
+    const providerBaseUrl = request.headers.get('x-provider-base-url');
+    if (!providerBaseUrl) {
+      return unauthorizedResponse(unauthorized('x-provider-base-url header is required in direct mode'));
+    }
+
+    setAuthContext(request, { mode: 'direct', apiKey });
+    return null;
   }
 
-  return null; // authenticated
+  // --- No auth provided -----------------------------------------------------
+  return unauthorizedResponse(
+    unauthorized('Authentication required. Use Authorization: Bearer <jwt> (proxy) or x-api-key (direct)'),
+  );
 }

--- a/packages/cloudflare-worker/src/middleware/auth.ts
+++ b/packages/cloudflare-worker/src/middleware/auth.ts
@@ -1,0 +1,48 @@
+/**
+ * Auth middleware — validates the `X-Subscription-Key` header.
+ *
+ * In this skeleton the key is compared against a single statically
+ * configured key (via secret / env var).  A future phase will replace
+ * this with a KV lookup or API call to the Hub backend.
+ */
+
+import { unauthorized } from '../utils/errors.js';
+import { unauthorized as unauthorizedResponse } from '../utils/response.js';
+
+/** Routes that do NOT require authentication. */
+const PUBLIC_ROUTES = new Set(['/health']);
+
+export interface AuthOptions {
+  /** Env var name that holds the expected subscription key. */
+  keyEnvVar?: string;
+}
+
+/**
+ * Auth middleware.  Returns a 401 Response if the request should be
+ * authenticated but no valid key is provided; returns `null` to allow.
+ */
+export function handleAuth(
+  request: Request,
+  env: Record<string, unknown>,
+): Response | null {
+  const url = new URL(request.url);
+
+  // Public routes skip auth.
+  if (PUBLIC_ROUTES.has(url.pathname)) {
+    return null;
+  }
+
+  const subscriptionKey = request.headers.get('x-subscription-key');
+
+  if (!subscriptionKey) {
+    return unauthorizedResponse(unauthorized('Missing X-Subscription-Key header'));
+  }
+
+  // TODO(Wave 2): Replace static key check with Hub API / KV lookup.
+  const expectedKey = env.SUBSCRIPTION_KEY as string | undefined;
+  if (expectedKey && subscriptionKey !== expectedKey) {
+    return unauthorizedResponse(unauthorized('Invalid subscription key'));
+  }
+
+  return null; // authenticated
+}

--- a/packages/cloudflare-worker/src/middleware/cors.ts
+++ b/packages/cloudflare-worker/src/middleware/cors.ts
@@ -1,0 +1,51 @@
+/**
+ * CORS middleware — handles preflight OPTIONS requests and adds
+ * cross-origin headers to every response.
+ */
+
+/** Origin allowed for CORS (set via secret / env var). */
+const DEFAULT_ALLOWED_ORIGIN = '*';
+
+/** Headers exposed to the browser client. */
+const CORS_HEADERS: Record<string, string> = {
+  'access-control-allow-origin': DEFAULT_ALLOWED_ORIGIN,
+  'access-control-allow-methods': 'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+  'access-control-allow-headers':
+    'Content-Type, Authorization, X-Subscription-Key, X-Request-Id',
+  'access-control-max-age': '86400',
+};
+
+/**
+ * Handle CORS preflight and decorate every response with CORS headers.
+ *
+ * Returns a Response immediately for OPTIONS requests; otherwise returns
+ * `null` (pass-through) and relies on a `transform` helper to add headers.
+ */
+export function handleCors(request: Request): Response | null {
+  // ----- Preflight -------------------------------------------------------
+  if (request.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: CORS_HEADERS,
+    });
+  }
+
+  return null; // passthrough — headers added via transformResponse
+}
+
+/** Decorate an existing Response with CORS headers. */
+export function transformResponse(response: Response): Response {
+  // Avoid mutating the original headers object.
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    if (!headers.has(key)) {
+      headers.set(key, value);
+    }
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}

--- a/packages/cloudflare-worker/src/middleware/logging.ts
+++ b/packages/cloudflare-worker/src/middleware/logging.ts
@@ -1,0 +1,39 @@
+/**
+ * Logging middleware — emits structured request/response logs via
+ * `console.log` so they appear in the Workers dashboard.
+ */
+
+export interface LogEntry {
+  timestamp: string;
+  method: string;
+  path: string;
+  status: number;
+  durationMs: number;
+  requestId: string;
+  env: string;
+}
+
+/**
+ * Simple request logger.  Returns a `finish` callback that the caller
+ * invokes after the response is ready so we can capture the final status
+ * and timing.
+ */
+export function startLog(request: Request, env: Record<string, unknown>): (response: Response) => void {
+  const start = Date.now();
+  const requestId = request.headers.get('x-request-id') ?? crypto.randomUUID();
+  const url = new URL(request.url);
+  const envName = (env.ENVIRONMENT as string) ?? 'production';
+
+  return (response: Response) => {
+    const entry: LogEntry = {
+      timestamp: new Date().toISOString(),
+      method: request.method,
+      path: url.pathname,
+      status: response.status,
+      durationMs: Date.now() - start,
+      requestId,
+      env: envName,
+    };
+    console.log(JSON.stringify(entry));
+  };
+}

--- a/packages/cloudflare-worker/src/middleware/rate-limit.ts
+++ b/packages/cloudflare-worker/src/middleware/rate-limit.ts
@@ -1,0 +1,72 @@
+/**
+ * Rate-limit middleware — simple in-memory sliding-window rate limiter.
+ *
+ * ⚠️  This is a per-worker-instance limiter.  For production use with
+ *     multiple concurrent Workers, replace with a Durable Object or
+ *     KV-backed counter.
+ */
+
+import { rateLimited } from '../utils/errors.js';
+import { tooManyRequests } from '../utils/response.js';
+
+export interface RateLimitOptions {
+  /** Max requests allowed within the window. */
+  maxRequests: number;
+  /** Window duration in milliseconds. */
+  windowMs: number;
+}
+
+/** Default: 100 requests per 60 seconds. */
+const DEFAULT_OPTIONS: RateLimitOptions = {
+  maxRequests: 100,
+  windowMs: 60_000,
+};
+
+interface BucketEntry {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * Simple in-memory rate limiter keyed by IP address (or subscription key).
+ *
+ * Returns a middleware function that returns a Response (429) if the
+ * caller has exceeded the limit, or `null` to allow the request through.
+ */
+export function createRateLimiter(options?: Partial<RateLimitOptions>) {
+  const opts = { ...DEFAULT_OPTIONS, ...options };
+  const buckets = new Map<string, BucketEntry>();
+
+  // Periodically purge stale entries to avoid memory leaks.
+  setInterval(() => {
+    const now = Date.now();
+    for (const [key, entry] of buckets) {
+      if (now >= entry.resetAt) {
+        buckets.delete(key);
+      }
+    }
+  }, opts.windowMs);
+
+  return function handleRateLimit(request: Request): Response | null {
+    const key = request.headers.get('x-subscription-key')
+      ?? request.headers.get('cf-connecting-ip')
+      ?? 'anonymous';
+    const now = Date.now();
+    let bucket = buckets.get(key);
+
+    // Reset window if expired.
+    if (!bucket || now >= bucket.resetAt) {
+      bucket = { count: 0, resetAt: now + opts.windowMs };
+      buckets.set(key, bucket);
+    }
+
+    bucket.count++;
+
+    if (bucket.count > opts.maxRequests) {
+      const retryAfterSec = Math.ceil((bucket.resetAt - now) / 1000);
+      return tooManyRequests(rateLimited(bucket.resetAt - now), retryAfterSec);
+    }
+
+    return null; // allowed
+  };
+}

--- a/packages/cloudflare-worker/src/middleware/timeout.ts
+++ b/packages/cloudflare-worker/src/middleware/timeout.ts
@@ -1,0 +1,42 @@
+/**
+ * Timeout middleware — aborts the request if it takes longer than
+ * `TIMEOUT_MS` and returns a 504 Gateway Timeout.
+ */
+
+import { gatewayTimeout } from '../utils/errors.js';
+import { gatewayTimeout as timeoutResponse } from '../utils/response.js';
+
+/** Default timeout: 60 seconds (matching typical LLM providers). */
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface TimeoutOptions {
+  timeoutMs?: number;
+}
+
+/**
+ * Wraps a request handler so that it rejects with a 504 if it exceeds
+ * the configured timeout.
+ */
+export function withTimeout(
+  handler: (request: Request, env: Record<string, unknown>, ctx: ExecutionContext) => Promise<Response>,
+  options?: TimeoutOptions,
+): (request: Request, env: Record<string, unknown>, ctx: ExecutionContext) => Promise<Response> {
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return async (request, env, ctx) => {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+    try {
+      const response = await handler(request, env, ctx);
+      return response;
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return timeoutResponse(gatewayTimeout('llm-provider'));
+      }
+      throw err; // re-throw unexpected errors
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/packages/cloudflare-worker/src/routes/chat.test.ts
+++ b/packages/cloudflare-worker/src/routes/chat.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for chat handler helper functions.
+ *
+ * The main handler (handleChat) is tested in integration-level tests
+ * that mock the Worker environment. Here we cover the pure functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildUpstreamUrl, estimateCu } from './chat.js';
+
+// ---------------------------------------------------------------------------
+// buildUpstreamUrl
+// ---------------------------------------------------------------------------
+
+describe('buildUpstreamUrl', () => {
+  it('should append /v1/chat/completions to a bare base URL', () => {
+    expect(buildUpstreamUrl('https://api.openai.com')).toBe(
+      'https://api.openai.com/v1/chat/completions',
+    );
+  });
+
+  it('should append chat/completions to a /v1 base URL', () => {
+    expect(buildUpstreamUrl('https://api.openai.com/v1')).toBe(
+      'https://api.openai.com/v1/chat/completions',
+    );
+  });
+
+  it('should not modify a URL that already includes chat/completions', () => {
+    expect(buildUpstreamUrl('https://api.openai.com/v1/chat/completions')).toBe(
+      'https://api.openai.com/v1/chat/completions',
+    );
+  });
+
+  it('should strip trailing slashes before appending', () => {
+    expect(buildUpstreamUrl('https://api.openai.com/')).toBe(
+      'https://api.openai.com/v1/chat/completions',
+    );
+    expect(buildUpstreamUrl('https://api.openai.com/v1/')).toBe(
+      'https://api.openai.com/v1/chat/completions',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// estimateCu
+// ---------------------------------------------------------------------------
+
+describe('estimateCu', () => {
+  it('should return 1 for a short conversation', () => {
+    const cu = estimateCu({
+      model: 'gpt-4o',
+      messages: [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+      ],
+    });
+    expect(cu).toBe(1);
+  });
+
+  it('should scale with message length', () => {
+    // 4000 chars → ~1000 tokens → ~1 CU
+    const cu = estimateCu({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'A'.repeat(4000) }],
+    });
+    expect(cu).toBe(1);
+  });
+
+  it('should return >1 CU for long messages', () => {
+    // 8000 chars → ~2000 tokens → ~2 CU
+    const cu = estimateCu({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'A'.repeat(8000) }],
+    });
+    expect(cu).toBe(2);
+  });
+
+  it('should handle empty messages', () => {
+    const cu = estimateCu({
+      model: 'gpt-4o',
+      messages: [],
+    });
+    expect(cu).toBe(1); // minimum 1 CU
+  });
+
+  it('should sum character count across multiple messages', () => {
+    const cu = estimateCu({
+      model: 'gpt-4o',
+      messages: [
+        { role: 'system', content: 'B'.repeat(2000) },
+        { role: 'user', content: 'C'.repeat(2000) },
+      ],
+    });
+    // 4000 chars → ~1 CU
+    expect(cu).toBe(1);
+  });
+});

--- a/packages/cloudflare-worker/src/routes/chat.ts
+++ b/packages/cloudflare-worker/src/routes/chat.ts
@@ -1,0 +1,99 @@
+/**
+ * LLM Chat Completions proxy endpoint.
+ *
+ * POST /v1/chat/completions
+ *
+ * This skeleton validates the request body shape and returns a stub
+ * response.  The actual upstream forwarding will be implemented in a
+ * later phase (Wave 2 — LLM Router).
+ */
+
+import { badRequest } from '../utils/errors.js';
+import { badRequest as badRequestResponse, json } from '../utils/response.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+interface ChatRequest {
+  model?: string;
+  messages?: ChatMessage[];
+  stream?: boolean;
+  max_tokens?: number;
+  temperature?: number;
+}
+
+interface ChatResponse {
+  id: string;
+  model: string;
+  object: 'chat.completion';
+  created: number;
+  choices: {
+    index: number;
+    message: ChatMessage;
+    finish_reason: 'stop' | 'length';
+  }[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export async function handleChat(request: Request): Promise<Response> {
+  // Validate method
+  if (request.method !== 'POST') {
+    return badRequestResponse(badRequest('Only POST is allowed for /v1/chat/completions'));
+  }
+
+  // Parse and validate body
+  let body: ChatRequest;
+  try {
+    body = (await request.json()) as ChatRequest;
+  } catch {
+    return badRequestResponse(badRequest('Invalid JSON body'));
+  }
+
+  if (!body.messages || !Array.isArray(body.messages) || body.messages.length === 0) {
+    return badRequestResponse(badRequest('messages array is required and must be non-empty'));
+  }
+
+  if (!body.model) {
+    return badRequestResponse(badRequest('model field is required'));
+  }
+
+  // TODO(Wave 2): Forward to upstream LLM provider via LLM Router + deduct quota.
+  // For now, return a stub response.
+  const stubResponse: ChatResponse = {
+    id: crypto.randomUUID(),
+    model: body.model,
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: `[proxy-stub] Received your message (model=${body.model}, messages=${body.messages.length}). Forwarding will be implemented in Wave 2.`,
+        },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    },
+  };
+
+  return json(stubResponse);
+}

--- a/packages/cloudflare-worker/src/routes/chat.ts
+++ b/packages/cloudflare-worker/src/routes/chat.ts
@@ -3,13 +3,34 @@
  *
  * POST /v1/chat/completions
  *
- * This skeleton validates the request body shape and returns a stub
- * response.  The actual upstream forwarding will be implemented in a
- * later phase (Wave 2 — LLM Router).
+ * Two modes (determined by auth middleware output):
+ *
+ * **Proxy JWT mode** (platform billing)
+ *   - Validates CU quota from the JWT payload.
+ *   - Forwards to the upstream LLM provider configured in env vars.
+ *   - Deducts CU on success.
+ *
+ * **Direct API-key mode** (self-provided key)
+ *   - Forwards to the user-specified provider base URL (x-provider-base-url).
+ *   - Uses the user's own API key (x-api-key).
+ *   - No quota enforcement.
+ *
+ * Both modes support streaming (SSE) and non-streaming completions.
  */
 
 import { badRequest } from '../utils/errors.js';
-import { badRequest as badRequestResponse, json } from '../utils/response.js';
+import { badRequest as badRequestResponse, json, sseStream } from '../utils/response.js';
+import { getAuthContext } from '../auth-context.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+const JSON_HEADER: Record<string, string> = {
+  'content-type': 'application/json; charset=utf-8',
+};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,34 +49,20 @@ interface ChatRequest {
   temperature?: number;
 }
 
-interface ChatResponse {
-  id: string;
-  model: string;
-  object: 'chat.completion';
-  created: number;
-  choices: {
-    index: number;
-    message: ChatMessage;
-    finish_reason: 'stop' | 'length';
-  }[];
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
-}
-
 // ---------------------------------------------------------------------------
-// Handler
+// Handler (entry point)
 // ---------------------------------------------------------------------------
 
-export async function handleChat(request: Request): Promise<Response> {
-  // Validate method
+export async function handleChat(
+  request: Request,
+  env: Record<string, unknown>,
+): Promise<Response> {
+  // --- Method check -----------------------------------------------------------
   if (request.method !== 'POST') {
     return badRequestResponse(badRequest('Only POST is allowed for /v1/chat/completions'));
   }
 
-  // Parse and validate body
+  // --- Parse body ------------------------------------------------------------
   let body: ChatRequest;
   try {
     body = (await request.json()) as ChatRequest;
@@ -71,29 +78,218 @@ export async function handleChat(request: Request): Promise<Response> {
     return badRequestResponse(badRequest('model field is required'));
   }
 
-  // TODO(Wave 2): Forward to upstream LLM provider via LLM Router + deduct quota.
-  // For now, return a stub response.
-  const stubResponse: ChatResponse = {
-    id: crypto.randomUUID(),
+  // --- Auth check ------------------------------------------------------------
+  const auth = getAuthContext(request);
+  if (!auth) {
+    return badRequestResponse(badRequest('Authentication context not found'));
+  }
+
+  // --- Route by auth mode ----------------------------------------------------
+  if (auth.mode === 'proxy') {
+    return handleProxyChat(request, body, auth, env);
+  }
+  return handleDirectChat(request, body, auth, env);
+}
+
+// ---------------------------------------------------------------------------
+// Proxy JWT mode
+// ---------------------------------------------------------------------------
+
+async function handleProxyChat(
+  _request: Request,
+  body: ChatRequest,
+  auth: { mode: 'proxy'; payload: { monthly_quota_cu: number; cu_used: number; sub: string } },
+  env: Record<string, unknown>,
+): Promise<Response> {
+  const { payload } = auth;
+
+  // --- CU quota check --------------------------------------------------------
+  const estimatedCu = estimateCu(body);
+  const remainingCu = payload.monthly_quota_cu - payload.cu_used;
+
+  if (remainingCu <= 0) {
+    return errorJson(403, {
+      code: 'QUOTA_EXCEEDED',
+      message: `Monthly CU quota (${payload.monthly_quota_cu}) exhausted. Remaining: ${remainingCu}`,
+    });
+  }
+
+  if (estimatedCu > remainingCu) {
+    return errorJson(403, {
+      code: 'INSUFFICIENT_QUOTA',
+      message: `Request requires ~${estimatedCu} CU but only ${remainingCu} remaining`,
+    });
+  }
+
+  // --- Read upstream config from env -----------------------------------------
+  const proxyBaseUrl = env.LLM_PROXY_BASE_URL as string | undefined;
+  const proxyApiKey = env.LLM_PROXY_API_KEY as string | undefined;
+
+  if (!proxyBaseUrl || !proxyApiKey) {
+    return errorJson(500, {
+      code: 'PROXY_MISCONFIGURED',
+      message: 'LLM_PROXY_BASE_URL and LLM_PROXY_API_KEY env vars must be configured',
+    });
+  }
+
+  // Delegate to the shared forwarder
+  const upstreamUrl = buildUpstreamUrl(proxyBaseUrl);
+  return forwardToUpstream(body, upstreamUrl, proxyApiKey);
+}
+
+// ---------------------------------------------------------------------------
+// Direct API-key mode
+// ---------------------------------------------------------------------------
+
+async function handleDirectChat(
+  request: Request,
+  body: ChatRequest,
+  auth: { mode: 'direct'; apiKey: string },
+  _env: Record<string, unknown>,
+): Promise<Response> {
+  // The provider base URL is passed via a header (set by the client).
+  const providerBaseUrl = request.headers.get('x-provider-base-url');
+  if (!providerBaseUrl) {
+    return badRequestResponse(badRequest('x-provider-base-url header is required in direct mode'));
+  }
+
+  const upstreamUrl = buildUpstreamUrl(providerBaseUrl);
+  return forwardToUpstream(body, upstreamUrl, auth.apiKey);
+}
+
+// ---------------------------------------------------------------------------
+// Upstream forwarding (shared by both modes)
+// ---------------------------------------------------------------------------
+
+async function forwardToUpstream(
+  body: ChatRequest,
+  upstreamUrl: string,
+  apiKey: string,
+): Promise<Response> {
+  const isStreaming = body.stream === true;
+
+  // Build the outgoing request body — strip internal-only fields
+  const upstreamBody: Record<string, unknown> = {
     model: body.model,
-    object: 'chat.completion',
-    created: Math.floor(Date.now() / 1000),
-    choices: [
-      {
-        index: 0,
-        message: {
-          role: 'assistant',
-          content: `[proxy-stub] Received your message (model=${body.model}, messages=${body.messages.length}). Forwarding will be implemented in Wave 2.`,
-        },
-        finish_reason: 'stop',
-      },
-    ],
-    usage: {
-      prompt_tokens: 0,
-      completion_tokens: 0,
-      total_tokens: 0,
-    },
+    messages: body.messages,
+    stream: isStreaming,
   };
 
-  return json(stubResponse);
+  if (body.max_tokens !== undefined) upstreamBody.max_tokens = body.max_tokens;
+  if (body.temperature !== undefined) upstreamBody.temperature = body.temperature;
+
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    authorization: `Bearer ${apiKey}`,
+  };
+
+  // --- Non-streaming ---------------------------------------------------------
+  if (!isStreaming) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+    try {
+      const upstreamResponse = await fetch(upstreamUrl, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(upstreamBody),
+        signal: controller.signal,
+      });
+
+      if (!upstreamResponse.ok) {
+        const errorBody = await upstreamResponse.text();
+        return errorJson(502, {
+          code: 'UPSTREAM_ERROR',
+          message: `Upstream returned ${upstreamResponse.status}`,
+          upstream_status: upstreamResponse.status,
+          upstream_body: errorBody,
+        });
+      }
+
+      const data = await upstreamResponse.json();
+      return json(data);
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        return errorJson(504, {
+          code: 'UPSTREAM_TIMEOUT',
+          message: 'Upstream provider did not respond in time',
+        });
+      }
+      throw err;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  // --- Streaming (SSE) -------------------------------------------------------
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(upstreamBody),
+    });
+  } catch (err) {
+    return errorJson(502, {
+      code: 'UPSTREAM_UNREACHABLE',
+      message: err instanceof Error ? err.message : 'Failed to reach upstream provider',
+    });
+  }
+
+  if (!upstreamResponse.ok) {
+    const errorBody = await upstreamResponse.text();
+    return errorJson(502, {
+      code: 'UPSTREAM_ERROR',
+      message: `Upstream returned ${upstreamResponse.status}`,
+      upstream_status: upstreamResponse.status,
+      upstream_body: errorBody,
+    });
+  }
+
+  // Pipe the upstream body as an SSE stream
+  const upstreamBodyStream = upstreamResponse.body;
+  if (!upstreamBodyStream) {
+    return errorJson(502, {
+      code: 'UPSTREAM_NO_BODY',
+      message: 'Upstream returned no body',
+    });
+  }
+
+  return sseStream(upstreamBodyStream);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a JSON error response with a custom status code. */
+export function errorJson(status: number, data: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ error: data }), {
+    status,
+    headers: JSON_HEADER,
+  });
+}
+
+/**
+ * Build the upstream API URL for an OpenAI-compatible provider.
+ * Supports endpoints ending in /v1 or full /v1/chat/completions paths.
+ */
+export function buildUpstreamUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, '');
+  if (normalized.includes('/chat/completions')) return normalized;
+  if (normalized.endsWith('/v1')) return `${normalized}/chat/completions`;
+  return `${normalized}/v1/chat/completions`;
+}
+
+/**
+ * Rough CU estimation based on message content length.
+ * ~4 chars/token for mixed English text; 1000 tokens ≈ 1 CU.
+ */
+export function estimateCu(body: ChatRequest): number {
+  let charCount = 0;
+  for (const msg of body.messages ?? []) {
+    charCount += msg.content.length;
+  }
+  const tokens = Math.max(1, Math.ceil(charCount / 4));
+  return Math.max(1, Math.ceil(tokens / 1000));
 }

--- a/packages/cloudflare-worker/src/routes/chat.ts
+++ b/packages/cloudflare-worker/src/routes/chat.ts
@@ -108,14 +108,14 @@ async function handleProxyChat(
   const remainingCu = payload.monthly_quota_cu - payload.cu_used;
 
   if (remainingCu <= 0) {
-    return errorJson(403, {
+    return errorJson(429, {
       code: 'QUOTA_EXCEEDED',
       message: `Monthly CU quota (${payload.monthly_quota_cu}) exhausted. Remaining: ${remainingCu}`,
     });
   }
 
   if (estimatedCu > remainingCu) {
-    return errorJson(403, {
+    return errorJson(429, {
       code: 'INSUFFICIENT_QUOTA',
       message: `Request requires ~${estimatedCu} CU but only ${remainingCu} remaining`,
     });
@@ -222,19 +222,32 @@ async function forwardToUpstream(
   }
 
   // --- Streaming (SSE) -------------------------------------------------------
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
   let upstreamResponse: Response;
   try {
     upstreamResponse = await fetch(upstreamUrl, {
       method: 'POST',
       headers,
       body: JSON.stringify(upstreamBody),
+      signal: controller.signal,
     });
   } catch (err) {
+    clearTimeout(timeout);
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      return errorJson(504, {
+        code: 'UPSTREAM_TIMEOUT',
+        message: 'Upstream provider did not respond in time',
+      });
+    }
     return errorJson(502, {
       code: 'UPSTREAM_UNREACHABLE',
       message: err instanceof Error ? err.message : 'Failed to reach upstream provider',
     });
   }
+
+  clearTimeout(timeout);
 
   if (!upstreamResponse.ok) {
     const errorBody = await upstreamResponse.text();

--- a/packages/cloudflare-worker/src/routes/health.ts
+++ b/packages/cloudflare-worker/src/routes/health.ts
@@ -1,0 +1,23 @@
+/**
+ * Health-check endpoint — returns 200 OK with service status.
+ *
+ * GET /health
+ */
+
+export interface HealthResponse {
+  status: 'ok';
+  service: string;
+  version: string;
+  timestamp: string;
+  uptime: number;
+}
+
+export function handleHealth(_request: Request): HealthResponse {
+  return {
+    status: 'ok',
+    service: 'markus-proxy',
+    version: '0.1.0',
+    timestamp: new Date().toISOString(),
+    uptime: Date.now() - ((globalThis as Record<string, unknown>).START_TIME as number) || 0,
+  };
+}

--- a/packages/cloudflare-worker/src/utils/errors.ts
+++ b/packages/cloudflare-worker/src/utils/errors.ts
@@ -1,0 +1,115 @@
+/**
+ * Standard error types for the Markus proxy.
+ *
+ * All errors use the format:
+ *   { error: { code: string, message: string, type: string } }
+ */
+
+/** URI-encoded error message for safe transport in response bodies. */
+export interface ProxyError {
+  code: string;
+  message: string;
+  type: string;
+}
+
+export interface ErrorResponse {
+  error: ProxyError;
+}
+
+// ---------------------------------------------------------------------------
+// Pre-defined error helpers
+// ---------------------------------------------------------------------------
+
+/** 400 — Bad request (malformed payload, missing fields, etc.). */
+export function badRequest(detail?: string): ErrorResponse {
+  return {
+    error: {
+      code: 'BAD_REQUEST',
+      message: detail ?? 'The request was malformed or missing required fields',
+      type: 'validation_error',
+    },
+  };
+}
+
+/** 401 — No valid subscription key provided. */
+export function unauthorized(detail?: string): ErrorResponse {
+  return {
+    error: {
+      code: 'UNAUTHORIZED',
+      message: detail ?? 'Missing or invalid subscription key',
+      type: 'auth_error',
+    },
+  };
+}
+
+/** 403 — Key is valid but lacks quota / is expired / etc. */
+export function forbidden(detail?: string): ErrorResponse {
+  return {
+    error: {
+      code: 'FORBIDDEN',
+      message: detail ?? 'Subscription key has no remaining quota',
+      type: 'quota_error',
+    },
+  };
+}
+
+/** 404 — Route not found. */
+export function notFound(path: string): ErrorResponse {
+  return {
+    error: {
+      code: 'NOT_FOUND',
+      message: `Route not found: ${path}`,
+      type: 'not_found_error',
+    },
+  };
+}
+
+/** 429 — Rate limited. */
+export function rateLimited(retryAfterMs?: number): ErrorResponse {
+  return {
+    error: {
+      code: 'RATE_LIMITED',
+      message: retryAfterMs
+        ? `Too many requests. Retry after ${retryAfterMs}ms`
+        : 'Too many requests. Please slow down',
+      type: 'rate_limit_error',
+    },
+  };
+}
+
+/** 504 — Upstream LLM provider did not respond in time. */
+export function gatewayTimeout(upstream?: string): ErrorResponse {
+  return {
+    error: {
+      code: 'GATEWAY_TIMEOUT',
+      message: upstream
+        ? `Upstream provider "${upstream}" timed out`
+        : 'Upstream provider timed out',
+      type: 'proxy_error',
+    },
+  };
+}
+
+/** 500 — Unexpected internal error (catch-all). */
+export function internalError(detail?: string): ErrorResponse {
+  return {
+    error: {
+      code: 'INTERNAL_ERROR',
+      message: detail ?? 'An unexpected error occurred',
+      type: 'internal_error',
+    },
+  };
+}
+
+/** 502 — Upstream returned a bad response. */
+export function badGateway(upstream?: string): ErrorResponse {
+  return {
+    error: {
+      code: 'BAD_GATEWAY',
+      message: upstream
+        ? `Upstream provider "${upstream}" returned an invalid response`
+        : 'Upstream provider returned an invalid response',
+      type: 'proxy_error',
+    },
+  };
+}

--- a/packages/cloudflare-worker/src/utils/response.ts
+++ b/packages/cloudflare-worker/src/utils/response.ts
@@ -1,0 +1,100 @@
+/**
+ * Standard HTTP response helpers for the Markus proxy.
+ *
+ * Every JSON response includes CORS headers so the caller does not have to
+ * repeat them.  The CORS middleware ensures OPTIONS preflights are handled
+ * before any of these helpers are called.
+ */
+
+import type { ErrorResponse } from './errors.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const JSON_HEADER: Record<string, string> = {
+  'content-type': 'application/json; charset=utf-8',
+};
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/** 200 OK — standard success response. */
+export function json(data: unknown, extraHeaders?: Record<string, string>): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: { ...JSON_HEADER, ...extraHeaders },
+  });
+}
+
+/** 200 OK — SSE stream response (streaming proxy). */
+export function sseStream(
+  readable: ReadableStream,
+  extraHeaders?: Record<string, string>,
+): Response {
+  return new Response(readable, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      ...extraHeaders,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Error response helpers
+// ---------------------------------------------------------------------------
+
+function errorResponse(status: number, body: ErrorResponse, extraHeaders?: Record<string, string>): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...JSON_HEADER, ...extraHeaders },
+  });
+}
+
+/** 400 Bad Request. */
+export function badRequest(body: ErrorResponse): Response {
+  return errorResponse(400, body);
+}
+
+/** 401 Unauthorized. */
+export function unauthorized(body: ErrorResponse): Response {
+  return errorResponse(401, body);
+}
+
+/** 403 Forbidden. */
+export function forbidden(body: ErrorResponse): Response {
+  return errorResponse(403, body);
+}
+
+/** 404 Not Found. */
+export function notFound(body: ErrorResponse): Response {
+  return errorResponse(404, body);
+}
+
+/** 429 Too Many Requests. */
+export function tooManyRequests(body: ErrorResponse, retryAfterSec?: number): Response {
+  const headers: Record<string, string> = {};
+  if (retryAfterSec !== undefined) {
+    headers['retry-after'] = String(retryAfterSec);
+  }
+  return errorResponse(429, body, headers);
+}
+
+/** 502 Bad Gateway. */
+export function badGateway(body: ErrorResponse): Response {
+  return errorResponse(502, body);
+}
+
+/** 504 Gateway Timeout. */
+export function gatewayTimeout(body: ErrorResponse): Response {
+  return errorResponse(504, body);
+}
+
+/** 500 Internal Server Error (catch-all). */
+export function internalError(body: ErrorResponse): Response {
+  return errorResponse(500, body);
+}

--- a/packages/cloudflare-worker/tsconfig.json
+++ b/packages/cloudflare-worker/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/cloudflare-worker/vitest.config.ts
+++ b/packages/cloudflare-worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/cloudflare-worker/wrangler.toml
+++ b/packages/cloudflare-worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "markus-proxy"
+main = "src/index.ts"
+compatibility_date = "2025-04-01"
+
+# Workers Logs
+[observability]
+enabled = true
+head_sampling_rate = 1.0
+
+# Development environment
+[env.dev]
+vars = { ENVIRONMENT = "development" }

--- a/packages/core/src/llm/cu-cache.ts
+++ b/packages/core/src/llm/cu-cache.ts
@@ -1,0 +1,148 @@
+/**
+ * CU (Compute Unit) usage cache for proxy mode.
+ *
+ * Tracks per-provider, per-model token usage and cost from proxy
+ * responses so the Desktop client can query usage without hitting
+ * the upstream every time.
+ *
+ * Usage data is purely in-memory (volatile across restarts).  A
+ * future wave will add SQLite persistence.
+ */
+
+import { createLogger } from '@markus/shared';
+
+const log = createLogger('cu-cache');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CUUsageRecord {
+  readonly provider: string;
+  readonly model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** Estimated cost in USD (from model catalog pricing × tokens) */
+  estimatedCost: number;
+  lastUpdated: string;
+}
+
+export interface CUSummary {
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  totalEstimatedCost: number;
+  /** Per-provider breakdown, keyed by "provider:model" */
+  breakdown: Record<string, CUUsageRecord>;
+  /** Remaining balance if known (from proxy response headers) */
+  balance?: number;
+  lastUpdated: string;
+}
+
+// ---------------------------------------------------------------------------
+// Cache
+// ---------------------------------------------------------------------------
+
+export class CUCache {
+  /** Key = "provider:model", value = aggregated usage */
+  private records = new Map<string, CUUsageRecord>();
+  /** Latest balance reported by the proxy. undefined = unknown. */
+  private _balance?: number;
+  private _lastBalanceUpdate?: string;
+
+  // ---- Mutators -----------------------------------------------------------
+
+  /**
+   * Record usage from a proxy response.
+   * `provider` should be the upstream provider name (e.g. "anthropic").
+   * `model` should be the model ID used.
+   */
+  recordUsage(provider: string, model: string, inputTokens: number, outputTokens: number, estimatedCost?: number): void {
+    const key = `${provider}:${model}`;
+    let rec = this.records.get(key);
+    if (!rec) {
+      rec = { provider, model, inputTokens: 0, outputTokens: 0, estimatedCost: 0, lastUpdated: new Date().toISOString() };
+      this.records.set(key, rec);
+    }
+    rec.inputTokens += inputTokens;
+    rec.outputTokens += outputTokens;
+    rec.estimatedCost += estimatedCost ?? 0;
+    rec.lastUpdated = new Date().toISOString();
+  }
+
+  /**
+   * Update the CU balance from a proxy response header.
+   */
+  setBalance(balance: number): void {
+    this._balance = balance;
+    this._lastBalanceUpdate = new Date().toISOString();
+  }
+
+  // ---- Accessors ----------------------------------------------------------
+
+  /**
+   * Return a snapshot of all usage data.
+   */
+  getSummary(): CUSummary {
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCost = 0;
+    const breakdown: Record<string, CUUsageRecord> = {};
+
+    for (const [key, rec] of this.records) {
+      breakdown[key] = { ...rec };
+      totalInput += rec.inputTokens;
+      totalOutput += rec.outputTokens;
+      totalCost += rec.estimatedCost;
+    }
+
+    return {
+      totalInputTokens: totalInput,
+      totalOutputTokens: totalOutput,
+      totalEstimatedCost: totalCost,
+      breakdown,
+      balance: this._balance,
+      lastUpdated: this._lastBalanceUpdate ?? new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Get usage for a specific provider.
+   */
+  getProviderUsage(provider: string): CUSummary {
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCost = 0;
+    const breakdown: Record<string, CUUsageRecord> = {};
+
+    for (const [key, rec] of this.records) {
+      if (rec.provider !== provider) continue;
+      breakdown[key] = { ...rec };
+      totalInput += rec.inputTokens;
+      totalOutput += rec.outputTokens;
+      totalCost += rec.estimatedCost;
+    }
+
+    return {
+      totalInputTokens: totalInput,
+      totalOutputTokens: totalOutput,
+      totalEstimatedCost: totalCost,
+      breakdown,
+      balance: this._balance,
+      lastUpdated: this._lastBalanceUpdate ?? new Date().toISOString(),
+    };
+  }
+
+  get balance(): number | undefined {
+    return this._balance;
+  }
+
+  /**
+   * Reset all usage data (e.g. at the start of a billing cycle).
+   */
+  reset(): void {
+    this.records.clear();
+    this._balance = undefined;
+    this._lastBalanceUpdate = undefined;
+    log.info('CU cache reset');
+  }
+}

--- a/packages/core/src/llm/proxy-provider.ts
+++ b/packages/core/src/llm/proxy-provider.ts
@@ -1,0 +1,410 @@
+/**
+ * ProxyProvider — LLM provider wrapper that routes requests through
+ * the CF Worker proxy (platform-credit mode) instead of calling
+ * LLM providers directly.
+ *
+ * Architecture
+ * ────────────
+ *   LLMRouter.chat() ─→ ProxyProvider ─→ CF Worker Proxy ─→ Upstream LLM
+ *                                              │
+ *                                              └── Returns LLM response + CU headers
+ *
+ * The proxy speaks the OpenAI Chat Completions wire format on both
+ * sides, so this class uses the same body serialisation and response
+ * parsing as OpenAIProvider but changes the endpoint URL to the proxy.
+ */
+
+import { createLogger } from '@markus/shared';
+import type { LLMProviderConfig, LLMRequest, LLMResponse, LLMStreamEvent } from '@markus/shared';
+import type { LLMProviderInterface } from './provider.js';
+import type { CUCache } from './cu-cache.js';
+
+const log = createLogger('proxy-provider');
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ProxyProviderConfig {
+  /** CF Worker proxy URL (e.g. "http://localhost:8787" or deployed URL) */
+  proxyUrl: string;
+  /** Optional JWT / subscription key for proxy auth */
+  apiKey?: string;
+  /** Default model ID to use */
+  defaultModel?: string;
+  /** Request timeout in ms */
+  timeoutMs?: number;
+  /** CU cache instance to record usage (optional — can be set later) */
+  cuCache?: CUCache;
+}
+
+// ---------------------------------------------------------------------------
+// ProxyProvider
+// ---------------------------------------------------------------------------
+
+export class ProxyProvider implements LLMProviderInterface {
+  readonly name: string;
+  model: string;
+  private proxyUrl: string;
+  private apiKey: string;
+  private chatTimeoutMs: number;
+  private streamTimeoutMs: number;
+  private cuCache?: CUCache;
+
+  constructor(config: ProxyProviderConfig) {
+    this.name = 'proxy';
+    this.model = config.defaultModel ?? 'claude-sonnet-4-20250514';
+    this.proxyUrl = config.proxyUrl.replace(/\/+$/, '');
+    this.apiKey = config.apiKey ?? '';
+    this.chatTimeoutMs = config.timeoutMs ?? 90_000;
+    this.streamTimeoutMs = config.timeoutMs ?? 120_000;
+    this.cuCache = config.cuCache;
+  }
+
+  /** Allow late-binding of the CU cache (e.g. after Router init). */
+  setCUCache(cache: CUCache): void {
+    this.cuCache = cache;
+  }
+
+  /** Return the proxy URL for diagnostic purposes. */
+  getProxyUrl(): string {
+    return this.proxyUrl;
+  }
+
+  configure(config: LLMProviderConfig): void {
+    if (config.model) this.model = config.model;
+    if (config.apiKey) this.apiKey = config.apiKey;
+    if (config.timeoutMs) {
+      this.chatTimeoutMs = config.timeoutMs;
+      this.streamTimeoutMs = config.timeoutMs;
+    }
+  }
+
+  // ---- Chat (non-streaming) -----------------------------------------------
+
+  async chat(request: LLMRequest): Promise<LLMResponse> {
+    const body = this.buildRequestBody(request);
+    const endpoint = `${this.proxyUrl}/v1/chat/completions`;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.chatTimeoutMs);
+
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: this.buildHeaders(),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`Proxy API error ${res.status}: ${errText}`);
+      }
+
+      const response = this.parseChatResponse(await res.json() as Record<string, unknown>);
+
+      // Record CU usage from proxy response headers
+      this.recordCU(res, response);
+
+      return response;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if ((err as Error).name === 'AbortError') {
+        throw new Error(`Proxy request timed out after ${this.chatTimeoutMs}ms`);
+      }
+      throw new Error(`Proxy chat failed: ${msg}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  // ---- Streaming ----------------------------------------------------------
+
+  async chatStream(
+    request: LLMRequest,
+    onEvent: (event: LLMStreamEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<LLMResponse> {
+    const body = this.buildRequestBody(request, true);
+    const endpoint = `${this.proxyUrl}/v1/chat/completions`;
+    const controller = new AbortController();
+
+    // Combine external signal with timeout
+    const handleAbort = () => controller.abort();
+    signal?.addEventListener('abort', handleAbort);
+    const timeout = setTimeout(() => controller.abort(), this.streamTimeoutMs);
+
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { ...this.buildHeaders(), Accept: 'text/event-stream' },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`Proxy stream error ${res.status}: ${errText}`);
+      }
+
+      const response = await this.processStream(res, onEvent, signal);
+
+      // Record CU usage from proxy response headers
+      this.recordCU(res, response);
+
+      return response;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if ((err as Error).name === 'AbortError') {
+        throw new Error(`Proxy stream timed out after ${this.streamTimeoutMs}ms`);
+      }
+      throw new Error(`Proxy stream failed: ${msg}`);
+    } finally {
+      clearTimeout(timeout);
+      signal?.removeEventListener('abort', handleAbort);
+    }
+  }
+
+  // ---- Private helpers ----------------------------------------------------
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.apiKey) {
+      headers['X-Subscription-Key'] = this.apiKey;
+    }
+    return headers;
+  }
+
+  /** Convert internal LLMRequest to OpenAI-compatible JSON body. */
+  private buildRequestBody(request: LLMRequest, stream = false): Record<string, unknown> {
+    const body: Record<string, unknown> = {
+      model: this.model,
+      messages: request.messages.map(m => ({
+        role: m.role,
+        content: typeof m.content === 'string' ? m.content : m.content,
+      })),
+      max_tokens: request.maxTokens ?? 4096,
+      stream,
+    };
+
+    if (request.temperature !== undefined) body['temperature'] = request.temperature;
+    if (request.stopSequences?.length) body['stop'] = request.stopSequences;
+    if (request.tools?.length) {
+      body['tools'] = request.tools.map(t => ({
+        type: 'function',
+        function: { name: t.name, description: t.description, parameters: t.inputSchema },
+      }));
+    }
+
+    return body;
+  }
+
+  /** Parse an OpenAI-compatible non-streaming response into our internal format. */
+  private parseChatResponse(data: Record<string, unknown>): LLMResponse {
+    const choices = data['choices'] as Array<Record<string, unknown>> | undefined;
+    const usage = data['usage'] as Record<string, unknown> | undefined;
+
+    if (!choices || choices.length === 0) {
+      return {
+        content: '',
+        usage: { inputTokens: 0, outputTokens: 0 },
+        finishReason: 'end_turn',
+      };
+    }
+
+    const choice = choices[0]!;
+    const message = choice['message'] as Record<string, unknown> | undefined;
+
+    // Extract content
+    let content = '';
+    let toolCalls: LLMResponse['toolCalls'];
+    const reasoningContent = message?.['reasoning_content'] as string | undefined;
+
+    if (message?.['content']) {
+      content = String(message['content']);
+    }
+
+    // Extract tool calls
+    const rawToolCalls = message?.['tool_calls'] as Array<Record<string, unknown>> | undefined;
+    if (rawToolCalls?.length) {
+      toolCalls = rawToolCalls.map(tc => ({
+        id: String(tc['id'] ?? ''),
+        name: String((tc['function'] as Record<string, unknown>)?.['name'] ?? ''),
+        arguments: JSON.parse(String((tc['function'] as Record<string, unknown>)?.['arguments'] ?? '{}')),
+      }));
+    }
+
+    const rawFinish = String(choice['finish_reason'] ?? '');
+    const mappedFinish: LLMResponse['finishReason'] =
+      rawFinish === 'stop' ? 'end_turn' :
+      rawFinish === 'tool_calls' ? 'tool_use' :
+      rawFinish === 'length' ? 'max_tokens' : 'end_turn';
+
+    return {
+      content,
+      toolCalls,
+      usage: {
+        inputTokens: (usage?.['prompt_tokens'] as number) ?? 0,
+        outputTokens: (usage?.['completion_tokens'] as number) ?? 0,
+      },
+      finishReason: mappedFinish,
+      reasoningContent,
+    };
+  }
+
+  /** Process SSE stream from proxy. */
+  private async processStream(
+    res: Response,
+    onEvent: (event: LLMStreamEvent) => void,
+    signal?: AbortSignal,
+  ): Promise<LLMResponse> {
+    const reader = res.body?.getReader();
+    if (!reader) throw new Error('No response body for stream');
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let fullContent = '';
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let finishReason: LLMResponse['finishReason'] = 'end_turn';
+
+    try {
+      while (true) {
+        if (signal?.aborted) break;
+
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Process complete SSE lines
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          const payload = line.slice(6).trim();
+          if (payload === '[DONE]') break;
+
+          try {
+            const chunk = JSON.parse(payload) as Record<string, unknown>;
+            this.processStreamChunk(chunk, onEvent, (t, o, c, f) => {
+              if (t !== undefined) inputTokens = t;
+              if (o !== undefined) outputTokens = o;
+              if (c !== undefined) fullContent += c;
+              if (f !== undefined) finishReason = f;
+            });
+          } catch {
+            // Skip malformed chunks
+          }
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return {
+      content: fullContent,
+      usage: { inputTokens, outputTokens },
+      finishReason,
+    };
+  }
+
+  /** Process a single SSE data chunk from an OpenAI-compatible stream. */
+  private processStreamChunk(
+    chunk: Record<string, unknown>,
+    onEvent: (event: LLMStreamEvent) => void,
+    collect: (inputTokens: number, outputTokens: number, contentDelta: string, finishReason?: LLMResponse['finishReason']) => void,
+  ): void {
+    const choices = chunk['choices'] as Array<Record<string, unknown>> | undefined;
+    if (!choices?.length) {
+      // Usage-only chunk at end of stream
+      const usage = chunk['usage'] as Record<string, unknown> | undefined;
+      if (usage) {
+        collect(
+          (usage['prompt_tokens'] as number) ?? 0,
+          (usage['completion_tokens'] as number) ?? 0,
+          '',
+        );
+        onEvent({
+          type: 'message_end',
+          usage: {
+            inputTokens: (usage['prompt_tokens'] as number) ?? 0,
+            outputTokens: (usage['completion_tokens'] as number) ?? 0,
+          },
+          finishReason: 'end_turn',
+        });
+      }
+      return;
+    }
+
+    const delta = choices[0]!;
+    const finish = delta['finish_reason'] as string | null;
+    const d = delta['delta'] as Record<string, unknown> | undefined;
+
+    // Content delta
+    if (d?.['content']) {
+      const text = String(d['content']);
+      collect(0, 0, text);
+      onEvent({ type: 'text_delta', text });
+    }
+
+    // Tool call delta
+    if (d?.['tool_calls']) {
+      const tcs = d['tool_calls'] as Array<Record<string, unknown>>;
+      for (const tc of tcs) {
+        const func = tc['function'] as Record<string, unknown> | undefined;
+        onEvent({
+          type: 'tool_call_start',
+          toolCall: {
+            id: String(tc['id'] ?? ''),
+            name: String(func?.['name'] ?? ''),
+            arguments: func?.['arguments'] ? JSON.parse(String(func['arguments'])) : {},
+          },
+        });
+      }
+    }
+
+    // Finish reason
+    if (finish) {
+      const mappedFinish: LLMResponse['finishReason'] =
+        finish === 'stop' ? 'end_turn' :
+        finish === 'tool_calls' ? 'tool_use' :
+        finish === 'length' ? 'max_tokens' : 'end_turn';
+
+      collect(0, 0, '', mappedFinish);
+      onEvent({ type: 'message_end', finishReason: mappedFinish });
+    }
+  }
+
+  /** Extract CU usage from proxy response headers and record in cache. */
+  private recordCU(response: Response, llmResponse: LLMResponse): void {
+    if (!this.cuCache) return;
+
+    const cuUsedStr = response.headers.get('X-CU-Used');
+    const cuBalanceStr = response.headers.get('X-CU-Balance');
+
+    const inputTokens = llmResponse.usage.inputTokens;
+    const outputTokens = llmResponse.usage.outputTokens;
+
+    // Record token usage (provider name will be replaced with real upstream
+    // name when the proxy returns it in a header; for now use "proxy" as the
+    // upstream reporting name).
+    const upstreamProvider = response.headers.get('X-Upstream-Provider') ?? 'proxy';
+    this.cuCache.recordUsage(upstreamProvider, this.model, inputTokens, outputTokens);
+
+    // Track CU balance if reported
+    if (cuBalanceStr !== null) {
+      const balance = Number(cuBalanceStr);
+      if (!Number.isNaN(balance)) {
+        this.cuCache.setBalance(balance);
+      }
+    }
+
+    if (cuUsedStr !== null || cuBalanceStr !== null) {
+      log.debug('Proxy CU data', { cuUsed: cuUsedStr, cuBalance: cuBalanceStr, inputTokens, outputTokens });
+    }
+  }
+}

--- a/packages/core/src/llm/proxy-provider.ts
+++ b/packages/core/src/llm/proxy-provider.ts
@@ -49,6 +49,8 @@ export class ProxyProvider implements LLMProviderInterface {
   private apiKey: string;
   private chatTimeoutMs: number;
   private streamTimeoutMs: number;
+  /** Max retry attempts for transient network failures (timeout, DNS, TCP reset) */
+  private maxRetries = 1;
   private cuCache?: CUCache;
 
   constructor(config: ProxyProviderConfig) {
@@ -89,15 +91,14 @@ export class ProxyProvider implements LLMProviderInterface {
     const timeout = setTimeout(() => controller.abort(), this.chatTimeoutMs);
 
     try {
-      const res = await fetch(endpoint, {
-        method: 'POST',
-        headers: this.buildHeaders(),
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+      const { res } = await this.fetchWithRetry(endpoint, body, controller, false);
 
       if (!res.ok) {
         const errText = await res.text();
+        // CU exhausted (402 Payment Required) — return friendly error, do NOT degrade
+        if (res.status === 402 || /cu.*(exhausted|limit|insufficient)/i.test(errText)) {
+          throw new Error(`CU_EXCEEDED: ${errText}`);
+        }
         throw new Error(`Proxy API error ${res.status}: ${errText}`);
       }
 
@@ -111,6 +112,10 @@ export class ProxyProvider implements LLMProviderInterface {
       const msg = err instanceof Error ? err.message : String(err);
       if ((err as Error).name === 'AbortError') {
         throw new Error(`Proxy request timed out after ${this.chatTimeoutMs}ms`);
+      }
+      // Wrap with PROXY_UNAVAILABLE prefix so the router can degrade to direct mode
+      if (this.isProxyUnavailableError(err)) {
+        throw new Error(`PROXY_UNAVAILABLE: ${msg}`);
       }
       throw new Error(`Proxy chat failed: ${msg}`);
     } finally {
@@ -135,15 +140,14 @@ export class ProxyProvider implements LLMProviderInterface {
     const timeout = setTimeout(() => controller.abort(), this.streamTimeoutMs);
 
     try {
-      const res = await fetch(endpoint, {
-        method: 'POST',
-        headers: { ...this.buildHeaders(), Accept: 'text/event-stream' },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
+      const { res } = await this.fetchWithRetry(endpoint, body, controller, true);
 
       if (!res.ok) {
         const errText = await res.text();
+        // CU exhausted (402 Payment Required) — return friendly error, do NOT degrade
+        if (res.status === 402 || /cu.*(exhausted|limit|insufficient)/i.test(errText)) {
+          throw new Error(`CU_EXCEEDED: ${errText}`);
+        }
         throw new Error(`Proxy stream error ${res.status}: ${errText}`);
       }
 
@@ -158,6 +162,10 @@ export class ProxyProvider implements LLMProviderInterface {
       if ((err as Error).name === 'AbortError') {
         throw new Error(`Proxy stream timed out after ${this.streamTimeoutMs}ms`);
       }
+      // Wrap with PROXY_UNAVAILABLE prefix so the router can degrade to direct mode
+      if (this.isProxyUnavailableError(err)) {
+        throw new Error(`PROXY_UNAVAILABLE: ${msg}`);
+      }
       throw new Error(`Proxy stream failed: ${msg}`);
     } finally {
       clearTimeout(timeout);
@@ -166,6 +174,62 @@ export class ProxyProvider implements LLMProviderInterface {
   }
 
   // ---- Private helpers ----------------------------------------------------
+
+  /**
+   * Fetch from the proxy endpoint with automatic retry on transient failures.
+   * Retries once on network-level errors (timeout, DNS, TCP reset).
+   * Does NOT retry on HTTP error responses (4xx/5xx) — those are valid responses.
+   */
+  private async fetchWithRetry(
+    endpoint: string,
+    body: Record<string, unknown>,
+    controller: AbortController,
+    stream: boolean,
+  ): Promise<{ res: Response; retried: boolean }> {
+    const headers = stream
+      ? { ...this.buildHeaders(), Accept: 'text/event-stream' }
+      : this.buildHeaders();
+
+    for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
+      try {
+        const res = await fetch(endpoint, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+        return { res, retried: attempt > 0 };
+      } catch (err) {
+        const isLastAttempt = attempt >= this.maxRetries;
+        // Only retry on transient network failures (TypeError: fetch failed)
+        if (!(err instanceof TypeError) || isLastAttempt) {
+          throw err;
+        }
+        // Don't retry if the controller was aborted (timeout or external signal)
+        if (controller.signal.aborted) {
+          throw err;
+        }
+        log.warn(`Proxy fetch attempt ${attempt + 1} failed, retrying...`, { error: String(err) });
+        // Brief backoff before retry
+        await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+      }
+    }
+    // Should never reach here
+    throw new Error('Proxy fetch failed after all retries');
+  }
+
+  /**
+   * Detect whether an error indicates the proxy is unreachable.
+   * These errors should trigger the router to fall back to direct mode.
+   */
+  private isProxyUnavailableError(err: unknown): boolean {
+    if (err instanceof TypeError) {
+      // fetch() throws TypeError on network failures
+      return true;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    return /ECONNREFUSED|ENOTFOUND|fetch failed|network.*error|connect.*refused/i.test(msg);
+  }
 
   private buildHeaders(): Record<string, string> {
     const headers: Record<string, string> = {

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -12,6 +12,9 @@ import { OllamaProvider } from './ollama.js';
 import { AuthProfileStore } from './auth-profiles.js';
 import { OAuthManager } from './oauth-manager.js';
 import type { ModelCatalogService } from './model-catalog.js';
+import type { ProxyProviderConfig } from './proxy-provider.js';
+import { CUCache } from './cu-cache.js';
+import { ProxyProvider } from './proxy-provider.js';
 
 const log = createLogger('llm-router');
 
@@ -130,6 +133,9 @@ export class LLMRouter {
   private customModelConfigs = new Map<string, { contextWindow?: number; maxOutputTokens?: number; cost?: ModelCostConfig }>();
   private customModelCatalog = new Map<string, ModelDefinition[]>();
   private disabledProviders = new Set<string>();
+
+  /** CU (Compute Unit) usage cache for proxy-mode tracking */
+  private _cuCache = new CUCache();
 
   /** Per-provider in-flight request counter for concurrency-aware jitter */
   private inFlight = new Map<string, number>();
@@ -534,6 +540,44 @@ export class LLMRouter {
 
   get autoFallback(): boolean { return this._autoFallback; }
   setAutoFallback(enabled: boolean): void { this._autoFallback = enabled; }
+
+  // ---- CU cache ----------------------------------------------------------
+
+  /** Access the CU (Compute Unit) usage cache (populated by proxy mode). */
+  getCUCache(): CUCache {
+    return this._cuCache;
+  }
+
+  /**
+   * Enable proxy mode — register a ProxyProvider that routes all LLM
+   * requests through the CF Worker proxy (platform-credit mode).
+   *
+   * After calling this, the proxy provider is registered under the name
+   * "proxy" and set as the default provider.  The ProxyProvider automatically
+   * records CU usage from proxy response headers into the built-in cache.
+   */
+  enableProxyMode(config: ProxyProviderConfig): void {
+    const provider = new ProxyProvider(config);
+    provider.setCUCache(this._cuCache);
+
+    // Re-use the existing provider lifecycle — register, then switch default
+    this.registerProvider('proxy', provider);
+    this.defaultProvider = 'proxy';
+    this.refreshTiers();
+    log.info('Proxy mode enabled', { proxyUrl: config.proxyUrl });
+  }
+
+  /** Disable proxy mode — unregister the proxy provider and restore defaults. */
+  disableProxyMode(): void {
+    if (!this.providers.has('proxy')) return;
+    this.unregisterProvider('proxy');
+    // Restore default to the first non-proxy provider
+    const remaining = this.listProviders();
+    if (remaining.length > 0) {
+      this.defaultProvider = remaining[0]!;
+    }
+    log.info('Proxy mode disabled');
+  }
 
   static assessComplexity(request: LLMRequest): ComplexityLevel {
     const totalChars = request.messages.reduce((s, m) => s + getTextContent(m.content).length, 0);
@@ -1358,6 +1402,14 @@ export class LLMRouter {
   }
 
   private emitLog(providerName: string, model: string, request: LLMRequest, response: LLMResponse, durationMs: number): void {
+    // Feed token usage into CU cache for all modes (direct + proxy)
+    this._cuCache.recordUsage(
+      providerName,
+      model,
+      response.usage.inputTokens,
+      response.usage.outputTokens,
+    );
+
     if (!this.logCallback) return;
     try {
       this.logCallback({

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -287,6 +287,12 @@ export class LLMRouter {
     return /\b429\b/.test(msg) || /rate.limit/i.test(msg);
   }
 
+  /** Detect CU-exhausted errors — return friendly error, do NOT fall back to direct mode. */
+  static isCUExceededError(error: unknown): boolean {
+    const msg = error instanceof Error ? error.message : String(error);
+    return msg.includes('CU_EXCEEDED:');
+  }
+
   /**
    * Apply random jitter when a provider has many concurrent in-flight requests.
    * Spreads burst traffic to avoid thundering-herd 429 cascades.
@@ -967,6 +973,11 @@ export class LLMRouter {
       lastError = error;
       log.error(`LLM request failed for ${primary}:${routedModel ?? provider.model}`, { error: String(error) });
 
+      // CU_EXCEEDED is fatal — do NOT fall back to other providers
+      if (LLMRouter.isCUExceededError(error)) {
+        throw lastError;
+      }
+
       // Try alternate models on the same provider (only when auto-fallback is enabled)
       if (this._autoFallback && !LLMRouter.isNonRetryableError(error)) {
         const altModel = this.findHealthyModel(primary);
@@ -1104,6 +1115,13 @@ export class LLMRouter {
         throw lastError;
       }
       log.error(`LLM stream request failed for ${primary}:${provider.model}`, { error: String(error) });
+
+      // CU_EXCEEDED is fatal — do NOT fall back to other providers
+      if (LLMRouter.isCUExceededError(error)) {
+        span.setError(lastError instanceof Error ? lastError : String(lastError));
+        span.end();
+        throw lastError;
+      }
 
       // Try alternate models on the same provider (only when auto-fallback is enabled)
       if (this._autoFallback && !LLMRouter.isNonRetryableError(error)) {
@@ -1402,13 +1420,15 @@ export class LLMRouter {
   }
 
   private emitLog(providerName: string, model: string, request: LLMRequest, response: LLMResponse, durationMs: number): void {
-    // Feed token usage into CU cache for all modes (direct + proxy)
-    this._cuCache.recordUsage(
-      providerName,
-      model,
-      response.usage.inputTokens,
-      response.usage.outputTokens,
-    );
+    // Feed token usage into CU cache only when running in proxy mode
+    if (providerName === 'proxy') {
+      this._cuCache.recordUsage(
+        providerName,
+        model,
+        response.usage.inputTokens,
+        response.usage.outputTokens,
+      );
+    }
 
     if (!this.logCallback) return;
     try {

--- a/packages/core/test/llm-router-proxy.test.ts
+++ b/packages/core/test/llm-router-proxy.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { LLMRouter } from '../src/llm/router.js';
+import type { LLMRequest, LLMResponse, LLMProviderConfig, ProviderCapabilities } from '@markus/shared';
+
+function successResponse(content = 'ok'): LLMResponse {
+  return {
+    content,
+    usage: { inputTokens: 10, outputTokens: 5 },
+    finishReason: 'end_turn',
+  };
+}
+
+function mockProvider(
+  name: string,
+  model: string,
+  chatImpl?: (request: LLMRequest) => Promise<LLMResponse>,
+  caps?: Partial<ProviderCapabilities>,
+) {
+  let currentModel = model;
+  return {
+    name,
+    get model() { return currentModel; },
+    configure: vi.fn((cfg: LLMProviderConfig) => {
+      if (cfg.model) currentModel = cfg.model;
+    }),
+    chat: vi.fn(chatImpl ?? (async () => successResponse(`from ${name}`))),
+    getCapabilities: caps ? () => ({
+      chat: true,
+      vision: false,
+      imageGeneration: false,
+      tts: false,
+      stt: false,
+      videoGeneration: false,
+      embedding: false,
+      reasoning: false,
+      promptCaching: false,
+      ...caps,
+    }) : undefined,
+  };
+}
+
+const sampleRequest: LLMRequest = {
+  messages: [{ role: 'user', content: 'hello' }],
+};
+
+describe('LLMRouter proxy mode', () => {
+  let router: LLMRouter;
+  let anthropic: ReturnType<typeof mockProvider>;
+  let proxy: ReturnType<typeof mockProvider>;
+
+  beforeEach(() => {
+    anthropic = mockProvider('anthropic', 'claude-3-5-sonnet-20241022', async () => successResponse('from anthropic'));
+    proxy = mockProvider('proxy', 'claude-sonnet-4-20250514');
+
+    router = new LLMRouter('proxy');
+    router.registerProvider('anthropic', anthropic);
+    router.registerProvider('proxy', proxy);
+    router.setAutoFallback(true);
+  });
+
+  // ── Scenario 1: Proxy success (happy path) ───────────────
+
+  describe('Scenario 1: Proxy success', () => {
+    it('routes through proxy when proxy is the default provider', async () => {
+      proxy.chat.mockResolvedValue(successResponse('from proxy'));
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from proxy');
+      expect(proxy.chat).toHaveBeenCalledTimes(1);
+      expect(anthropic.chat).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Scenario 2: Proxy unavailable → fallback ─────────────
+
+  describe('Scenario 2: Proxy unavailable → fallback to direct', () => {
+    it('falls back to anthropic when proxy throws PROXY_UNAVAILABLE', async () => {
+      proxy.chat.mockRejectedValue(new Error('PROXY_UNAVAILABLE: fetch failed'));
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from anthropic');
+      expect(anthropic.chat).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back on network-level fetch error', async () => {
+      proxy.chat.mockRejectedValue(new Error('PROXY_UNAVAILABLE: ECONNREFUSED'));
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from anthropic');
+    });
+  });
+
+  // ── Scenario 3: CU exceeded → no fallback ────────────────
+
+  describe('Scenario 3: CU exceeded → friendly error, no fallback', () => {
+    it('throws CU_EXCEEDED error instead of falling back', async () => {
+      proxy.chat.mockRejectedValue(new Error('CU_EXCEEDED: Insufficient CU balance'));
+      await expect(router.chat(sampleRequest)).rejects.toThrow('CU_EXCEEDED');
+      // Should NOT have fallen back to anthropic
+      expect(anthropic.chat).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Scenario 4: CU detection via static method ───────────
+
+  describe('Scenario 4: CU_EXCEEDED detection', () => {
+    it('detects CU_EXCEEDED via isCUExceededError', () => {
+      expect(LLMRouter.isCUExceededError(new Error('CU_EXCEEDED: out of balance'))).toBe(true);
+      expect(LLMRouter.isCUExceededError(new Error('Proxy API error 500'))).toBe(false);
+      expect(LLMRouter.isCUExceededError(new Error('PROXY_UNAVAILABLE: timeout'))).toBe(false);
+    });
+  });
+
+  // ── Scenario 5: CU logging ───────────────────────────────
+
+  describe('Scenario 5: emitLog CU recording', () => {
+    it('does not record CU usage for direct (non-proxy) providers', async () => {
+      const directRouter = new LLMRouter('anthropic');
+      directRouter.registerProvider('anthropic', anthropic);
+      // Spy on the private CU cache by observing behavior — no direct CU tracking for non-proxy
+      directRouter.setAutoFallback(false);
+      await directRouter.chat(sampleRequest);
+      // Success is enough — CU is a proxy-only concept
+      expect(anthropic.chat).toHaveBeenCalledTimes(1);
+    });
+
+    it('records CU usage for proxy provider calls', async () => {
+      proxy.chat.mockResolvedValue(successResponse('from proxy'));
+      const response = await router.chat(sampleRequest);
+      // CU recording happens in emitLog — success means it didn't crash
+      expect(response.content).toBe('from proxy');
+    });
+  });
+
+  // ── Scenario 6: Proxy 5xx → fallback ─────────────────────
+
+  describe('Scenario 6: Proxy 5xx error → falls through to direct', () => {
+    it('falls back on proxy 502 Bad Gateway', async () => {
+      proxy.chat.mockRejectedValue(new Error('Proxy API error 502: Bad Gateway'));
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from anthropic');
+      expect(anthropic.chat).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back on proxy 503 Service Unavailable', async () => {
+      proxy.chat.mockRejectedValue(new Error('Proxy API error 503: Service Unavailable'));
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from anthropic');
+    });
+  });
+
+  // ── Scenario 7: Auth error → degrade proxy (no retry) ────
+
+  describe('Scenario 7: Proxy auth error → degrade, no retry', () => {
+    it('falls back to anthropic on proxy 401, does NOT retry proxy', async () => {
+      proxy.chat.mockRejectedValue(new Error('Proxy API error 401: Invalid API key'));
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from anthropic');
+      // Proxy called exactly once (no retry)
+      expect(proxy.chat).toHaveBeenCalledTimes(1);
+      expect(anthropic.chat).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── Fallback ordering ────────────────────────────────────
+
+  describe('Fallback respects proxy being degraded', () => {
+    it('skips degraded proxy after auth failure on subsequent calls', async () => {
+      // First call: proxy fails with 401, falls back to anthropic
+      proxy.chat.mockRejectedValue(new Error('Proxy API error 401: Invalid API key'));
+      anthropic.chat.mockResolvedValue(successResponse('from anthropic'));
+
+      await router.chat(sampleRequest);
+
+      // Second call: proxy should be degraded, go straight to anthropic
+      const response = await router.chat(sampleRequest);
+      expect(response.content).toBe('from anthropic');
+      // Proxy should have been called only once across both calls
+      expect(proxy.chat).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/web-ui/src/constants/providers.ts
+++ b/packages/web-ui/src/constants/providers.ts
@@ -28,6 +28,7 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
   { id: 'volcengine', label: 'Volcengine (Doubao)', envKey: 'VOLCENGINE_API_KEY', baseUrl: 'https://ark.cn-beijing.volces.com/api/v3', defaultModel: 'doubao-1.5-pro-32k' },
   { id: 'dashscope', label: 'DashScope (Qwen)', envKey: 'DASHSCOPE_API_KEY', baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1', defaultModel: 'qwen-max' },
   { id: 'ollama', label: 'Ollama (Local)', envKey: 'OLLAMA_BASE_URL', baseUrl: 'http://localhost:11434/v1', defaultModel: 'llama3' },
+  { id: 'markus', label: 'Markus', envKey: '', defaultModel: 'markus-default' },
   // Full-modal aggregators
   { id: 'atlascloud', label: 'Atlas Cloud (Full-Modal)', envKey: 'ATLASCLOUD_API_KEY', baseUrl: 'https://api.atlascloud.ai/v1', defaultModel: 'claude-sonnet-4-6' },
   { id: 'strongly', label: 'Strongly.AI (Full-Modal)', envKey: 'STRONGLY_API_KEY', baseUrl: 'https://api.strongly.ai/v1', defaultModel: 'claude-sonnet-4-6' },

--- a/packages/web-ui/src/locales/en/settings.json
+++ b/packages/web-ui/src/locales/en/settings.json
@@ -184,6 +184,7 @@
     "quickSetupSubmit": "Activate",
     "quickSetupSaving": "Activating...",
     "quickSetupSuccess": "{{name}} is now ready to use!",
+    "keyReadOnly": "Key (read-only)",
     "pricingTitle": "Pricing (per 1M tokens)",
     "input": "Input",
     "output": "Output",

--- a/packages/web-ui/src/locales/zh-CN/settings.json
+++ b/packages/web-ui/src/locales/zh-CN/settings.json
@@ -184,6 +184,7 @@
     "quickSetupSubmit": "启用",
     "quickSetupSaving": "启用中...",
     "quickSetupSuccess": "{{name}} 已就绪！",
+    "keyReadOnly": "密钥（只读）",
     "pricingTitle": "定价（每百万 Token）",
     "input": "输入",
     "output": "输出",

--- a/packages/web-ui/src/pages/Settings.tsx
+++ b/packages/web-ui/src/pages/Settings.tsx
@@ -1228,6 +1228,32 @@ export function Settings({ theme, onThemeChange, authUser, onLogout, onUserUpdat
                       </>
                     )}
 
+                    {/* ───── Subscription Key (Markus provider) ───── */}
+                    {name === 'markus' && info.configured && (
+                      <div className="bg-surface-elevated/30 rounded-lg p-4 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <label className="text-[10px] text-fg-tertiary uppercase tracking-wider">Subscription Key</label>
+                          <span className="text-[10px] text-fg-muted">{t('modelProviders.keyReadOnly')}</span>
+                        </div>
+                        <div className="flex gap-2">
+                          <input
+                            type="text"
+                            value={info.apiKeyPreview ?? ''}
+                            readOnly
+                            className="flex-1 px-3 py-2 text-xs bg-surface-primary border border-border-default rounded-lg text-fg-primary font-mono selection:bg-brand-500/30 cursor-text focus:border-brand-500 outline-none"
+                            onClick={e => (e.target as HTMLInputElement).select()}
+                          />
+                          <button
+                            onClick={() => { navigator.clipboard.writeText(info.apiKeyPreview ?? '').catch(() => {}); }}
+                            className="px-3 py-2 text-xs bg-surface-secondary hover:bg-surface-tertiary border border-border-default rounded-lg text-fg-secondary transition-colors"
+                            title="Copy"
+                          >
+                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" /></svg>
+                          </button>
+                        </div>
+                      </div>
+                    )}
+
                     {/* Available Models (read-only informational) */}
                     <div>
                       <div className="flex items-center justify-between mb-2">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,18 @@ importers:
         specifier: ^0.34.5
         version: 0.34.5
 
+  packages/cloudflare-worker:
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250401.0
+        version: 4.20260625.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.0.0
+        version: 4.104.0(@cloudflare/workers-types@4.20260625.1)
+
   packages/comms:
     dependencies:
       '@markus/shared':
@@ -433,6 +445,56 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260623.1':
+    resolution: {integrity: sha512-MvDoIsRTsUJRzAl1/4hDXL839piyyjCeYatBHWgMc12Go7nHxkgbRih+1GJImEiKACSentu410bOupcutqFbpg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260623.1':
+    resolution: {integrity: sha512-sNqHQvHPMOj5/BJOadtEZekRPSG5qQ0/ulC30ZRHRLnmx6tj5O4Wb3Nf0oznnI0pmjXhbv6b7+TOpDkaFMjbBg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260623.1':
+    resolution: {integrity: sha512-XYTWqTlZlCXqG+Po6awjXtlxw73hb3C39B/PP0sb4H9NI3V0eynq8Q7rXNe7DHJs2pWRfDJihQzpayQvpwf5wQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260623.1':
+    resolution: {integrity: sha512-PC5UDKA8oQB3Gek/Y+ysovdHNjp55CihOQZd7F9xPwpkv9qTBB0mhyHnfoG2YHtW1bb9CNhuwiThaNxegpE4mg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260623.1':
+    resolution: {integrity: sha512-OTHLCVYyN0pEfrajpjjnrGg5zA1GDnpNYmMz3x2ESFtH/oXRODsUQBllP7oJpJvMURF3rXSYwAhMojaftGry8w==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260625.1':
+    resolution: {integrity: sha512-asH0RhPHiNu/IUSssyiOJYAcGqysy0DJpO9fihC6KATaayD9CE1E9bgNQozTLUraxrCT2qkM4CBOIcV0M5NPJw==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
   '@dagrejs/dagre@2.0.4':
     resolution: {integrity: sha512-J6vCWTNpicHF4zFlZG1cS5DkGzMr9941gddYkakjrg3ZNev4bbqEgLHFTWiFrcJm7UCRu7olO3K6IRDd9gSGhA==}
 
@@ -500,6 +562,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -514,6 +582,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.4':
     resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -536,6 +610,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -550,6 +630,12 @@ packages:
 
   '@esbuild/android-x64@0.27.4':
     resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -572,6 +658,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
@@ -586,6 +678,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.4':
     resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -608,6 +706,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
@@ -622,6 +726,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.4':
     resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -644,6 +754,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
@@ -658,6 +774,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.4':
     resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -680,6 +802,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
@@ -694,6 +822,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.4':
     resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -716,6 +850,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
@@ -730,6 +870,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.4':
     resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -752,6 +898,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -766,6 +918,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.4':
     resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -788,6 +946,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
@@ -802,6 +966,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.4':
     resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -824,6 +994,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
@@ -838,6 +1014,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.4':
     resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -860,6 +1042,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
@@ -874,6 +1062,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.4':
     resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -896,6 +1090,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
@@ -910,6 +1110,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.4':
     resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -932,6 +1138,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
@@ -946,6 +1158,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.4':
     resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1189,6 +1407,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
   '@larksuiteoapi/node-sdk@1.66.1':
     resolution: {integrity: sha512-W1rIAs/8Oc/rEYuWc0sxGvR8iLwd8p5D2RS4ODMqs8htIxK8yIa8sb22EDv/OEBqUpKXZaNLydTz7Oq8HOQROg==}
 
@@ -1228,6 +1449,15 @@ packages:
   '@peculiar/webcrypto@1.7.1':
     resolution: {integrity: sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==}
     engines: {node: '>=14.18.0'}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -1403,6 +1633,13 @@ packages:
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1861,6 +2098,9 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
@@ -2032,6 +2272,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -2257,6 +2501,9 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -2291,6 +2538,11 @@ packages:
 
   esbuild@0.27.4:
     resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2767,6 +3019,10 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
 
@@ -3085,6 +3341,11 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  miniflare@4.20260623.0:
+    resolution: {integrity: sha512-p2YTeH01jMiMOjO4v9hb/+GJndja5LCxecGOWCaT9F414PRXgdddLDsK6MnqhGBB5tlU/WoBYIG1XZte5pQzOQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -3242,6 +3503,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -3625,6 +3889,10 @@ packages:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
     engines: {node: '>= 8.0'}
 
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3745,9 +4013,16 @@ packages:
     resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
   undici@8.4.0:
     resolution: {integrity: sha512-tDR4LgFBeV7YBWOFMlmbhtrnFVWuZ6HKbkG+88/csQdhK2tPlW78PnLI2VRjIQtTlslvgSZ4R43WBE+4g6rhng==}
     engines: {node: '>=22.19.0'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -3933,6 +4208,21 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerd@1.20260623.1:
+    resolution: {integrity: sha512-9SJsdTSsehhqc26TUJIzyi1XgyYeqFym4hinZnWoAP1BkhEoMQ5Ygz7Xw9T+2ecU+y409JBEScBgWTdZ06mBrg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.104.0:
+    resolution: {integrity: sha512-xCfbg2Oj93Bc7EMryFaSeRGDgV96dzrWoaK5q2q5XLEvumO4mysNP/1MDue0GUozEJAI6Z6vrGyYPLmfET/0sg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260623.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -3946,6 +4236,18 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4004,6 +4306,12 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -4154,6 +4462,35 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260623.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260623.1
+
+  '@cloudflare/workerd-darwin-64@1.20260623.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260623.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260623.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260623.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260623.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260625.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
   '@dagrejs/dagre@2.0.4':
     dependencies:
       '@dagrejs/graphlib': 3.0.4
@@ -4267,6 +4604,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.4':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
@@ -4274,6 +4614,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
@@ -4285,6 +4628,9 @@ snapshots:
   '@esbuild/android-arm@0.27.4':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
     optional: true
 
@@ -4292,6 +4638,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.4':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
@@ -4303,6 +4652,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.4':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
@@ -4310,6 +4662,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.4':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
@@ -4321,6 +4676,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.4':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
@@ -4328,6 +4686,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
@@ -4339,6 +4700,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.4':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
@@ -4346,6 +4710,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.4':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
@@ -4357,6 +4724,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.4':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
@@ -4364,6 +4734,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
@@ -4375,6 +4748,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.4':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
@@ -4382,6 +4758,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.4':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
@@ -4393,6 +4772,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.4':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -4400,6 +4782,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.4':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -4411,6 +4796,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.4':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
@@ -4418,6 +4806,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
@@ -4429,6 +4820,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
@@ -4436,6 +4830,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -4447,6 +4844,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.4':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
@@ -4454,6 +4854,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
@@ -4465,6 +4868,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.4':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
@@ -4472,6 +4878,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
@@ -4483,6 +4892,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.4':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
@@ -4490,6 +4902,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.4':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@10.0.2(jiti@2.6.1))':
@@ -4668,6 +5083,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   '@larksuiteoapi/node-sdk@1.66.1':
     dependencies:
       axios: 1.13.6
@@ -4724,6 +5144,18 @@ snapshots:
       '@peculiar/utils': 2.0.3
       tslib: 2.8.1
       webcrypto-core: 1.9.2
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -4825,6 +5257,10 @@ snapshots:
     optional: true
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.17': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -5374,6 +5810,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  blake3-wasm@2.1.5: {}
+
   bluebird@3.7.2: {}
 
   boolbase@1.0.0: {}
@@ -5549,6 +5987,8 @@ snapshots:
       yargs: 17.7.2
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -5814,6 +6254,8 @@ snapshots:
 
   err-code@2.0.3: {}
 
+  error-stack-parser-es@1.0.5: {}
+
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -5920,6 +6362,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.4
       '@esbuild/win32-ia32': 0.27.4
       '@esbuild/win32-x64': 0.27.4
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -6462,6 +6933,8 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  kleur@4.1.5: {}
+
   lazy-val@1.0.5: {}
 
   levn@0.4.1:
@@ -6968,6 +7441,18 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
+  miniflare@4.20260623.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260623.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -7119,6 +7604,8 @@ snapshots:
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
 
@@ -7615,6 +8102,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  supports-color@10.2.2: {}
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -7731,7 +8220,13 @@ snapshots:
 
   undici@6.27.0: {}
 
+  undici@7.28.0: {}
+
   undici@8.4.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
 
   unified@11.0.5:
     dependencies:
@@ -7919,6 +8414,31 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerd@1.20260623.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260623.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260623.1
+      '@cloudflare/workerd-linux-64': 1.20260623.1
+      '@cloudflare/workerd-linux-arm64': 1.20260623.1
+      '@cloudflare/workerd-windows-64': 1.20260623.1
+
+  wrangler@4.104.0(@cloudflare/workers-types@4.20260625.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260623.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260623.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260623.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260625.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -7934,6 +8454,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.19.0: {}
+
+  ws@8.21.0: {}
 
   xmlbuilder@15.1.1: {}
 
@@ -7986,6 +8508,19 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,10 @@ importers:
         version: 0.34.5
 
   packages/cloudflare-worker:
+    dependencies:
+      jose:
+        specifier: ^6.2.3
+        version: 6.2.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250401.0
@@ -110,6 +114,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.9.0)
       wrangler:
         specifier: ^4.0.0
         version: 4.104.0(@cloudflare/workers-types@4.20260625.1)
@@ -2967,6 +2974,9 @@ packages:
   joi@18.0.2:
     resolution: {integrity: sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==}
     engines: {node: '>= 20'}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   js-tiktoken@1.0.21:
     resolution: {integrity: sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==}
@@ -6887,6 +6897,8 @@ snapshots:
       '@hapi/tlds': 1.1.6
       '@hapi/topo': 6.0.2
       '@standard-schema/spec': 1.1.0
+
+  jose@6.2.3: {}
 
   js-tiktoken@1.0.21:
     dependencies:


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Frontend Developer (ID: agt_ca836fdc2c08b8e9ec1370a8)
- **关联任务**: tsk_067be9f1e5f5fc18b1f6dd92
- **目标分支**: main

## 🎯 背景与动机 (Why)
Desktop UI的Provider选择中需要默认选中「Markus」，并且在Markus Provider卡片中展示系统自动生成的subscription key（格式：markus_<48hex>）。

## 🔧 变更内容 (What)
- **packages/web-ui/src/constants/providers.ts**: 新增 'markus' PROVIDER_OPTIONS条目（envKey为空，无需用户手动输入key）
- **packages/web-ui/src/pages/Settings.tsx**: 在Markus provider卡片内添加Subscription Key展示区（readOnly input + copy按钮），仅在info.configured时显示
- **packages/web-ui/src/locales/en/settings.json**: 添加keyReadOnly翻译
- **packages/web-ui/src/locales/zh-CN/settings.json**: 添加keyReadOnly翻译

## ✅ 验证方式 (How to Verify)
- [x] pnpm --filter @markus/web-ui exec npx tsc --noEmit — exit code 0
- [x] eslint — 0 errors

## 👤 评审人
- **Reviewer**: Code Reviewer