### PR TITLE
[TASK-tsk_77dd7d9518a0e2d066c05a73][Backend Developer] feat: define PlanConfig types and canonical plan data

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -16,6 +16,8 @@ export * from './types/cognitive.js';
 export * from './types/model-catalog.js';
 export * from './types/license.js';
 export * from './types/coding-tool.js';
+export * from './types/plan.js';
+export * from './plan-config.js';
 export * from './utils/config.js';
 export * from './utils/logger.js';
 export * from './utils/id.js';

--- a/packages/shared/src/plan-config.test.ts
+++ b/packages/shared/src/plan-config.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPlanConfig,
+  getDefaultPlan,
+  listPlans,
+  isValidPlan,
+  isValidSubscriptionKey,
+  parseSubscriptionKey,
+  detectPlan,
+  inspectSubscriptionKey,
+} from './plan-config.js';
+import type { PlanName } from './types/plan.js';
+
+// ── Test fixture ────────────────────────────────────────────────────────────
+
+/** A valid subscription key (48 hex chars after prefix) */
+const VALID_KEY = `markus_${'a'.repeat(48)}`;
+
+/** Key of invalid length */
+const INVALID_LEN_KEY = `markus_${'a'.repeat(16)}`;
+
+/** Key with bad prefix */
+const BAD_PREFIX_KEY = `hub_${'a'.repeat(48)}`;
+
+/** Key with non-hex chars */
+const BAD_HEX_KEY = `markus_${'g'.repeat(48)}`;
+
+// ── getPlanConfig ───────────────────────────────────────────────────────────
+
+describe('getPlanConfig', () => {
+  it('should return config for free plan', () => {
+    const cfg = getPlanConfig('free');
+    expect(cfg.name).toBe('free');
+    expect(cfg.monthlyQuotaCu).toBeGreaterThan(0);
+    expect(cfg.priceUsd).toBe(0);
+  });
+
+  it('should return config for enterprise plan', () => {
+    const cfg = getPlanConfig('enterprise');
+    expect(cfg.name).toBe('enterprise');
+    expect(cfg.monthlyQuotaCu).toBeGreaterThan(0);
+    expect(cfg.priceUsd).toBeGreaterThan(0);
+  });
+
+  it('should include windowQuotas for each plan', () => {
+    const names: PlanName[] = ['free', 'basic', 'plus', 'pro', 'max', 'team', 'enterprise'];
+    for (const name of names) {
+      const cfg = getPlanConfig(name);
+      expect(cfg.windowQuotas.length).toBeGreaterThan(0);
+      expect(cfg.windowQuotas[0].hours).toBeGreaterThan(0);
+      expect(cfg.windowQuotas[0].maxCu).toBeGreaterThan(0);
+    }
+  });
+
+  it('should have increasing monthly quotas', () => {
+    const quotas = listPlans().map(p => getPlanConfig(p).monthlyQuotaCu);
+    for (let i = 1; i < quotas.length; i++) {
+      expect(quotas[i]).toBeGreaterThan(quotas[i - 1]);
+    }
+  });
+
+  it('should have increasing prices', () => {
+    const prices = listPlans().map(p => getPlanConfig(p).priceUsd);
+    for (let i = 1; i < prices.length; i++) {
+      expect(prices[i]).toBeGreaterThanOrEqual(prices[i - 1]);
+    }
+  });
+
+  it('should throw for unknown plan', () => {
+    expect(() => getPlanConfig('unknown' as PlanName)).toThrow('Unknown plan');
+  });
+});
+
+// ── getDefaultPlan ──────────────────────────────────────────────────────────
+
+describe('getDefaultPlan', () => {
+  it('should return the free plan', () => {
+    const cfg = getDefaultPlan();
+    expect(cfg.name).toBe('free');
+    expect(cfg.priceUsd).toBe(0);
+  });
+});
+
+// ── listPlans ───────────────────────────────────────────────────────────────
+
+describe('listPlans', () => {
+  it('should return 7 plan names', () => {
+    const names = listPlans();
+    expect(names).toHaveLength(7);
+  });
+
+  it('should return plans in order: free → enterprise', () => {
+    const names = listPlans();
+    expect(names[0]).toBe('free');
+    expect(names[6]).toBe('enterprise');
+  });
+
+  it('should return a new array each call', () => {
+    const a = listPlans();
+    const b = listPlans();
+    expect(a).toEqual(b);
+    expect(a).not.toBe(b);
+  });
+});
+
+// ── isValidPlan ─────────────────────────────────────────────────────────────
+
+describe('isValidPlan', () => {
+  it('should return true for all valid plan names', () => {
+    for (const name of listPlans()) {
+      expect(isValidPlan(name)).toBe(true);
+    }
+  });
+
+  it('should return false for unknown plan names', () => {
+    expect(isValidPlan('unknown')).toBe(false);
+    expect(isValidPlan('premium')).toBe(false);
+    expect(isValidPlan('')).toBe(false);
+  });
+});
+
+// ── isValidSubscriptionKey ──────────────────────────────────────────────────
+
+describe('isValidSubscriptionKey', () => {
+  it('should accept a correctly formatted key', () => {
+    expect(isValidSubscriptionKey(VALID_KEY)).toBe(true);
+  });
+
+  it('should reject keys with wrong length', () => {
+    expect(isValidSubscriptionKey(INVALID_LEN_KEY)).toBe(false);
+  });
+
+  it('should reject keys with wrong prefix', () => {
+    expect(isValidSubscriptionKey(BAD_PREFIX_KEY)).toBe(false);
+  });
+
+  it('should reject keys with non-hex characters', () => {
+    expect(isValidSubscriptionKey(BAD_HEX_KEY)).toBe(false);
+  });
+
+  it('should reject empty string', () => {
+    expect(isValidSubscriptionKey('')).toBe(false);
+  });
+});
+
+// ── parseSubscriptionKey ────────────────────────────────────────────────────
+
+describe('parseSubscriptionKey', () => {
+  it('should extract hex payload from valid key', () => {
+    const hex = parseSubscriptionKey(VALID_KEY);
+    expect(hex).toBe('a'.repeat(48));
+  });
+
+  it('should return null for invalid key', () => {
+    expect(parseSubscriptionKey(BAD_HEX_KEY)).toBeNull();
+    expect(parseSubscriptionKey('')).toBeNull();
+  });
+});
+
+// ── detectPlan ──────────────────────────────────────────────────────────────
+
+describe('detectPlan', () => {
+  it('should return free plan for invalid key without strategy', async () => {
+    const result = await detectPlan('bad_key');
+    expect(result.plan.name).toBe('free');
+  });
+
+  it('should return free plan for valid key without strategy', async () => {
+    const result = await detectPlan(VALID_KEY);
+    expect(result.plan.name).toBe('free');
+  });
+
+  it('should use lookup strategy when provided', async () => {
+    const strategy = async (_key: string): Promise<PlanName | undefined> => 'pro';
+    const result = await detectPlan(VALID_KEY, strategy);
+    expect(result.plan.name).toBe('pro');
+    expect(result.planName).toBe('pro');
+    expect(result.plan.monthlyQuotaCu).toBe(500000);
+  });
+
+  it('should fall back to free if strategy returns unknown plan', async () => {
+    const strategy = async (_key: string): Promise<PlanName | undefined> => 'unknown' as PlanName;
+    const result = await detectPlan(VALID_KEY, strategy);
+    expect(result.plan.name).toBe('free');
+  });
+
+  it('should not call strategy for invalid keys', async () => {
+    let called = false;
+    const strategy = async (_key: string): Promise<PlanName | undefined> => {
+      called = true;
+      return 'pro';
+    };
+    const result = await detectPlan('bad_key', strategy);
+    expect(result.plan.name).toBe('free');
+    expect(called).toBe(false);
+  });
+});
+
+// ── inspectSubscriptionKey ──────────────────────────────────────────────────
+
+describe('inspectSubscriptionKey', () => {
+  it('should return valid=true for correct key', () => {
+    const info = inspectSubscriptionKey(VALID_KEY);
+    expect(info.valid).toBe(true);
+    expect(info.prefix).toBe('markus');
+  });
+
+  it('should return valid=false for incorrect key', () => {
+    const info = inspectSubscriptionKey('bad');
+    expect(info.valid).toBe(false);
+  });
+});

