### PR TITLE
feat(token-billing): pre-reserve + post-correct CU charging middleware

### DIFF
--- a/packages/cloudflare-worker/README.md
+++ b/packages/cloudflare-worker/README.md
@@ -54,11 +54,20 @@ npx wrangler secret put LLM_PROXY_BASE_URL --env production
 npx wrangler secret put LLM_PROXY_API_KEY --env production
 ```
 
+If using token billing (CU quota system), also set:
+
+```bash
+npx wrangler secret put UPSTASH_REDIS_URL --env production
+npx wrangler secret put UPSTASH_REDIS_TOKEN --env production
+```
+
 | Secret | Description | Example |
 |--------|-------------|---------|
 | `PROXY_JWT_SECRET` | JWT signing secret (generate via `openssl rand -hex 32`) | `a1b2c3...` |
 | `LLM_PROXY_BASE_URL` | Upstream LLM provider base URL | `https://api.openai.com/v1` |
 | `LLM_PROXY_API_KEY` | API key for upstream LLM provider | `sk-...` |
+| `UPSTASH_REDIS_URL` | Upstash Redis REST URL (for CU quota billing) | `https://xxxx.upstash.io` |
+| `UPSTASH_REDIS_TOKEN` | Upstash Redis REST token | `AXXXX...` |
 
 ### 5. (Optional) Configure domain / routes
 
@@ -120,6 +129,9 @@ Expected response:
 | `PROXY_JWT_SECRET` | secret | `wrangler secret put` | Yes (proxy mode) |
 | `LLM_PROXY_BASE_URL` | secret | `wrangler secret put` | Yes (proxy mode) |
 | `LLM_PROXY_API_KEY` | secret | `wrangler secret put` | Yes (proxy mode) |
+| `UPSTASH_REDIS_URL` | secret | `wrangler secret put` | Only if using CU quota |
+| `UPSTASH_REDIS_TOKEN` | secret | `wrangler secret put` | Only if using CU quota |
+| `DEFAULT_CU_LIMIT` | per-environment | `wrangler.toml` `[env.*.vars]` | No (default: `10000`) |
 
 ## Testing
 

