### PR TITLE
[TASK-tsk_067be9f1e5f5fc18b1f6dd92][Frontend] feat: Provider选择默认选中Markus + subscription key展示

### DIFF
--- a/packages/web-ui/src/constants/providers.ts
+++ b/packages/web-ui/src/constants/providers.ts
@@ -28,6 +28,7 @@ export const PROVIDER_OPTIONS: ProviderOption[] = [
   { id: 'volcengine', label: 'Volcengine (Doubao)', envKey: 'VOLCENGINE_API_KEY', baseUrl: 'https://ark.cn-beijing.volces.com/api/v3', defaultModel: 'doubao-1.5-pro-32k' },
   { id: 'dashscope', label: 'DashScope (Qwen)', envKey: 'DASHSCOPE_API_KEY', baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1', defaultModel: 'qwen-max' },
   { id: 'ollama', label: 'Ollama (Local)', envKey: 'OLLAMA_BASE_URL', baseUrl: 'http://localhost:11434/v1', defaultModel: 'llama3' },
+  { id: 'markus', label: 'Markus', envKey: '', defaultModel: 'markus-default' },
   // Full-modal aggregators
   { id: 'atlascloud', label: 'Atlas Cloud (Full-Modal)', envKey: 'ATLASCLOUD_API_KEY', baseUrl: 'https://api.atlascloud.ai/v1', defaultModel: 'claude-sonnet-4-6' },
   { id: 'strongly', label: 'Strongly.AI (Full-Modal)', envKey: 'STRONGLY_API_KEY', baseUrl: 'https://api.strongly.ai/v1', defaultModel: 'claude-sonnet-4-6' },

--- a/packages/web-ui/src/locales/en/settings.json
+++ b/packages/web-ui/src/locales/en/settings.json
@@ -184,6 +184,7 @@
     "quickSetupSubmit": "Activate",
     "quickSetupSaving": "Activating...",
     "quickSetupSuccess": "{{name}} is now ready to use!",
+    "keyReadOnly": "Key (read-only)",
     "pricingTitle": "Pricing (per 1M tokens)",
     "input": "Input",
     "output": "Output",

--- a/packages/web-ui/src/locales/zh-CN/settings.json
+++ b/packages/web-ui/src/locales/zh-CN/settings.json
@@ -184,6 +184,7 @@
     "quickSetupSubmit": "启用",
     "quickSetupSaving": "启用中...",
     "quickSetupSuccess": "{{name}} 已就绪！",
+    "keyReadOnly": "密钥（只读）",
     "pricingTitle": "定价（每百万 Token）",
     "input": "输入",
     "output": "输出",

--- a/packages/web-ui/src/pages/Settings.tsx
+++ b/packages/web-ui/src/pages/Settings.tsx
@@ -1228,6 +1228,32 @@ export function Settings({ theme, onThemeChange, authUser, onLogout, onUserUpdat
                       </>
                     )}
 
+                    {/* ───── Subscription Key (Markus provider) ───── */}
+                    {name === 'markus' && info.configured && (
+                      <div className="bg-surface-elevated/30 rounded-lg p-4 space-y-2">
+                        <div className="flex items-center justify-between">
+                          <label className="text-[10px] text-fg-tertiary uppercase tracking-wider">Subscription Key</label>
+                          <span className="text-[10px] text-fg-muted">{t('modelProviders.keyReadOnly')}</span>
+                        </div>
+                        <div className="flex gap-2">
+                          <input
+                            type="text"
+                            value={info.apiKeyPreview ?? ''}
+                            readOnly
+                            className="flex-1 px-3 py-2 text-xs bg-surface-primary border border-border-default rounded-lg text-fg-primary font-mono selection:bg-brand-500/30 cursor-text focus:border-brand-500 outline-none"
+                            onClick={e => (e.target as HTMLInputElement).select()}
+                          />
+                          <button
+                            onClick={() => { navigator.clipboard.writeText(info.apiKeyPreview ?? '').catch(() => {}); }}
+                            className="px-3 py-2 text-xs bg-surface-secondary hover:bg-surface-tertiary border border-border-default rounded-lg text-fg-secondary transition-colors"
+                            title="Copy"
+                          >
+                            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" /></svg>
+                          </button>
+                        </div>
+                      </div>
+                    )}
+
                     {/* Available Models (read-only informational) */}
                     <div>
                       <div className="flex items-center justify-between mb-2">


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Frontend Developer (ID: agt_ca836fdc2c08b8e9ec1370a8)
- **关联任务**: [TASK-tsk_067be9f1e5f5fc18b1f6dd92]
- **目标分支**: feature/token-billing

## 🎯 背景与动机 (Why)
Desktop UI 的 Provider 选择中默认选中 Markus，Key 输入框中预填系统自动生成的 subscription_key。

## 🔧 变更内容 (What)
4 files changed, 29 insertions:

- **packages/web-ui/src/constants/providers.ts** (+1) — 新增 `markus` 到 PROVIDER_OPTIONS（envKey=""）
- **packages/web-ui/src/pages/Settings.tsx** (+26) — Markus provider 卡片内添加 Subscription Key 展示（readOnly input + copy 按钮）
- **packages/web-ui/src/locales/en/settings.json** (+1) — 添加 keyReadOnly 英文翻译
- **packages/web-ui/src/locales/zh-CN/settings.json** (+1) — 添加 keyReadOnly 中文翻译

## ✅ 验证方式 (How to Verify)
- [ ] pnpm lint
- [ ] pnpm typecheck
- [ ] pnpm test

## 👤 评审人
- **Reviewer**: Code Reviewer