--- a/packages/shared/src/plan-config.ts
+++ b/packages/shared/src/plan-config.ts
@@ -1,0 +1,248 @@
+// ─── Plan Configuration Module ─────────────────────────────────────────────
+//
+// Provides typed access to the 7-tier plan system.
+// The canonical plan data is embedded here as a typed constant so it avoids
+// ESM JSON import issues with tsc -b project references.
+//
+// A standalone JSON copy lives at plan-data.json for CF Workers and other
+// non-TypeScript consumers. Keep both in sync.
+//
+// Subscription key format: markus_<48-hex-chars>
+// The key itself does NOT encode the plan; plan is resolved via an async
+// lookup strategy (e.g. Hub API call or local DB query).
+
+import type { PlanName, PlanConfig, WindowQuota } from './types/plan.js';
+
+// ── Canonical plan data ─────────────────────────────────────────────────────
+// Keep in sync with plan-data.json
+
+const PLANS: Record<PlanName, PlanConfig> = {
+  free: {
+    name: 'free',
+    displayName: 'Free',
+    monthlyQuotaCu: 10000,
+    windowQuotas: [{ hours: 5, maxCu: 1000 }],
+    priceUsd: 0,
+    priceUsdYearly: 0,
+    maxAgents: 1,
+    maxTeamMembers: 1,
+    features: ['core-agent', 'web-ui', 'community-skills'],
+  },
+  basic: {
+    name: 'basic',
+    displayName: 'Basic',
+    monthlyQuotaCu: 50000,
+    windowQuotas: [{ hours: 5, maxCu: 5000 }],
+    priceUsd: 9,
+    priceUsdYearly: 90,
+    maxAgents: 3,
+    maxTeamMembers: 3,
+    features: ['core-agent', 'web-ui', 'community-skills', 'custom-tools', 'basic-support'],
+  },
+  plus: {
+    name: 'plus',
+    displayName: 'Plus',
+    monthlyQuotaCu: 200000,
+    windowQuotas: [{ hours: 5, maxCu: 20000 }],
+    priceUsd: 29,
+    priceUsdYearly: 290,
+    maxAgents: 5,
+    maxTeamMembers: 5,
+    features: ['core-agent', 'web-ui', 'community-skills', 'custom-tools', 'priority-support', 'a2a'],
+  },
+  pro: {
+    name: 'pro',
+    displayName: 'Pro',
+    monthlyQuotaCu: 500000,
+    windowQuotas: [{ hours: 5, maxCu: 50000 }],
+    priceUsd: 79,
+    priceUsdYearly: 790,
+    maxAgents: 10,
+    maxTeamMembers: 10,
+    features: ['core-agent', 'web-ui', 'community-skills', 'custom-tools', 'priority-support', 'a2a', 'custom-llm', 'analytics'],
+  },
+  max: {
+    name: 'max',
+    displayName: 'Max',
+    monthlyQuotaCu: 2_000_000,
+    windowQuotas: [{ hours: 5, maxCu: 200_000 }],
+    priceUsd: 199,
+    priceUsdYearly: 1990,
+    maxAgents: 25,
+    maxTeamMembers: 25,
+    features: ['core-agent', 'web-ui', 'community-skills', 'custom-tools', 'priority-support', 'a2a', 'custom-llm', 'analytics', 'premium-models', 'advanced-workflows'],
+  },
+  team: {
+    name: 'team',
+    displayName: 'Team',
+    monthlyQuotaCu: 5_000_000,
+    windowQuotas: [{ hours: 5, maxCu: 500_000 }],
+    priceUsd: 499,
+    priceUsdYearly: 4990,
+    maxAgents: 50,
+    maxTeamMembers: 50,
+    features: ['core-agent', 'web-ui', 'community-skills', 'custom-tools', 'dedicated-support', 'a2a', 'custom-llm', 'analytics', 'premium-models', 'advanced-workflows', 'sso', 'audit-logs'],
+  },
+  enterprise: {
+    name: 'enterprise',
+    displayName: 'Enterprise',
+    monthlyQuotaCu: 20_000_000,
+    windowQuotas: [{ hours: 5, maxCu: 2_000_000 }],
+    priceUsd: 1499,
+    priceUsdYearly: 14990,
+    maxAgents: 999,
+    maxTeamMembers: 999,
+    features: ['core-agent', 'web-ui', 'community-skills', 'custom-tools', 'dedicated-support', 'a2a', 'custom-llm', 'analytics', 'premium-models', 'advanced-workflows', 'sso', 'audit-logs', 'on-premise', 'white-label', 'custom-contract'],
+  },
+};
+
+const PLAN_NAMES: PlanName[] = ['free', 'basic', 'plus', 'pro', 'max', 'team', 'enterprise'];
+const PLAN_NAMES_SET = new Set<string>(PLAN_NAMES);
+
+// ── Validation patterns ─────────────────────────────────────────────────────
+
+/** Pattern for a valid Markus subscription key: markus_<48-hex-chars> */
+const SUBSCRIPTION_KEY_RE = /^markus_[0-9a-f]{48}$/;
+
+/** Pattern for extracting the hex payload from a subscription key */
+const HEX_48 = /^markus_([0-9a-f]{48})$/;
+
+// ── Plan lookup helpers ─────────────────────────────────────────────────────
+
+/**
+ * Return the full config for a given plan name.
+ * Throws if the plan name is unknown.
+ */
+export function getPlanConfig(plan: PlanName): PlanConfig {
+  const cfg = PLANS[plan];
+  if (!cfg) {
+    throw new Error(`Unknown plan: "${plan}". Valid plans: ${PLAN_NAMES.join(', ')}`);
+  }
+  return cfg;
+}
+
+/**
+ * Return the free plan config (safe default for unauthenticated / fallback).
+ */
+export function getDefaultPlan(): PlanConfig {
+  return PLANS.free;
+}
+
+/**
+ * List all valid plan names (ordered from Free → Enterprise).
+ */
+export function listPlans(): PlanName[] {
+  return [...PLAN_NAMES];
+}
+
+/**
+ * Check whether the given string is a known plan name.
+ */
+export function isValidPlan(value: string): value is PlanName {
+  return PLAN_NAMES_SET.has(value);
+}
+
+// ── Subscription key helpers ────────────────────────────────────────────────
+
+/**
+ * Validate a subscription key format.
+ * Returns `true` if the key matches `markus_<48-hex-chars>`.
+ */
+export function isValidSubscriptionKey(key: string): boolean {
+  return SUBSCRIPTION_KEY_RE.test(key);
+}
+
+/**
+ * Extract the hex payload from a subscription key.
+ * Returns null if the key format is invalid.
+ */
+export function parseSubscriptionKey(key: string): string | null {
+  const match = HEX_48.exec(key);
+  return match ? match[1] : null;
+}
+
+// ── Plan detection ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve which plan a subscription key belongs to.
+ *
+ * This is intentionally async — in production the caller provides a
+ * `lookupStrategy` that queries the Hub DB (or a cache).  If no strategy is
+ * given, falls back to the free plan (safe default for non-production paths).
+ *
+ * @example
+ * ```ts
+ * const plan = await detectPlan(key, async (k) => {
+ *   const user = await db.select(...).where(eq(users.subscriptionKey, k));
+ *   return user?.planType ?? 'free';
+ * });
+ * ```
+ */
+export async function detectPlan(
+  subscriptionKey: string,
+  lookupStrategy?: (key: string) => Promise<PlanName | undefined>,
+): Promise<{ plan: PlanConfig; planName: PlanName }> {
+  if (!isValidSubscriptionKey(subscriptionKey)) {
+    return { plan: PLANS.free, planName: 'free' };
+  }
+
+  if (lookupStrategy) {
+    const plan = await lookupStrategy(subscriptionKey);
+    if (plan && isValidPlan(plan)) {
+      return { plan: PLANS[plan], planName: plan };
+    }
+  }
+
+  return { plan: PLANS.free, planName: 'free' };
+}
+
+// ── Subscription key prefix inspection ──────────────────────────────────────
+
+/**
+ * Inspect a subscription key to determine its validity and environment prefix.
+ */
+export function inspectSubscriptionKey(key: string): { valid: boolean; prefix: string } {
+  const prefix = key.startsWith('markus_') ? 'markus' : 'unknown';
+  return {
+    valid: isValidSubscriptionKey(key),
+    prefix,
+  };
+}
+
+// ── Serialization helper ────────────────────────────────────────────────────
+
+/**
+ * Return a plain object of all plan configs (useful for HTTP responses
+ * that need the full plan catalog).
+ */
+export function getAllPlanConfigs(): Record<PlanName, PlanConfig> {
+  return { ...PLANS };
+}
+
+// ── Sync guard ──────────────────────────────────────────────────────────────
+
+/**
+ * Validate a PlanConfig object against known schema invariants.
+ * Useful for verifying plan-data.json stays in sync with the TypeScript source.
+ */
+export function validatePlanConfig(config: PlanConfig): string[] {
+  const errors: string[] = [];
+  if (!PLAN_NAMES_SET.has(config.name)) {
+    errors.push(`Invalid plan name: "${config.name}"`);
+  }
+  if (config.monthlyQuotaCu <= 0) {
+    errors.push(`monthlyQuotaCu must be > 0, got ${config.monthlyQuotaCu}`);
+  }
+  if (config.windowQuotas.length === 0) {
+    errors.push('windowQuotas must not be empty');
+  }
+  for (const wq of config.windowQuotas) {
+    if (wq.hours <= 0) errors.push(`windowQuotas.hours must be > 0, got ${wq.hours}`);
+    if (wq.maxCu <= 0) errors.push(`windowQuotas.maxCu must be > 0, got ${wq.maxCu}`);
+  }
+  if (config.priceUsd < 0) errors.push(`priceUsd must be >= 0, got ${config.priceUsd}`);
+  if (config.priceUsdYearly < 0) errors.push(`priceUsdYearly must be >= 0, got ${config.priceUsdYearly}`);
+  if (config.maxAgents <= 0) errors.push(`maxAgents must be > 0, got ${config.maxAgents}`);
+  if (config.maxTeamMembers <= 0) errors.push(`maxTeamMembers must be > 0, got ${config.maxTeamMembers}`);
+  return errors;
+}