--- a/packages/cloudflare-worker/README.md
+++ b/packages/cloudflare-worker/README.md
@@ -1,0 +1,173 @@
+# Markus Proxy — Cloudflare Worker
+
+Production-grade LLM proxy with token billing support, running on Cloudflare Workers.
+
+## Architecture
+
+```
+Client → [Cloudflare Worker] → Upstream LLM Provider (OpenAI-compatible)
+```
+
+Requests are authenticated via:
+- **Proxy JWT mode** — Bearer token with embedded CU quota (platform billing)
+- **Direct API-key mode** — Caller provides their own API key (passthrough)
+
+## Prerequisites
+
+- Node.js >= 22
+- pnpm >= 9
+- [Cloudflare account](https://dash.cloudflare.com) with Workers enabled
+- `wrangler` CLI (installed via `pnpm install`)
+
+## Setup
+
+### 1. Install dependencies
+
+```bash
+cd packages/cloudflare-worker
+pnpm install
+```
+
+### 2. Configure wrangler.toml
+
+Edit `wrangler.toml` and set your `account_id`:
+
+```toml
+account_id = "your-account-id-here"
+```
+
+Find your Account ID at [Cloudflare Dashboard](https://dash.cloudflare.com) → Workers & Pages.
+
+### 3. Authenticate with Cloudflare
+
+```bash
+npx wrangler login
+```
+
+This opens a browser window to authorize wrangler CLI with your Cloudflare account.
+
+### 4. Set production secrets
+
+```bash
+npx wrangler secret put PROXY_JWT_SECRET --env production
+npx wrangler secret put LLM_PROXY_BASE_URL --env production
+npx wrangler secret put LLM_PROXY_API_KEY --env production
+```
+
+| Secret | Description | Example |
+|--------|-------------|---------|
+| `PROXY_JWT_SECRET` | JWT signing secret (generate via `openssl rand -hex 32`) | `a1b2c3...` |
+| `LLM_PROXY_BASE_URL` | Upstream LLM provider base URL | `https://api.openai.com/v1` |
+| `LLM_PROXY_API_KEY` | API key for upstream LLM provider | `sk-...` |
+
+### 5. (Optional) Configure domain / routes
+
+In Cloudflare Dashboard:
+1. Add your domain to Cloudflare
+2. Workers & Pages → markus-proxy → Triggers → Custom Domains
+3. Add `proxy.markus.ai` (or your preferred subdomain)
+
+If using routes instead of custom domains, update `routes` in `wrangler.toml`.
+
+## Deployment
+
+### Production
+
+```bash
+cd packages/cloudflare-worker
+npx wrangler deploy --env production
+```
+
+### Staging (if configured)
+
+```bash
+npx wrangler deploy --env staging
+```
+
+### Local development
+
+```bash
+npx wrangler dev
+```
+
+This starts a local dev server at `http://localhost:8787`.
+
+## Verification
+
+After deployment, verify the health endpoint:
+
+```bash
+curl https://proxy.markus.ai/health
+```
+
+Expected response:
+
+```json
+{
+  "status": "ok",
+  "service": "markus-proxy",
+  "version": "0.1.0",
+  "timestamp": "2025-04-01T00:00:00.000Z",
+  "uptime": 12345
+}
+```
+
+## Environment Variables
+
+| Variable | Scope | Where to set | Required |
+|----------|-------|-------------|----------|
+| `ENVIRONMENT` | per-environment | `wrangler.toml` `[env.*.vars]` | Yes |
+| `PROXY_JWT_SECRET` | secret | `wrangler secret put` | Yes (proxy mode) |
+| `LLM_PROXY_BASE_URL` | secret | `wrangler secret put` | Yes (proxy mode) |
+| `LLM_PROXY_API_KEY` | secret | `wrangler secret put` | Yes (proxy mode) |
+
+## Testing
+
+```bash
+pnpm test          # Run unit tests
+pnpm test:watch    # Watch mode
+pnpm typecheck     # TypeScript type checking
+pnpm build         # Dry-run deploy (validate config)
+```
+
+## CI/CD
+
+The Worker deployment can be added to GitHub Actions:
+
+```yaml
+- name: Deploy Worker
+  run: npx wrangler deploy --env production
+  working-directory: packages/cloudflare-worker
+  env:
+    CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+> Note: For CI/CD, use a Cloudflare API Token with `Workers: Edit` permissions
+> set via GitHub Secrets, rather than `wrangler login`.
+
+## Project Structure
+
+```
+packages/cloudflare-worker/
+├── wrangler.toml          # Worker configuration
+├── src/
+│   ├── index.ts           # Entry point / request handler
+│   ├── auth-context.ts    # Auth context (request-scoped)
+│   ├── jwt-verify.ts      # JWT verification
+│   ├── routes/
+│   │   ├── health.ts      # GET /health
+│   │   └── chat.ts        # POST /v1/chat/completions
+│   ├── middleware/
+│   │   ├── auth.ts        # JWT / API-key auth
+│   │   ├── cors.ts        # CORS headers
+│   │   ├── logging.ts     # Request logging
+│   │   ├── rate-limit.ts  # In-memory rate limiting
+│   │   └── timeout.ts     # Request timeout
+│   └── utils/
+│       ├── errors.ts      # Error types
+│       └── response.ts    # Response helpers
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+└── README.md
+```

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -13,15 +13,13 @@
  *     ├─ CORS (handles OPTIONS preflight)
  *     ├─ Logging (captures start time)
  *     ├─ Rate Limit (in-memory sliding window)
- *     ├─ Auth (validates X-Subscription-Key)
+ *     ├─ Auth (validates JWT or x-api-key)
+ *     ├─ Charging (pre-reserve CU, may return 429)
  *     │
  *     └─ Router ─┬─ GET  /health                → health.ts
  *                 └─ POST /v1/chat/completions   → chat.ts
- *
- * Future phases will add:
- *   - /v1/models          → model list
- *   - /v1/usage           → usage stats
- *   - Token deduction & quota checks via Hub API
+ *                      │
+ *                      └─ Post-correct (refund unused CU)
  */
 
 // ---------------------------------------------------------------------------
@@ -52,6 +50,7 @@ import { handleCors, transformResponse } from './middleware/cors.js';
 import { startLog } from './middleware/logging.js';
 import { createRateLimiter } from './middleware/rate-limit.js';
 import { handleAuth } from './middleware/auth.js';
+import { handleCharging, postCorrectCu } from './middleware/charging.js';
 import { withTimeout } from './middleware/timeout.js';
 import { handleHealth } from './routes/health.js';
 import { handleChat } from './routes/chat.js';
@@ -95,13 +94,22 @@ export default {
       return transformResponse(authResponse);
     }
 
-    // ----- 5. Route + handler (with timeout) --------------------------------
+    // ----- 5. Charging (pre-reserve CU, may return 429) ---------------------
+    const chargingResponse = await handleCharging(request, env);
+    if (chargingResponse) {
+      finishLog(chargingResponse);
+      return transformResponse(chargingResponse);
+    }
+
+    // ----- 6. Route + handler (with timeout) --------------------------------
     const handler = withTimeout(routeRequest);
 
     try {
       const response = await handler(request, env, ctx);
-      finishLog(response);
-      return transformResponse(response);
+      // Post-correct: refund unused CU after handler completes
+      const correctedResponse = await postCorrectCu(env, request, response);
+      finishLog(correctedResponse);
+      return transformResponse(correctedResponse);
     } catch (err) {
       const errorResponse = handleFatalError(err);
       finishLog(errorResponse);

--- a/packages/cloudflare-worker/src/index.ts
+++ b/packages/cloudflare-worker/src/index.ts
@@ -24,6 +24,30 @@
  *   - Token deduction & quota checks via Hub API
  */
 
+// ---------------------------------------------------------------------------
+// Environment bindings
+// ---------------------------------------------------------------------------
+
+export interface Env {
+  /** Environment identifier ("development", "staging", "production") */
+  ENVIRONMENT: string;
+
+  /** Upstream LLM provider base URL (proxy JWT mode) */
+  LLM_PROXY_BASE_URL?: string;
+
+  /** Upstream LLM provider API key (proxy JWT mode) */
+  LLM_PROXY_API_KEY?: string;
+
+  /** Upstash Redis REST API URL */
+  UPSTASH_REDIS_URL: string;
+
+  /** Upstash Redis REST API token */
+  UPSTASH_REDIS_TOKEN: string;
+
+  /** Default CU quota limit per user (parsed as number) */
+  DEFAULT_CU_LIMIT?: string;
+}
+
 import { handleCors, transformResponse } from './middleware/cors.js';
 import { startLog } from './middleware/logging.js';
 import { createRateLimiter } from './middleware/rate-limit.js';

--- a/packages/cloudflare-worker/src/middleware/__tests__/charging.test.ts
+++ b/packages/cloudflare-worker/src/middleware/__tests__/charging.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Tests for the charging middleware (pre-reserve + post-correct CU).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks — auto-mock (no factory) to avoid hoisting issues
+// ---------------------------------------------------------------------------
+
+vi.mock('../../redis/quota.js');
+vi.mock('../../auth-context.js');
+
+// ---------------------------------------------------------------------------
+// Subject under test (must import AFTER vi.mock)
+// ---------------------------------------------------------------------------
+
+import { deductQuota, creditQuota } from '../../redis/quota.js';
+import { getAuthContext } from '../../auth-context.js';
+
+import {
+  estimateMaxCu,
+  setChargingContext,
+  getChargingContext,
+  preReserveCu,
+  postCorrectCu,
+  handleCharging,
+} from '../charging.js';
+
+import type { ChargingContext } from '../charging.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(url = 'https://api.markus.com/v1/chat/completions', method = 'POST', body?: unknown): Request {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.headers = { 'content-type': 'application/json' };
+    init.body = JSON.stringify(body);
+  }
+  return new Request(url, init);
+}
+
+function makeEnv(hasRedis = true): Record<string, unknown> {
+  return hasRedis
+    ? { UPSTASH_REDIS_URL: 'https://redis.example.com', UPSTASH_REDIS_TOKEN: 'tok_abc', DEFAULT_CU_LIMIT: '100000' }
+    : { DEFAULT_CU_LIMIT: '100000' };
+}
+
+function makeResponse(headers?: Record<string, string>): Response {
+  return new Response(JSON.stringify({ id: 'test' }), {
+    status: 200,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('estimateMaxCu', () => {
+  it('returns 5 CU for empty messages (1 input + 4096 output = 4097 → 5)', () => {
+    expect(estimateMaxCu({ messages: [] })).toBe(5);
+  });
+
+  it('returns 5 CU for very short message (1 input + 4096 output = 5)', () => {
+    expect(estimateMaxCu({ messages: [{ role: 'user', content: 'Hi' }] })).toBe(5);
+  });
+
+  it('returns 5 CU for ~3600 input chars (900 tokens + 4096 output = 4996)', () => {
+    const longContent = 'A'.repeat(3600); // ~900 tokens input
+    // 900 + 4096 = 4996 → ceil(4996/1000) = 5
+    expect(estimateMaxCu({ messages: [{ role: 'user', content: longContent }] })).toBe(5);
+  });
+
+  it('accounts for max_tokens in estimation', () => {
+    const content = 'A'.repeat(200); // 50 tokens input
+    // max_tokens = 100 → 50 + 100 = 150 → 1 CU
+    expect(estimateMaxCu({ messages: [{ role: 'user', content }], max_tokens: 100 })).toBe(1);
+  });
+
+  it('defaults to 4096 output tokens when max_tokens is not set', () => {
+    const content = 'A'.repeat(4000); // 1000 tokens input
+    // 1000 + 4096 = 5096 → ceil(5096/1000) = 6
+    expect(estimateMaxCu({ messages: [{ role: 'user', content }] })).toBe(6);
+  });
+
+  it('sums across multiple messages', () => {
+    const msg = { role: 'user' as const, content: 'A'.repeat(2000) };
+    // 500 tokens per msg × 3 = 1500 + 4096 = 5596 → 6 CU
+    expect(estimateMaxCu({ messages: [msg, msg, msg] })).toBe(6);
+  });
+
+  it('returns minimum 1 CU even for zero-length content with max_tokens=0', () => {
+    expect(estimateMaxCu({ messages: [{ role: 'user', content: '' }], max_tokens: 0 })).toBe(1);
+  });
+});
+
+describe('charging context (set/getChargingContext)', () => {
+  it('stores and retrieves context from the same request', () => {
+    const req = makeRequest();
+    const ctx: ChargingContext = { userId: 'u1', reserved: 10, limit: 100 };
+
+    setChargingContext(req, ctx);
+    expect(getChargingContext(req)).toEqual(ctx);
+  });
+
+  it('returns undefined when no context is set', () => {
+    const req = makeRequest();
+    expect(getChargingContext(req)).toBeUndefined();
+  });
+
+  it('isolates context between different requests', () => {
+    const req1 = makeRequest();
+    const req2 = makeRequest();
+    const ctx: ChargingContext = { userId: 'u1', reserved: 10, limit: 100 };
+
+    setChargingContext(req1, ctx);
+    expect(getChargingContext(req2)).toBeUndefined();
+    expect(getChargingContext(req1)).toEqual(ctx);
+  });
+});
+
+describe('preReserveCu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns skip when no Redis is configured', async () => {
+    const env = makeEnv(false);
+    const result = await preReserveCu(env, 'user1', 10);
+
+    expect(result).toEqual({ ok: true, reserved: 0, remaining: 999999, limit: 999999 });
+    expect(deductQuota).not.toHaveBeenCalled();
+  });
+
+  it('returns ok with reserved amount on successful deduction', async () => {
+    vi.mocked(deductQuota).mockResolvedValueOnce({
+      remaining: 990,
+      usage: 10,
+      limit: 1000,
+    });
+
+    const env = makeEnv(true);
+    const result = await preReserveCu(env, 'user1', 10);
+
+    expect(result).toEqual({ ok: true, reserved: 10, remaining: 990, limit: 1000 });
+    expect(vi.mocked(deductQuota)).toHaveBeenCalledWith(env, 'user1', 10);
+  });
+
+  it('returns QUOTA_EXCEEDED when remaining is -1', async () => {
+    vi.mocked(deductQuota).mockResolvedValueOnce({
+      remaining: -1,
+      usage: 100000,
+      limit: 1000,
+    });
+
+    const env = makeEnv(true);
+    const result = await preReserveCu(env, 'user1', 10);
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'QUOTA_EXCEEDED',
+      message: expect.stringContaining('exhausted'),
+    });
+  });
+
+  it('returns RESERVE_FAILED when deduct returns error', async () => {
+    vi.mocked(deductQuota).mockResolvedValueOnce({
+      error: 'some_error',
+      remaining: 0,
+      usage: 0,
+      limit: 1000,
+    });
+
+    const env = makeEnv(true);
+    const result = await preReserveCu(env, 'user1', 10);
+
+    expect(result).toEqual({
+      ok: false,
+      code: 'RESERVE_FAILED',
+      message: expect.stringContaining('some_error'),
+    });
+  });
+
+  it('degrades gracefully when deductQuota throws', async () => {
+    vi.mocked(deductQuota).mockRejectedValueOnce(new Error('Redis timeout'));
+
+    const env = makeEnv(true);
+    const result = await preReserveCu(env, 'user1', 10);
+
+    expect(result).toEqual({ ok: true, reserved: 0, remaining: -2, limit: 0 });
+  });
+});
+
+describe('postCorrectCu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns response unchanged when no charging context exists', async () => {
+    const req = makeRequest();
+    const res = makeResponse();
+
+    const result = await postCorrectCu(makeEnv(true), req, res);
+
+    expect(result.status).toBe(200);
+    const cuHeaders = Array.from(result.headers.keys()).filter(h => h.startsWith('x-cu-'));
+    expect(cuHeaders).toHaveLength(0);
+  });
+
+  it('adds CU headers without refund when reserved equals actual', async () => {
+    const req = makeRequest();
+    setChargingContext(req, { userId: 'u1', reserved: 5, limit: 1000 });
+    const res = makeResponse({ 'x-cu-actual': '5' });
+
+    const result = await postCorrectCu(makeEnv(true), req, res);
+
+    expect(result.headers.get('x-cu-cost')).toBe('5');
+    expect(result.headers.get('x-cu-remaining')).toBe('995'); // 1000 - 5
+    expect(result.headers.get('x-cu-limit')).toBe('1000');
+    expect(creditQuota).not.toHaveBeenCalled();
+  });
+
+  it('refunds difference when reserved > actual', async () => {
+    vi.mocked(creditQuota).mockResolvedValueOnce({ remaining: 10, usage: 5, limit: 15 });
+
+    const req = makeRequest();
+    setChargingContext(req, { userId: 'u1', reserved: 10, limit: 15 });
+    const res = makeResponse({ 'x-cu-actual': '3' });
+
+    const result = await postCorrectCu(makeEnv(true), req, res);
+
+    expect(vi.mocked(creditQuota)).toHaveBeenCalledWith(
+      expect.objectContaining({ UPSTASH_REDIS_URL: 'https://redis.example.com' }),
+      'u1',
+      7, // refund = 10 - 3 = 7
+    );
+    expect(result.headers.get('x-cu-cost')).toBe('3');
+    expect(result.headers.get('x-cu-remaining')).toBe('12'); // 15 - 3 = 12
+    expect(result.headers.get('x-cu-limit')).toBe('15');
+  });
+
+  it('falls back to reserved amount when x-cu-actual header is missing', async () => {
+    const req = makeRequest();
+    setChargingContext(req, { userId: 'u1', reserved: 5, limit: 1000 });
+    const res = makeResponse(); // no x-cu-actual → uses reserved as final cost
+
+    const result = await postCorrectCu(makeEnv(true), req, res);
+
+    expect(creditQuota).not.toHaveBeenCalled();
+    expect(result.headers.get('x-cu-cost')).toBe('5'); // reserved as final cost
+    expect(result.headers.get('x-cu-remaining')).toBe('995'); // 1000 - 5
+    expect(result.headers.get('x-cu-limit')).toBe('1000');
+  });
+
+  it('handles creditQuota failure gracefully (non-fatal)', async () => {
+    vi.mocked(creditQuota).mockRejectedValueOnce(new Error('Refund failed'));
+
+    const req = makeRequest();
+    setChargingContext(req, { userId: 'u1', reserved: 10, limit: 1000 });
+    const res = makeResponse({ 'x-cu-actual': '3' });
+
+    const result = await postCorrectCu(makeEnv(true), req, res);
+
+    expect(result.status).toBe(200);
+    expect(result.headers.get('x-cu-cost')).toBe('3');
+    expect(result.headers.get('x-cu-remaining')).toBe('997'); // 1000 - 3
+    expect(result.headers.get('x-cu-limit')).toBe('1000');
+  });
+
+  it('does nothing when reserved is 0 (charging skipped)', async () => {
+    const req = makeRequest();
+    setChargingContext(req, { userId: 'u1', reserved: 0, limit: 1000 });
+    const res = makeResponse({ 'x-cu-actual': '5' });
+
+    const result = await postCorrectCu(makeEnv(true), req, res);
+
+    expect(creditQuota).not.toHaveBeenCalled();
+    expect(result.status).toBe(200);
+  });
+});
+
+describe('handleCharging', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: proxy mode, sufficient quota
+    vi.mocked(getAuthContext).mockReturnValue({
+      mode: 'proxy',
+      payload: { sub: 'user_test', plan_type: 'pro', monthly_quota_cu: 100000, cu_used: 0, iat: 1000, exp: 2000 },
+    });
+    vi.mocked(deductQuota).mockResolvedValue({ remaining: 99990, usage: 10, limit: 100000 });
+  });
+
+  it('passes through for non-POST requests', async () => {
+    const req = new Request('https://api.markus.com/v1/chat/completions', { method: 'GET' });
+    const result = await handleCharging(req, makeEnv(true));
+    expect(result).toBeNull();
+  });
+
+  it('passes through for non-chat routes', async () => {
+    const req = makeRequest('https://api.markus.com/health');
+    const result = await handleCharging(req, makeEnv(true));
+    expect(result).toBeNull();
+  });
+
+  it('passes through when no auth context', async () => {
+    vi.mocked(getAuthContext).mockReturnValueOnce(undefined);
+    const req = makeRequest();
+    const result = await handleCharging(req, makeEnv(true));
+    expect(result).toBeNull();
+  });
+
+  it('passes through in direct API-key mode', async () => {
+    vi.mocked(getAuthContext).mockReturnValueOnce({
+      mode: 'direct',
+      apiKey: 'sk-xxx',
+    });
+    const req = makeRequest();
+    const result = await handleCharging(req, makeEnv(true));
+    expect(result).toBeNull();
+  });
+
+  it('passes through and attaches charging context for proxy mode with sufficient quota', async () => {
+    const req = makeRequest(undefined, 'POST', {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+
+    const result = await handleCharging(req, makeEnv(true));
+
+    expect(result).toBeNull();
+    const ctx = getChargingContext(req);
+    expect(ctx).toBeDefined();
+    expect(ctx!.userId).toBe('user_test');
+    expect(ctx!.reserved).toBeGreaterThan(0);
+    expect(ctx!.limit).toBe(100000);
+  });
+
+  it('returns 429 when quota is exceeded', async () => {
+    vi.mocked(deductQuota).mockResolvedValueOnce({
+      remaining: -1, usage: 100000, limit: 1000,
+    });
+
+    const req = makeRequest(undefined, 'POST', {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+
+    const result = await handleCharging(req, makeEnv(true));
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(429);
+    const body = await result!.json() as { error: { code: string } };
+    expect(body.error.code).toBe('FORBIDDEN');
+  });
+
+  it('passes through for malformed JSON body', async () => {
+    const req = new Request('https://api.markus.com/v1/chat/completions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: 'not-json',
+    });
+
+    const result = await handleCharging(req, makeEnv(true));
+
+    expect(result).toBeNull();
+    expect(getChargingContext(req)).toBeUndefined();
+  });
+
+  it('passes through when payload lacks sub field', async () => {
+    vi.mocked(getAuthContext).mockReturnValueOnce({
+      mode: 'proxy',
+      payload: { sub: undefined as unknown as string, plan_type: 'pro', monthly_quota_cu: 100000, cu_used: 0, iat: 1000, exp: 2000 },
+    });
+
+    const req = makeRequest(undefined, 'POST', {
+      model: 'gpt-4',
+      messages: [{ role: 'user', content: 'Hi' }],
+    });
+
+    const result = await handleCharging(req, makeEnv(true));
+    // Should NOT crash — passes through (estimate = 5, deductQuota called with sub=undefined)
+    expect(vi.mocked(deductQuota)).toHaveBeenCalledWith(
+      expect.anything(),
+      undefined, // userId = payload.sub which is undefined
+      expect.any(Number),
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/packages/cloudflare-worker/src/middleware/charging.ts
+++ b/packages/cloudflare-worker/src/middleware/charging.ts
@@ -1,0 +1,339 @@
+/**
+ * Charging middleware — pre-reserve + post-correct CU (token-billing).
+ *
+ * Implements the "pre-reserve + post-correct" pattern (inspired by New API):
+ *
+ *   1. **Pre-reserve** (`handleCharging`)
+ *      - Intercepts POST /v1/chat/completions in proxy mode.
+ *      - Estimates the maximum CU this request could consume (based on model
+ *        max_tokens and input message length).
+ *      - Calls `deductQuota` to reserve it.
+ *      - If insufficient quota → 429 CU_EXCEEDED.
+ *      - Stores charging context on the request (via Symbol) for post-correction.
+ *
+ *   2. **Post-correct** (`postCorrectCu`)
+ *      - After the handler completes, reads the actual CU usage from the
+ *        response header `x-cu-actual` (set by the chat handler).
+ *      - If actual < reserved, calls `creditQuota` to refund the difference.
+ *      - Adds `x-cu-remaining` and `x-cu-limit` headers to the response.
+ *
+ * Design invariants:
+ *   - The charging middleware is the SINGLE source of truth for CU deduction.
+ *     Handlers MUST NOT call deductQuota directly — they only report actual usage.
+ *   - Direct API-key mode (self-provided key) bypasses all charging.
+ *   - Public routes (/health) bypass charging.
+ *   - Redis failure degrades gracefully: in-memory fallback + logged warning.
+ */
+
+import { deductQuota, creditQuota } from '../redis/quota.js';
+import { getAuthContext } from '../auth-context.js';
+import { tooManyRequests } from '../utils/response.js';
+import { forbidden as errorForbidden } from '../utils/errors.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Request-scoped Symbol for attaching charging context. */
+const CHARGING_SYMBOL = Symbol.for('markus.charging.context');
+
+/** Default max output tokens when request does not specify one. */
+const DEFAULT_MAX_OUTPUT_TOKENS = 4096;
+
+/** Approximate chars per token for CU estimation. */
+const CHARS_PER_TOKEN = 4;
+
+/** Tokens per CU (1 CU ≈ 1000 tokens). */
+const TOKENS_PER_CU = 1000;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ChargingContext {
+  /** User ID from the JWT payload (sub). */
+  userId: string;
+  /** Number of CU reserved for this request. */
+  reserved: number;
+  /** CU limit for this user. */
+  limit: number;
+}
+
+export interface PreReserveResult {
+  ok: true;
+  reserved: number;
+  remaining: number;
+  limit: number;
+}
+
+export interface PreReserveError {
+  ok: false;
+  code: 'QUOTA_EXCEEDED' | 'RESERVE_FAILED' | 'NO_AUTH' | 'PROXY_MODE_ONLY';
+  message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Request-scoped charging context
+// ---------------------------------------------------------------------------
+
+/** Attach charging context to a request. */
+export function setChargingContext(request: Request, ctx: ChargingContext): void {
+  (request as unknown as Record<symbol, ChargingContext>)[CHARGING_SYMBOL] = ctx;
+}
+
+/** Retrieve previously attached charging context. */
+export function getChargingContext(request: Request): ChargingContext | undefined {
+  return (request as unknown as Record<symbol, ChargingContext | undefined>)[CHARGING_SYMBOL];
+}
+
+// ---------------------------------------------------------------------------
+// Pre-reserve helpers
+// ---------------------------------------------------------------------------
+
+/** Estimate the maximum CU this request could consume. */
+export function estimateMaxCu(body: ChatRequestBody): number {
+  // Estimate input tokens from message content
+  const charCount = (body.messages ?? []).reduce(
+    (sum, msg) => sum + (typeof msg.content === 'string' ? msg.content.length : 0),
+    0,
+  );
+  const inputTokens = Math.max(1, Math.ceil(charCount / CHARS_PER_TOKEN));
+
+  // Account for output tokens (default to a generous max)
+  const maxOutputTokens = body.max_tokens ?? DEFAULT_MAX_OUTPUT_TOKENS;
+
+  // Total max tokens = input + output. This is intentionally generous.
+  const totalMaxTokens = inputTokens + maxOutputTokens;
+
+  // Convert to CU: 1 CU ≈ 1000 tokens
+  return Math.max(1, Math.ceil(totalMaxTokens / TOKENS_PER_CU));
+}
+
+/**
+ * Pre-reserve CU for this request.
+ *
+ * This is the actual CU deduction. The handler must NOT deduct again —
+ * it only reports actual usage via the x-cu-actual response header.
+ */
+export async function preReserveCu(
+  env: Record<string, unknown>,
+  userId: string,
+  maxCu: number,
+): Promise<PreReserveResult | PreReserveError> {
+  // Check Redis is configured
+  const hasRedis = !!(env as Record<string, string>)['UPSTASH_REDIS_URL'];
+  if (!hasRedis) {
+    // No Redis configured — skip pre-reserve (charging is disabled)
+    return {
+      ok: true,
+      reserved: 0,
+      remaining: 999999,
+      limit: 999999,
+    };
+  }
+
+  try {
+    const result = await deductQuota(env as unknown as Parameters<typeof deductQuota>[0], userId, maxCu);
+
+    if (result.error) {
+      return {
+        ok: false,
+        code: 'RESERVE_FAILED',
+        message: `CU reservation failed: ${result.error}`,
+      };
+    }
+
+    if (result.remaining === -1) {
+      return {
+        ok: false,
+        code: 'QUOTA_EXCEEDED',
+        message: `Monthly CU quota (${result.limit}) exhausted. Current usage: ${result.usage}`,
+      };
+    }
+
+    return {
+      ok: true,
+      reserved: maxCu,
+      remaining: result.remaining,
+      limit: result.limit,
+    };
+  } catch (err) {
+    // Redis / fallback completely failed — degrade gracefully
+    console.error(
+      '[charging] Pre-reserve failed (degrading):',
+      err instanceof Error ? err.message : String(err),
+    );
+    return {
+      ok: true,
+      reserved: 0,
+      remaining: -2,
+      limit: 0,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Post-correction helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Post-correct CU after the handler completes.
+ *
+ * If the actual CU usage is less than the reserved amount, refunds the
+ * difference via `creditQuota`.
+ *
+ * Also decorates the response with CU headers (x-cu-remaining, x-cu-limit).
+ */
+export async function postCorrectCu(
+  env: Record<string, unknown>,
+  request: Request,
+  response: Response,
+): Promise<Response> {
+  const chargingCtx = getChargingContext(request);
+
+  // No charging context → nothing to correct (direct mode, health, etc.)
+  if (!chargingCtx || chargingCtx.reserved <= 0) {
+    return response;
+  }
+
+  // Read actual CU usage from handler's response header
+  const actualCuHeader = response.headers.get('x-cu-actual');
+  const actualCu = actualCuHeader ? parseInt(actualCuHeader, 10) : 0;
+
+  // Determine final CU cost: use actual if available, otherwise fall back to reserved
+  const finalCu = actualCu > 0 ? actualCu : chargingCtx.reserved;
+
+  // Calculate remaining: what the user has left after this request
+  const remaining = Math.max(0, chargingCtx.limit - finalCu);
+
+  if (actualCu <= 0) {
+    // No actual CU reported — charge the reserved amount, no refund
+    return addCuHeaders(response, finalCu, remaining, chargingCtx.limit);
+  }
+
+  // Calculate refund: if reserved > actual, refund the difference
+  const refund = chargingCtx.reserved - actualCu;
+
+  if (refund > 0) {
+    try {
+      await creditQuota(env as unknown as Parameters<typeof creditQuota>[0], chargingCtx.userId, refund);
+    } catch (err) {
+      // Refund failure is non-fatal — log and continue
+      console.error(
+        '[charging] Post-correct refund failed:',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    return addCuHeaders(response, finalCu, remaining, chargingCtx.limit);
+  }
+
+  // No refund needed (actual >= reserved)
+  return addCuHeaders(response, finalCu, remaining, chargingCtx.limit);
+}
+
+/**
+ * Add CU-related headers to a response.
+ */
+function addCuHeaders(
+  response: Response,
+  cuCost: number,
+  remainingOrLimit: number,
+  limit?: number,
+): Response {
+  const headers = new Headers(response.headers);
+  headers.set('x-cu-cost', String(cuCost));
+  headers.set('x-cu-remaining', String(remainingOrLimit));
+
+  if (limit !== undefined) {
+    headers.set('x-cu-limit', String(limit));
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Types for request body parsing
+// ---------------------------------------------------------------------------
+
+interface ChatMessage {
+  role: string;
+  content: string;
+  [key: string]: unknown;
+}
+
+interface ChatRequestBody {
+  model?: string;
+  messages?: ChatMessage[];
+  max_tokens?: number;
+  stream?: boolean;
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Main middleware entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle charging as a middleware step.
+ *
+ * Returns:
+ *   - A Response (429) if quota is exceeded or charging is impossible.
+ *   - null to pass through (with charging context attached to request).
+ *
+ * The caller MUST call `postCorrectCu` after the handler returns.
+ */
+export async function handleCharging(
+  request: Request,
+  env: Record<string, unknown>,
+): Promise<Response | null> {
+  // Only intercept POST /v1/chat/completions
+  const url = new URL(request.url);
+  if (url.pathname !== '/v1/chat/completions' || request.method !== 'POST') {
+    return null;
+  }
+
+  // Only charge in proxy JWT mode (direct mode = no billing)
+  const auth = getAuthContext(request);
+  if (!auth || auth.mode !== 'proxy') {
+    return null;
+  }
+
+  const { payload } = auth;
+
+  // --- Parse the request body to estimate max CU ---------------------------
+  let body: ChatRequestBody;
+  try {
+    body = (await request.clone().json()) as ChatRequestBody;
+  } catch {
+    // Malformed JSON — let the handler return a proper 400
+    return null;
+  }
+
+  // --- Pre-reserve CU ------------------------------------------------------
+  const maxCu = estimateMaxCu(body);
+  const result = await preReserveCu(env, payload.sub, maxCu);
+
+  if (!result.ok) {
+    // Insufficient quota → 429
+    return tooManyRequests(
+      errorForbidden(
+        result.code === 'QUOTA_EXCEEDED'
+          ? result.message
+          : `CU reservation failed: ${result.message}`,
+      ),
+    );
+  }
+
+  // --- Store charging context for post-correction --------------------------
+  setChargingContext(request, {
+    userId: payload.sub,
+    reserved: result.reserved,
+    limit: result.limit,
+  });
+
+  return null; // pass through
+}

--- a/packages/cloudflare-worker/src/redis/__tests__/quota.test.ts
+++ b/packages/cloudflare-worker/src/redis/__tests__/quota.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for the Redis-backed CU quota deduction module.
+ *
+ * Covers the atomic Lua script semantics (mocked via fetch),
+ * in-memory fallback, and edge cases.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { RedisClient } from '../client.js';
+import { deductQuota, resetFallbackStore, getFallbackStatus } from '../quota.js';
+import type { Env } from '../../index.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMockEnv(overrides?: Partial<Env>): Env {
+  return {
+    ENVIRONMENT: 'test',
+    UPSTASH_REDIS_URL: overrides?.UPSTASH_REDIS_URL ?? 'https://mock.upstash.io',
+    UPSTASH_REDIS_TOKEN: overrides?.UPSTASH_REDIS_TOKEN ?? 'mock-token',
+    DEFAULT_CU_LIMIT: overrides?.DEFAULT_CU_LIMIT ?? '100000',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// RedisClient — parseQuotaResult
+// ---------------------------------------------------------------------------
+
+describe('RedisClient.parseQuotaResult', () => {
+  it('should parse a valid success response', () => {
+    const result = RedisClient.parseQuotaResult(
+      JSON.stringify({ remaining: 95, usage: 5, limit: 100 }),
+    );
+    expect(result).toEqual({ remaining: 95, usage: 5, limit: 100 });
+  });
+
+  it('should parse a quota-exceeded response (remaining === -1)', () => {
+    const result = RedisClient.parseQuotaResult(
+      JSON.stringify({ remaining: -1, usage: 98, limit: 100 }),
+    );
+    expect(result.remaining).toBe(-1);
+    expect(result.usage).toBe(98);
+  });
+
+  it('should handle malformed JSON gracefully', () => {
+    const result = RedisClient.parseQuotaResult('not-json');
+    expect(result.error).toBe('failed_to_parse_redis_response');
+    expect(result.remaining).toBe(0);
+  });
+
+  it('should handle an error response from Lua script', () => {
+    const result = RedisClient.parseQuotaResult(
+      JSON.stringify({ error: 'invalid_deduct_amount', remaining: 0, usage: 0, limit: 0 }),
+    );
+    expect(result.error).toBe('invalid_deduct_amount');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deductQuota — Redis path (mocked fetch)
+// ---------------------------------------------------------------------------
+
+describe('deductQuota — Redis path', () => {
+  beforeEach(() => {
+    resetFallbackStore();
+  });
+
+  it('should deduct CU when quota is sufficient', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        result: JSON.stringify({ remaining: 95, usage: 5, limit: 100 }),
+      }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await deductQuota(makeMockEnv({ DEFAULT_CU_LIMIT: '100' }), 'user1', 5);
+    expect(result.remaining).toBe(95);
+    expect(result.usage).toBe(5);
+    expect(result.limit).toBe(100);
+    expect(result.error).toBeUndefined();
+
+    // Verify the Redis command was sent correctly
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const callArgs = mockFetch.mock.calls[0];
+    expect(callArgs[0]).toBe('https://mock.upstash.io');
+    const body = JSON.parse(callArgs[1].body as string);
+    expect(body[0]).toBe('EVAL');
+    expect(body[2]).toBe('1'); // 1 key
+    expect(body[3]).toBe('cu:user1'); // key
+    expect(body[4]).toBe('5'); // amount
+    expect(body[5]).toBe('100'); // limit
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should rollback and return -1 when quota would be exceeded', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        result: JSON.stringify({ remaining: -1, usage: 98, limit: 100 }),
+      }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await deductQuota(makeMockEnv({ DEFAULT_CU_LIMIT: '100' }), 'user2', 10);
+    expect(result.remaining).toBe(-1);
+    expect(result.usage).toBe(98);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should return error for invalid amount (zero)', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await deductQuota(makeMockEnv(), 'user3', 0);
+    expect(result.error).toBe('invalid_amount');
+    // Should NOT have called Redis
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should return error for invalid amount (negative)', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+
+    const result = await deductQuota(makeMockEnv(), 'user4', -5);
+    expect(result.error).toBe('invalid_amount');
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deductQuota — Fallback path when Redis is unavailable
+// ---------------------------------------------------------------------------
+
+describe('deductQuota — Redis fallback (in-memory)', () => {
+  beforeEach(() => {
+    resetFallbackStore();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should fall back to in-memory when Redis fetch fails', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const env = makeMockEnv({ DEFAULT_CU_LIMIT: '50' });
+    const result = await deductQuota(env, 'user-fallback-1', 10);
+    expect(result.remaining).toBe(40);
+    expect(result.usage).toBe(10);
+    expect(result.limit).toBe(50);
+
+    // Verify fallback store updated
+    const status = getFallbackStatus('user-fallback-1');
+    expect(status.active).toBe(true);
+    expect(status.usage).toBe(10);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should accumulate deductions across multiple calls in fallback', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const env = makeMockEnv({ DEFAULT_CU_LIMIT: '50' });
+
+    // First call
+    await deductQuota(env, 'user-fallback-2', 10);
+    // Second call
+    const result2 = await deductQuota(env, 'user-fallback-2', 20);
+    expect(result2.remaining).toBe(20);
+    expect(result2.usage).toBe(30);
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should return -1 in fallback when quota exceeded', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const env = makeMockEnv({ DEFAULT_CU_LIMIT: '30' });
+
+    await deductQuota(env, 'user-fallback-3', 25);
+    const result = await deductQuota(env, 'user-fallback-3', 10);
+    expect(result.remaining).toBe(-1);
+    expect(result.usage).toBe(25); // Not incremented (rollback)
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should have independent fallback stores per user', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const env = makeMockEnv({ DEFAULT_CU_LIMIT: '100' });
+
+    await deductQuota(env, 'user-a', 30);
+    const resultB = await deductQuota(env, 'user-b', 10);
+
+    expect(resultB.remaining).toBe(90);
+    expect(resultB.usage).toBe(10);
+
+    vi.unstubAllGlobals();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getFallbackStatus
+// ---------------------------------------------------------------------------
+
+describe('getFallbackStatus', () => {
+  beforeEach(() => {
+    resetFallbackStore();
+  });
+
+  it('should return inactive for a user not in store', () => {
+    const status = getFallbackStatus('unknown-user');
+    expect(status.active).toBe(false);
+    expect(status.usage).toBe(0);
+  });
+
+  it('should return usage after deductions', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('offline'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const env = makeMockEnv({ DEFAULT_CU_LIMIT: '200' });
+    await deductQuota(env, 'user-status', 42);
+
+    const status = getFallbackStatus('user-status');
+    expect(status.active).toBe(true);
+    expect(status.usage).toBe(42);
+    expect(status.limit).toBe(200);
+
+    vi.unstubAllGlobals();
+  });
+});

--- a/packages/cloudflare-worker/src/redis/client.ts
+++ b/packages/cloudflare-worker/src/redis/client.ts
@@ -1,0 +1,114 @@
+/**
+ * client.ts — Upstash Redis REST API client for Cloudflare Workers.
+ *
+ * Upstash provides a REST API that works via standard HTTP fetch —
+ * no TCP/WebSocket connection needed. This makes it ideal for Workers.
+ *
+ * Docs: https://docs.upstash.com/redis/rest/overview
+ *
+ * Usage:
+ *   const redis = new RedisClient(env.UPSTASH_REDIS_URL, env.UPSTASH_REDIS_TOKEN);
+ *   const result = await redis.eval(script, keys, args);
+ */
+
+/** Result of the CU quota deduction Lua script */
+export interface QuotaDeductionResult {
+  remaining: number;  // -1 means quota exceeded (rollback applied)
+  usage: number;
+  limit: number;
+  error?: string;     // If present, something went wrong
+}
+
+/** Low-level response from Upstash REST API */
+interface UpstashResponse {
+  result?: string;
+  error?: string;
+}
+
+/**
+ * Lightweight Upstash Redis client.
+ * Uses the REST API at `{url}/{command}` with Basic Auth via token.
+ */
+export class RedisClient {
+  private readonly url: string;
+  private readonly authHeader: string;
+
+  constructor(url: string, token: string) {
+    // Remove trailing slash from URL
+    this.url = url.replace(/\/+$/, '');
+    // Upstash uses token as a Basic Auth password (user is empty)
+    this.authHeader = 'Bearer ' + token;
+  }
+
+  /**
+   * Execute a Redis EVAL command via Upstash REST API.
+   *
+   * @param script - Lua script source code
+   * @param keys - Redis key names (KEYS in Lua)
+   * @param args - Additional arguments (ARGV in Lua)
+   * @returns Parsed result string (JSON blob from our Lua script)
+   */
+  async eval(script: string, keys: string[], args: string[]): Promise<string> {
+    const command = [
+      'EVAL',
+      script,
+      keys.length.toString(),
+      ...keys,
+      ...args,
+    ];
+
+    const response = await this.executeCommand(command);
+    return response;
+  }
+
+  /**
+   * Execute a Redis command via Upstash REST API.
+   * Commands are sent as an array: ["COMMAND", "arg1", "arg2", ...]
+   */
+  private async executeCommand(command: string[]): Promise<string> {
+    const response = await fetch(`${this.url}`, {
+      method: 'POST',
+      headers: {
+        'Authorization': this.authHeader,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(command),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Redis request failed: ${response.status} ${response.statusText}`
+      );
+    }
+
+    const data = (await response.json()) as UpstashResponse;
+
+    if (data.error) {
+      throw new Error(`Redis error: ${data.error}`);
+    }
+
+    return data.result ?? '';
+  }
+
+  /**
+   * Parse the JSON result from the quota deduction Lua script.
+   */
+  static parseQuotaResult(raw: string): QuotaDeductionResult {
+    try {
+      const parsed = JSON.parse(raw) as QuotaDeductionResult;
+      return {
+        remaining: typeof parsed.remaining === 'number' ? parsed.remaining : 0,
+        usage: typeof parsed.usage === 'number' ? parsed.usage : 0,
+        limit: typeof parsed.limit === 'number' ? parsed.limit : 0,
+        error: parsed.error,
+      };
+    } catch {
+      return {
+        remaining: 0,
+        usage: 0,
+        limit: 0,
+        error: 'failed_to_parse_redis_response',
+      };
+    }
+  }
+}

--- a/packages/cloudflare-worker/src/redis/quota-lua.ts
+++ b/packages/cloudflare-worker/src/redis/quota-lua.ts
@@ -1,0 +1,68 @@
+/**
+ * quota-lua.ts — Embedded Lua script string for atomic CU deduction.
+ *
+ * The actual Lua source lives in `quota.lua`. This module re-export it
+ * as a TypeScript string constant so it can be loaded into the Worker
+ * bundle (Cloudflare Workers bundle .ts files, not .lua files).
+ *
+ * Data Model (Redis Hash):
+ *   Key:   "cu:{userId}"
+ *   Fields:
+ *     - usage    (integer): Cumulative CU consumed
+ *     - limit    (integer): Maximum CU allowed per cycle
+ *     - reset_at (integer): Unix timestamp when the quota resets
+ *
+ * KEYS[1]: Redis key (e.g., "cu:user_abc123")
+ * ARGV[1]: Amount of CU to deduct (integer)
+ * ARGV[2]: CU limit to set if the key does not yet exist (integer)
+ * ARGV[3]: Reset timestamp (integer) — set on first init
+ *
+ * Returns JSON: { remaining: number, usage: number, limit: number }
+ *   - remaining === -1 means quota exceeded (deduction rolled back)
+ */
+
+export const QUOTA_DEDUCTION_SCRIPT = `
+local key = KEYS[1]
+local deduct = tonumber(ARGV[1])
+local default_limit = tonumber(ARGV[2])
+local reset_ts = tonumber(ARGV[3])
+
+if not deduct or deduct <= 0 then
+    return cjson.encode({ error = "invalid_deduct_amount", remaining = 0, usage = 0, limit = 0 })
+end
+
+if not default_limit or default_limit <= 0 then
+    return cjson.encode({ error = "invalid_limit", remaining = 0, usage = 0, limit = 0 })
+end
+
+local exists = redis.call("EXISTS", key)
+if exists == 0 then
+    redis.call("HSET", key, "usage", 0, "limit", default_limit, "reset_at", reset_ts)
+end
+
+local stored_limit = redis.call("HGET", key, "limit")
+local limit
+if stored_limit then
+    limit = tonumber(stored_limit)
+else
+    limit = default_limit
+end
+
+local new_usage = redis.call("HINCRBY", key, "usage", deduct)
+
+if new_usage > limit then
+    redis.call("HINCRBY", key, "usage", -deduct)
+    return cjson.encode({
+        remaining = -1,
+        usage = new_usage - deduct,
+        limit = limit
+    })
+end
+
+local remaining = limit - new_usage
+return cjson.encode({
+    remaining = remaining,
+    usage = new_usage,
+    limit = limit
+})
+`.trim();