--- a/packages/shared/src/plan-data.json
+++ b/packages/shared/src/plan-data.json
@@ -1,0 +1,93 @@
+{
+  "free": {
+    "name": "free",
+    "displayName": "Free",
+    "monthlyQuotaCu": 10000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 1000 }
+    ],
+    "priceUsd": 0,
+    "priceUsdYearly": 0,
+    "maxAgents": 1,
+    "maxTeamMembers": 1,
+    "features": ["core-agent", "web-ui", "community-skills"]
+  },
+  "basic": {
+    "name": "basic",
+    "displayName": "Basic",
+    "monthlyQuotaCu": 50000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 5000 }
+    ],
+    "priceUsd": 9,
+    "priceUsdYearly": 90,
+    "maxAgents": 3,
+    "maxTeamMembers": 3,
+    "features": ["core-agent", "web-ui", "community-skills", "custom-tools", "basic-support"]
+  },
+  "plus": {
+    "name": "plus",
+    "displayName": "Plus",
+    "monthlyQuotaCu": 200000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 20000 }
+    ],
+    "priceUsd": 29,
+    "priceUsdYearly": 290,
+    "maxAgents": 5,
+    "maxTeamMembers": 5,
+    "features": ["core-agent", "web-ui", "community-skills", "custom-tools", "priority-support", "a2a"]
+  },
+  "pro": {
+    "name": "pro",
+    "displayName": "Pro",
+    "monthlyQuotaCu": 500000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 50000 }
+    ],
+    "priceUsd": 79,
+    "priceUsdYearly": 790,
+    "maxAgents": 10,
+    "maxTeamMembers": 10,
+    "features": ["core-agent", "web-ui", "community-skills", "custom-tools", "priority-support", "a2a", "custom-llm", "analytics"]
+  },
+  "max": {
+    "name": "max",
+    "displayName": "Max",
+    "monthlyQuotaCu": 2000000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 200000 }
+    ],
+    "priceUsd": 199,
+    "priceUsdYearly": 1990,
+    "maxAgents": 25,
+    "maxTeamMembers": 25,
+    "features": ["core-agent", "web-ui", "community-skills", "custom-tools", "priority-support", "a2a", "custom-llm", "analytics", "premium-models", "advanced-workflows"]
+  },
+  "team": {
+    "name": "team",
+    "displayName": "Team",
+    "monthlyQuotaCu": 5000000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 500000 }
+    ],
+    "priceUsd": 499,
+    "priceUsdYearly": 4990,
+    "maxAgents": 50,
+    "maxTeamMembers": 50,
+    "features": ["core-agent", "web-ui", "community-skills", "custom-tools", "dedicated-support", "a2a", "custom-llm", "analytics", "premium-models", "advanced-workflows", "sso", "audit-logs"]
+  },
+  "enterprise": {
+    "name": "enterprise",
+    "displayName": "Enterprise",
+    "monthlyQuotaCu": 20000000,
+    "windowQuotas": [
+      { "hours": 5, "maxCu": 2000000 }
+    ],
+    "priceUsd": 1499,
+    "priceUsdYearly": 14990,
+    "maxAgents": 999,
+    "maxTeamMembers": 999,
+    "features": ["core-agent", "web-ui", "community-skills", "custom-tools", "dedicated-support", "a2a", "custom-llm", "analytics", "premium-models", "advanced-workflows", "sso", "audit-logs", "on-premise", "white-label", "custom-contract"]
+  }
+}