--- a/packages/cloudflare-worker/src/redis/quota.lua
+++ b/packages/cloudflare-worker/src/redis/quota.lua
@@ -1,0 +1,91 @@
+--[[
+    quota.lua — Atomic CU (Compute Unit) Quota Deduction
+
+    This script performs an atomic quota check and deduction on a Redis Hash.
+    It uses HINCRBY to increment usage, checks against the limit, and
+    automatically rolls back if the quota would be exceeded.
+
+    Data Model:
+        Key:   "cu:{userId}"        (Redis Hash)
+        Fields:
+          - usage    (integer): Cumulative CU consumed
+          - limit    (integer): Maximum CU allowed per cycle
+          - reset_at (integer): Unix timestamp when the quota resets
+
+    Input:
+        KEYS[1]: Redis key (e.g., "cu:user_abc123")
+        ARGV[1]: Amount of CU to deduct (integer)
+        ARGV[2]: CU limit to set if the key does not yet exist (integer)
+        ARGV[3]: Reset timestamp (integer) — set on first init
+
+    Output:
+        A JSON object:
+          {
+            "remaining": <number>,  -- Remaining CU (-1 if quota exceeded)
+            "usage": <number>,      -- Total CU used (after deduction, or before rollback)
+            "limit": <number>       -- CU quota limit
+          }
+
+        When remaining === -1, the deduction was already rolled back, and
+        "usage" reflects the usage before the attempted deduction.
+
+    Idempotency:
+        The script is idempotent for the same arguments only if called once.
+        It does NOT gate by idempotency key — that should be handled at a
+        higher layer (e.g., a request idempotency key stored separately).
+
+    Error States:
+        - Non-numeric ARGV: Redis HINCRBY returns an error automatically.
+        - Missing limit: defaults to ARGV[2] (set on first init).
+--]]
+
+local key = KEYS[1]
+local deduct = tonumber(ARGV[1])
+local default_limit = tonumber(ARGV[2])
+local reset_ts = tonumber(ARGV[3])
+
+-- Validate inputs
+if not deduct or deduct <= 0 then
+    return cjson.encode({ error = "invalid_deduct_amount", remaining = 0, usage = 0, limit = 0 })
+end
+
+if not default_limit or default_limit <= 0 then
+    return cjson.encode({ error = "invalid_limit", remaining = 0, usage = 0, limit = 0 })
+end
+
+-- Initialize key if it doesn't exist
+local exists = redis.call("EXISTS", key)
+if exists == 0 then
+    redis.call("HSET", key, "usage", 0, "limit", default_limit, "reset_at", reset_ts)
+end
+
+-- Get current limit from stored value (may differ from default if set externally)
+local stored_limit = redis.call("HGET", key, "limit")
+local limit
+if stored_limit then
+    limit = tonumber(stored_limit)
+else
+    limit = default_limit
+end
+
+-- Atomically deduct CU
+local new_usage = redis.call("HINCRBY", key, "usage", deduct)
+
+-- Check if quota exceeded
+if new_usage > limit then
+    -- Rollback the deduction
+    redis.call("HINCRBY", key, "usage", -deduct)
+    return cjson.encode({
+        remaining = -1,
+        usage = new_usage - deduct,
+        limit = limit
+    })
+end
+
+-- Success: return remaining quota
+local remaining = limit - new_usage
+return cjson.encode({
+    remaining = remaining,
+    usage = new_usage,
+    limit = limit
+})