--- a/packages/shared/src/types/plan.ts
+++ b/packages/shared/src/types/plan.ts
@@ -1,0 +1,43 @@
+// ─── Plan Configuration Types ──────────────────────────────────────────────
+//
+// 7-tier plan system for Markus token-billing.
+// Each plan has defined CU quotas, window rate limits, and pricing.
+//
+// The canonical plan config data lives in plan-data.json (in the parent dir);
+// these types describe its shape and provide helper accessors.
+
+/** All supported plan tiers */
+export type PlanName = 'free' | 'basic' | 'plus' | 'pro' | 'max' | 'team' | 'enterprise';
+
+/** Short time-window quota (e.g. 5-hour rate limit) */
+export interface WindowQuota {
+  /** Duration in hours */
+  hours: number;
+  /** Max compute units allowed in this window */
+  maxCu: number;
+}
+
+/** Full plan configuration */
+export interface PlanConfig {
+  /** Unique identifier (matches PlanName) */
+  name: PlanName;
+  /** Human-readable display name */
+  displayName: string;
+  /** Monthly CU entitlement */
+  monthlyQuotaCu: number;
+  /** Short-window rate limits (throttling, not billing) */
+  windowQuotas: WindowQuota[];
+  /** Monthly price in USD (0 = free) */
+  priceUsd: number;
+  /** Annual price in USD per month (discounted; 0 = free) */
+  priceUsdYearly: number;
+  /** Max active agents allowed */
+  maxAgents: number;
+  /** Max team members allowed */
+  maxTeamMembers: number;
+  /** Feature flags / capability labels */
+  features: string[];
+}
+
+/** Map of all plans keyed by name */
+export type PlanConfigMap = Record<PlanName, PlanConfig>;


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Backend Developer (ID: agt_45ee41456c2a1e988a9c19fd)
- **关联任务**: tsk_77dd7d9518a0e2d066c05a73
- **目标分支**: feature/token-billing

## 🎯 背景与动机
Wave2-A 任务：在 shared 包中定义套餐映射配置，包括 PlanConfig 类型定义、7 层套餐的 CU 配额数据、和检测/解析辅助函数。

## 🔧 变更内容 (What)
- `packages/shared/src/types/plan.ts`: PlanConfig, PlanConfigMap, WindowQuota 类型定义
- `packages/shared/src/plan-config.ts`: 7 层套餐规范数据 + getPlanConfig/listPlans/isValidPlan/detectPlan/subscriptionKey 辅助函数
- `packages/shared/src/plan-data.json`: 套餐数据的 JSON 序列化版本
- `packages/shared/src/index.ts`: 导出 plan types + plan-config
- `packages/shared/src/plan-config.test.ts`: 26 个单元测试

## ✅ 验证方式 (How to Verify)
- [x] pnpm typecheck 通过
- [x] pnpm test (26/26 plan-config tests pass)
- [x] Pre-existing failures: 9 CLI tests (port 9000 EADDRINUSE — not related)

## 👤 评审人
- **Reviewer**: Code Reviewer