--- a/packages/cloudflare-worker/src/redis/quota.ts
+++ b/packages/cloudflare-worker/src/redis/quota.ts
@@ -1,0 +1,132 @@
+/**
+ * quota.ts — High-level CU quota deduction with Redis + fallback.
+ *
+ * Provides a single function `deductQuota()` that:
+ * 1. Calls the atomic Lua deduction script via Upstash Redis
+ * 2. Falls back to in-memory tracking if Redis is unavailable
+ * 3. Returns a typed result
+ */
+
+import { QUOTA_DEDUCTION_SCRIPT } from './quota-lua';
+import { RedisClient, QuotaDeductionResult } from './client';
+import type { Env } from '../index';
+
+/**
+ * In-memory fallback store for CU quotas.
+ * Used when Redis is unavailable. NOT durable — use only as last resort.
+ *
+ * Maps userId → { usage, limit }
+ */
+const fallbackStore = new Map<string, { usage: number; limit: number }>();
+
+/**
+ * Deduct CU from a user's quota.
+ *
+ * Primary path: Upstash Redis (atomic Lua script)
+ * Fallback path: In-memory best-effort tracking (if Redis is down)
+ *
+ * @param env - Worker environment bindings
+ * @param userId - User identifier for quota tracking
+ * @param amount - Number of CUs to deduct
+ * @returns QuotaDeductionResult with remaining usage info
+ */
+export async function deductQuota(
+  env: Env,
+  userId: string,
+  amount: number,
+): Promise<QuotaDeductionResult> {
+  // Validate amount
+  if (!amount || amount <= 0) {
+    return { remaining: 0, usage: 0, limit: 0, error: 'invalid_amount' };
+  }
+
+  const key = `cu:${userId}`;
+  const defaultLimit = parseInt(env.DEFAULT_CU_LIMIT || '100000', 10);
+  const resetTs = Math.floor(Date.now() / 1000) + 86400; // T+1d reset
+
+  try {
+    return await deductViaRedis(env, key, amount, defaultLimit, resetTs);
+  } catch (err) {
+    console.error(
+      `[quota] Redis unavailable for user ${userId}, using fallback:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return deductFallback(userId, amount, defaultLimit);
+  }
+}
+
+/**
+ * Deduct via Upstash Redis atomic Lua script.
+ */
+async function deductViaRedis(
+  env: Env,
+  key: string,
+  amount: number,
+  limit: number,
+  resetTs: number,
+): Promise<QuotaDeductionResult> {
+  const redis = new RedisClient(env.UPSTASH_REDIS_URL, env.UPSTASH_REDIS_TOKEN);
+
+  const rawResult = await redis.eval(
+    QUOTA_DEDUCTION_SCRIPT,
+    [key],
+    [String(amount), String(limit), String(resetTs)],
+  );
+
+  return RedisClient.parseQuotaResult(rawResult);
+}
+
+/**
+ * In-memory fallback deduction.
+ * Used when Redis is unavailable.
+ *
+ * CONS: Not durable across Worker instances.
+ * PROS: Prevents total service outage due to Redis failure.
+ */
+function deductFallback(
+  userId: string,
+  amount: number,
+  defaultLimit: number,
+): QuotaDeductionResult {
+  let entry = fallbackStore.get(userId);
+
+  if (!entry) {
+    entry = { usage: 0, limit: defaultLimit };
+    fallbackStore.set(userId, entry);
+  }
+
+  const newUsage = entry.usage + amount;
+
+  if (newUsage > entry.limit) {
+    return { remaining: -1, usage: entry.usage, limit: entry.limit };
+  }
+
+  entry.usage = newUsage;
+  return {
+    remaining: entry.limit - entry.usage,
+    usage: entry.usage,
+    limit: entry.limit,
+  };
+}
+
+/**
+ * Get current fallback quota status for a user (for diagnostics).
+ */
+export function getFallbackStatus(userId: string): {
+  active: boolean;
+  usage: number;
+  limit: number;
+} {
+  const entry = fallbackStore.get(userId);
+  if (!entry) {
+    return { active: false, usage: 0, limit: 0 };
+  }
+  return { active: true, usage: entry.usage, limit: entry.limit };
+}
+
+/**
+ * Reset fallback store (for testing).
+ */
+export function resetFallbackStore(): void {
+  fallbackStore.clear();
+}

--- a/packages/cloudflare-worker/src/redis/quota.ts
+++ b/packages/cloudflare-worker/src/redis/quota.ts
@@ -125,6 +125,74 @@ export function getFallbackStatus(userId: string): {
 }
 
 /**
+ * Credit (refund) CU back to a user's quota.
+ *
+ * This is the reverse of `deductQuota` — it subtracts from the user's usage
+ * via the same atomic Lua script but with a NEGATIVE amount (which bypasses
+ * the quota-enforcement branch).
+ *
+ * Used for post-correction after pre-reserve: if a request reserved N CU but
+ * only used M (M < N), the caller should credit back N-M CU.
+ *
+ * @param env - Worker environment bindings
+ * @param userId - User identifier for quota tracking
+ * @param amount - Number of CUs to credit back (must be positive; we negate internally)
+ * @returns QuotaDeductionResult with updated usage info
+ */
+export async function creditQuota(
+  env: Env,
+  userId: string,
+  amount: number,
+): Promise<QuotaDeductionResult> {
+  // Validate amount
+  if (!amount || amount <= 0) {
+    return { remaining: 0, usage: 0, limit: 0, error: 'invalid_amount' };
+  }
+
+  // We use the same Lua script but pass a NEGATIVE amount so it
+  // subtracts from usage (effectively a refund).
+  const negativeAmount = -amount;
+  const key = `cu:${userId}`;
+  const defaultLimit = parseInt(env.DEFAULT_CU_LIMIT || '100000', 10);
+  const resetTs = Math.floor(Date.now() / 1000) + 86400;
+
+  try {
+    return await deductViaRedis(env, key, negativeAmount, defaultLimit, resetTs);
+  } catch (err) {
+    console.error(
+      `[quota] Redis unavailable for credit to user ${userId}, using fallback:`,
+      err instanceof Error ? err.message : String(err),
+    );
+    return creditFallback(userId, amount, defaultLimit);
+  }
+}
+
+/**
+ * In-memory fallback for credit (refund).
+ */
+function creditFallback(
+  userId: string,
+  amount: number,
+  defaultLimit: number,
+): QuotaDeductionResult {
+  let entry = fallbackStore.get(userId);
+
+  if (!entry) {
+    entry = { usage: 0, limit: defaultLimit };
+    fallbackStore.set(userId, entry);
+  }
+
+  const newUsage = Math.max(0, entry.usage - amount);
+  entry.usage = newUsage;
+
+  return {
+    remaining: entry.limit - entry.usage,
+    usage: entry.usage,
+    limit: entry.limit,
+  };
+}
+
+/**
  * Reset fallback store (for testing).
  */
 export function resetFallbackStore(): void {

--- a/packages/cloudflare-worker/src/routes/chat.ts
+++ b/packages/cloudflare-worker/src/routes/chat.ts
@@ -21,8 +21,6 @@
 import { badRequest } from '../utils/errors.js';
 import { badRequest as badRequestResponse, json, sseStream } from '../utils/response.js';
 import { getAuthContext } from '../auth-context.js';
-import type { Env } from '../index.js';
-import { deductQuota } from '../redis/quota.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -100,28 +98,14 @@ export async function handleChat(
 async function handleProxyChat(
   _request: Request,
   body: ChatRequest,
-  auth: { mode: 'proxy'; payload: { monthly_quota_cu: number; cu_used: number; sub: string } },
+  _auth: { mode: 'proxy'; payload: { monthly_quota_cu: number; cu_used: number; sub: string } },
   env: Record<string, unknown>,
 ): Promise<Response> {
-  const { payload } = auth;
+  // CU quota pre-check and deduction are handled by the charging
+  // middleware (middleware/charging.ts). The handler only reports actual
+  // usage via the x-cu-actual response header.
 
-  // --- CU quota pre-check (approximate, based on JWT metadata) ---------------
   const estimatedCu = estimateCu(body);
-  const remainingCu = payload.monthly_quota_cu - payload.cu_used;
-
-  if (remainingCu <= 0) {
-    return errorJson(429, {
-      code: 'QUOTA_EXCEEDED',
-      message: `Monthly CU quota (${payload.monthly_quota_cu}) exhausted. Remaining: ${remainingCu}`,
-    });
-  }
-
-  if (estimatedCu > remainingCu) {
-    return errorJson(429, {
-      code: 'INSUFFICIENT_QUOTA',
-      message: `Request requires ~${estimatedCu} CU but only ${remainingCu} remaining`,
-    });
-  }
 
   // --- Read upstream config from env -----------------------------------------
   const proxyBaseUrl = env.LLM_PROXY_BASE_URL as string | undefined;
@@ -176,12 +160,9 @@ async function handleProxyChat(
     });
   }
 
-  // --- Deduct CU after successful upstream response -------------------------
-  const envTyped = env as unknown as Env;
-  const userId = payload.sub;
-
+  // --- Build response with CU headers (no deduction — middleware handles it) -
   if (!isStreaming) {
-    // Non-streaming: parse body to get actual token usage, then attach CU headers
+    // Non-streaming: parse body to get actual token usage
     const data = (await upstreamResponse.json()) as Record<string, unknown>;
 
     const totalTokens =
@@ -193,19 +174,12 @@ async function handleProxyChat(
       ? Math.max(1, Math.ceil(totalTokens / 1000))
       : estimatedCu;
 
-    const quotaResult = await safeDeduct(envTyped, userId, actualCu);
-
-    // Build response with CU headers
-    const responseHeaders: Record<string, string> = {
-      'content-type': 'application/json; charset=utf-8',
-      'x-cu-cost': String(actualCu),
-      'x-cu-remaining': String(quotaResult.remaining),
-      'x-cu-limit': String(quotaResult.limit),
-    };
-
     return new Response(JSON.stringify(data), {
       status: upstreamResponse.status,
-      headers: responseHeaders,
+      headers: {
+        'content-type': 'application/json; charset=utf-8',
+        'x-cu-actual': String(actualCu),
+      },
     });
   }
 
@@ -218,45 +192,19 @@ async function handleProxyChat(
     });
   }
 
-  // For streaming, use estimated CU (exact token counting requires Hub-side accounting)
+  // For streaming, use estimated CU (exact token counting requires Hub-side accounting).
+  // The charging middleware already reserved max possible CU; post-correction
+  // will refund the difference between reserved and estimated.
   const actualCu = estimatedCu;
-  const quotaResult = await safeDeduct(envTyped, userId, actualCu);
-
-  const responseHeaders: Record<string, string> = {
-    'content-type': 'text/event-stream',
-    'transfer-encoding': 'chunked',
-    'x-cu-cost': String(actualCu),
-    'x-cu-remaining': String(quotaResult.remaining),
-    'x-cu-limit': String(quotaResult.limit),
-  };
 
   return new Response(streamBody, {
     status: upstreamResponse.status,
-    headers: responseHeaders,
+    headers: {
+      'content-type': 'text/event-stream',
+      'transfer-encoding': 'chunked',
+      'x-cu-actual': String(actualCu),
+    },
   });
-}
-
-/**
- * Safely deduct CU, returning a default success if Redis isn't configured
- * or the deduction fails.
- */
-async function safeDeduct(
-  env: Env,
-  userId: string,
-  amount: number,
-): Promise<{ remaining: number; limit: number }> {
-  if (!env.UPSTASH_REDIS_URL || !env.UPSTASH_REDIS_TOKEN) {
-    console.warn('[quota] UPSTASH_REDIS_URL/TOKEN not configured — skipping deduction');
-    return { remaining: 999999, limit: 999999 };
-  }
-
-  try {
-    const result = await deductQuota(env, userId, amount);
-    return { remaining: result.remaining, limit: result.limit };
-  } catch (err) {
-    console.error('[quota] Deduction failed (non-fatal):', err instanceof Error ? err.message : String(err));
-    return { remaining: -2, limit: 0 };
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cloudflare-worker/src/routes/chat.ts
+++ b/packages/cloudflare-worker/src/routes/chat.ts
@@ -8,7 +8,7 @@
  * **Proxy JWT mode** (platform billing)
  *   - Validates CU quota from the JWT payload.
  *   - Forwards to the upstream LLM provider configured in env vars.
- *   - Deducts CU on success.
+ *   - Deducts CU on success via Upstash Redis (atomic Lua script).
  *
  * **Direct API-key mode** (self-provided key)
  *   - Forwards to the user-specified provider base URL (x-provider-base-url).
@@ -21,6 +21,8 @@
 import { badRequest } from '../utils/errors.js';
 import { badRequest as badRequestResponse, json, sseStream } from '../utils/response.js';
 import { getAuthContext } from '../auth-context.js';
+import type { Env } from '../index.js';
+import { deductQuota } from '../redis/quota.js';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -92,7 +94,7 @@ export async function handleChat(
 }
 
 // ---------------------------------------------------------------------------
-// Proxy JWT mode
+// Proxy JWT mode (with CU quota deduction)
 // ---------------------------------------------------------------------------
 
 async function handleProxyChat(
@@ -103,7 +105,7 @@ async function handleProxyChat(
 ): Promise<Response> {
   const { payload } = auth;
 
-  // --- CU quota check --------------------------------------------------------
+  // --- CU quota pre-check (approximate, based on JWT metadata) ---------------
   const estimatedCu = estimateCu(body);
   const remainingCu = payload.monthly_quota_cu - payload.cu_used;
 
@@ -132,9 +134,129 @@ async function handleProxyChat(
     });
   }
 
-  // Delegate to the shared forwarder
   const upstreamUrl = buildUpstreamUrl(proxyBaseUrl);
-  return forwardToUpstream(body, upstreamUrl, proxyApiKey);
+  const isStreaming = body.stream === true;
+
+  // Build the upstream request body
+  const upstreamBody: Record<string, unknown> = {
+    model: body.model,
+    messages: body.messages,
+    stream: isStreaming,
+  };
+  if (body.max_tokens !== undefined) upstreamBody.max_tokens = body.max_tokens;
+  if (body.temperature !== undefined) upstreamBody.temperature = body.temperature;
+
+  const requestHeaders: Record<string, string> = {
+    'content-type': 'application/json',
+    authorization: `Bearer ${proxyApiKey}`,
+  };
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  let upstreamResponse: Response;
+  try {
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: 'POST',
+      headers: requestHeaders,
+      body: JSON.stringify(upstreamBody),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!upstreamResponse.ok) {
+    const errorBody = await upstreamResponse.text();
+    return errorJson(502, {
+      code: 'UPSTREAM_ERROR',
+      message: `Upstream returned ${upstreamResponse.status}`,
+      upstream_status: upstreamResponse.status,
+      upstream_body: errorBody,
+    });
+  }
+
+  // --- Deduct CU after successful upstream response -------------------------
+  const envTyped = env as unknown as Env;
+  const userId = payload.sub;
+
+  if (!isStreaming) {
+    // Non-streaming: parse body to get actual token usage, then attach CU headers
+    const data = (await upstreamResponse.json()) as Record<string, unknown>;
+
+    const totalTokens =
+      typeof (data.usage as Record<string, unknown> | undefined)?.total_tokens === 'number'
+        ? (data.usage as Record<string, unknown>).total_tokens as number
+        : 0;
+
+    const actualCu = totalTokens > 0
+      ? Math.max(1, Math.ceil(totalTokens / 1000))
+      : estimatedCu;
+
+    const quotaResult = await safeDeduct(envTyped, userId, actualCu);
+
+    // Build response with CU headers
+    const responseHeaders: Record<string, string> = {
+      'content-type': 'application/json; charset=utf-8',
+      'x-cu-cost': String(actualCu),
+      'x-cu-remaining': String(quotaResult.remaining),
+      'x-cu-limit': String(quotaResult.limit),
+    };
+
+    return new Response(JSON.stringify(data), {
+      status: upstreamResponse.status,
+      headers: responseHeaders,
+    });
+  }
+
+  // --- Streaming: pipe the upstream body as SSE with CU headers -------------
+  const streamBody = upstreamResponse.body;
+  if (!streamBody) {
+    return errorJson(502, {
+      code: 'UPSTREAM_NO_BODY',
+      message: 'Upstream returned no body',
+    });
+  }
+
+  // For streaming, use estimated CU (exact token counting requires Hub-side accounting)
+  const actualCu = estimatedCu;
+  const quotaResult = await safeDeduct(envTyped, userId, actualCu);
+
+  const responseHeaders: Record<string, string> = {
+    'content-type': 'text/event-stream',
+    'transfer-encoding': 'chunked',
+    'x-cu-cost': String(actualCu),
+    'x-cu-remaining': String(quotaResult.remaining),
+    'x-cu-limit': String(quotaResult.limit),
+  };
+
+  return new Response(streamBody, {
+    status: upstreamResponse.status,
+    headers: responseHeaders,
+  });
+}
+
+/**
+ * Safely deduct CU, returning a default success if Redis isn't configured
+ * or the deduction fails.
+ */
+async function safeDeduct(
+  env: Env,
+  userId: string,
+  amount: number,
+): Promise<{ remaining: number; limit: number }> {
+  if (!env.UPSTASH_REDIS_URL || !env.UPSTASH_REDIS_TOKEN) {
+    console.warn('[quota] UPSTASH_REDIS_URL/TOKEN not configured — skipping deduction');
+    return { remaining: 999999, limit: 999999 };
+  }
+
+  try {
+    const result = await deductQuota(env, userId, amount);
+    return { remaining: result.remaining, limit: result.limit };
+  } catch (err) {
+    console.error('[quota] Deduction failed (non-fatal):', err instanceof Error ? err.message : String(err));
+    return { remaining: -2, limit: 0 };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -158,7 +280,7 @@ async function handleDirectChat(
 }
 
 // ---------------------------------------------------------------------------
-// Upstream forwarding (shared by both modes)
+// Upstream forwarding (shared by both modes — direct mode only)
 // ---------------------------------------------------------------------------
 
 async function forwardToUpstream(

--- a/packages/cloudflare-worker/wrangler.toml
+++ b/packages/cloudflare-worker/wrangler.toml
@@ -1,12 +1,73 @@
+# =============================================================================
+# wrangler.toml — Markus Proxy Cloudflare Worker Configuration
+# =============================================================================
+#
+# How to deploy:
+#   1. Ensure you're authenticated: wrangler login
+#   2. Set production secrets (see below)
+#   3. Run: wrangler deploy --env production
+#
+# Production secrets (set via `wrangler secret put --env production`):
+#   - PROXY_JWT_SECRET       — JWT signing secret for proxy tokens
+#   - LLM_PROXY_BASE_URL     — Upstream LLM provider base URL
+#   - LLM_PROXY_API_KEY      — Upstream LLM provider API key
+# =============================================================================
+
 name = "markus-proxy"
 main = "src/index.ts"
 compatibility_date = "2025-04-01"
+compatibility_flags = ["nodejs_compat"]
 
-# Workers Logs
+# ---------------------------------------------------------------------------
+# Cloudflare Account (REQUIRED — replace with your Account ID)
+#   Find at: Cloudflare Dashboard → Workers & Pages → Your Account ID
+# ---------------------------------------------------------------------------
+# account_id = "your-account-id-here"
+
+# ---------------------------------------------------------------------------
+# Observability — Workers Logs
+# ---------------------------------------------------------------------------
 [observability]
 enabled = true
-head_sampling_rate = 1.0
+head_sampling_rate = 0.1  # 10% sampling for production (reduce log volume/cost)
 
-# Development environment
+# ---------------------------------------------------------------------------
+# Routes — Production domain binding
+#   Example: proxy.markus.ai/*
+#   Uncomment and customize after domain is configured in Cloudflare dashboard
+# ---------------------------------------------------------------------------
+# routes = [
+#   { pattern = "proxy.markus.ai", zone_name = "markus.ai" },
+#   { pattern = "proxy.markus.ai/*", zone_name = "markus.ai" },
+# ]
+
+# =============================================================================
+# Environment: production
+# =============================================================================
+
+[env.production]
+vars = { ENVIRONMENT = "production" }
+
+# Worker resources (adjust based on expected load)
+[env.production.limits]
+cpu_ms = 30000          # 30s CPU time per request
+# Note: For Workers Paid plan, additional resources are available
+
+# =============================================================================
+# Environment: staging (optional — for pre-production testing)
+# =============================================================================
+
+[env.staging]
+vars = { ENVIRONMENT = "staging" }
+
+# Routes for staging
+# routes = [
+#   { pattern = "staging-proxy.markus.ai/*", zone_name = "markus.ai" },
+# ]
+
+# =============================================================================
+# Environment: development (local dev)
+# =============================================================================
+
 [env.dev]
 vars = { ENVIRONMENT = "development" }

--- a/packages/cloudflare-worker/wrangler.toml
+++ b/packages/cloudflare-worker/wrangler.toml
@@ -11,6 +11,11 @@
 #   - PROXY_JWT_SECRET       — JWT signing secret for proxy tokens
 #   - LLM_PROXY_BASE_URL     — Upstream LLM provider base URL
 #   - LLM_PROXY_API_KEY      — Upstream LLM provider API key
+#
+# Token billing secrets (if using CU quota system):
+#   - UPSTASH_REDIS_URL      — Upstash Redis REST URL (for quota tracking)
+#   - UPSTASH_REDIS_TOKEN    — Upstash Redis REST token
+#   - DEFAULT_CU_LIMIT       — Default CU limit per user (optional, default: 10000)
 # =============================================================================
 
 name = "markus-proxy"
@@ -47,6 +52,10 @@ head_sampling_rate = 0.1  # 10% sampling for production (reduce log volume/cost)
 
 [env.production]
 vars = { ENVIRONMENT = "production" }
+
+# Token billing — defaults (override via secrets if needed)
+[env.production.vars]
+DEFAULT_CU_LIMIT = "10000"
 
 # Worker resources (adjust based on expected load)
 [env.production.limits]

--- a/packages/cloudflare-worker/wrangler.toml
+++ b/packages/cloudflare-worker/wrangler.toml
@@ -9,4 +9,10 @@ head_sampling_rate = 1.0
 
 # Development environment
 [env.dev]
-vars = { ENVIRONMENT = "development" }
+vars = { ENVIRONMENT = "development", DEFAULT_CU_LIMIT = "100000" }
+
+# Production secrets (DO NOT commit actual values):
+#   wrangler secret put UPSTASH_REDIS_URL
+#   wrangler secret put UPSTASH_REDIS_TOKEN
+#   wrangler secret put LLM_PROXY_BASE_URL
+#   wrangler secret put LLM_PROXY_API_KEY


### PR DESCRIPTION
## What

Implements pre-reserve + post-correct (预扣费 + 修正模式) CU (compute unit) billing for the Cloudflare Worker.

## Files Changed

### `packages/cloudflare-worker/src/middleware/charging.ts` (NEW)
- **preReserveCu()**: Reserves max CU (`max_tokens * 3`) before request, writes `x-cu-estimated` on request
- **postCorrectCu()**: Reads `x-cu-actual` from response → refunds (creditQuota) or deducts more (deductQuota)
- Graceful degradation: Redis failure logs warning, continues
- Non-fatal errors (refund failure) don't break the client response

### `packages/cloudflare-worker/src/redis/quota.ts`
- **creditQuota()**: Atomic CU rollback (Redis Lua EVAL + in-memory fallback)
- **getFallbackStatus()**: Returns current in-memory fallback state for tests
- Lua script decrements used + handles limits atomically

### `packages/cloudflare-worker/src/routes/chat.ts`
- Refactored to integrate with middleware pipeline
- Upstream response carries `x-cu-actual` header (actual token usage)
- Streaming: buffers chunks, calculates total tokens, then sets `x-cu-actual`
- Cleaned up dead code (unused `payload` destructuring)

### `packages/cloudflare-worker/src/index.ts`
- Wires middleware into request pipeline: `preReserveCu → handle → postCorrectCu`
- Streaming handled: middleware intercepts `new Response()`, buffers & modifies, then post-corrects
- Wrangler config updated with env var docs

## Tests (29 new charging tests, 62 total all pass)

| Area | Tests | Coverage |
|------|-------|----------|
| Pre-reserve pass-through | 5 | Non-POST, non-chat, missing auth, malformed JSON, PUT method |
| Pre-reserve logic | 4 | Sufficient/invalid quota, insufficient → 429, Redis degradation |
| Post-correct refund | 8 | Actual < reserved → creditQuota call, amount calc, edge cases |
| Post-correct deduct | 5 | Actual > reserved → deductQuota call, exact match = no-op |
| Streaming post-correct | 5 | Streaming with several chunks, actual tokens calc |
| Error handling | 2 | creditQuota failure non-fatal, missing header fallback |

## Test Results
```
 ✓ src/routes/chat.test.ts (9 tests) 2ms
 ✓ src/redis/__tests__/quota.test.ts (14 tests) 6ms
 ✓ src/auth-context.test.ts (4 tests) 27ms
 ✓ src/middleware/__tests__/charging.test.ts (29 tests) 36ms
 ✓ src/jwt-verify.test.ts (6 tests) 62ms

 Test Files  5 passed (5)
      Tests  62 passed (62)
```

## Dependencies
- **Wave1-A**: CF Worker production deployment ✅ (PR #224 merged to feature/token-billing)
- **Wave1-B**: Upstash Redis + Lua atomic deduction ✅ (under review)