### PR TITLE
[tsk_cfa7b3c780992a4bfded28dd][Account & Model Management Developer] feat: 添加 GPT-5.6 系列模型至 OpenAI Provider 目录

### DIFF
--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -23,8 +23,8 @@ export const PROVIDERS: ProviderModel[] = [
     id: 'openai',
     label: 'OpenAI',
     envKey: 'OPENAI_API_KEY',
-    defaultModel: 'gpt-5.4',
-    models: ['gpt-5.4', 'gpt-4.1', 'gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini', 'o4-mini'],
+    defaultModel: 'gpt-5.6-terra',
+    models: ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna', 'gpt-5.4', 'gpt-4.1', 'gpt-4o', 'gpt-4o-mini', 'o3', 'o3-mini', 'o4-mini'],
   },
   {
     id: 'google',
@@ -84,6 +84,9 @@ export const PROVIDERS: ProviderModel[] = [
     baseUrl: 'https://openrouter.ai/api/v1',
     defaultModel: 'xiaomi/mimo-v2-pro:free',
     models: [
+      'openai/gpt-5.6-sol',
+      'openai/gpt-5.6-terra',
+      'openai/gpt-5.6-luna',
       'anthropic/claude-opus-4.6',
       'anthropic/claude-sonnet-4.6',
       'qwen/qwen3.6-plus',
@@ -203,7 +206,7 @@ export const PROVIDERS: ProviderModel[] = [
     envKey: 'ATLASCLOUD_API_KEY',
     baseUrl: 'https://api.atlascloud.ai/v1',
     defaultModel: 'claude-sonnet-4-6',
-    models: ['claude-sonnet-4-6', 'gpt-4.1', 'gemini-2.5-pro', 'deepseek-v3', 'flux-1-schnell'],
+    models: ['claude-sonnet-4-6', 'gpt-5.6-terra', 'gpt-4.1', 'gemini-2.5-pro', 'deepseek-v3', 'flux-1-schnell'],
   },
   {
     id: 'strongly',
@@ -211,7 +214,7 @@ export const PROVIDERS: ProviderModel[] = [
     envKey: 'STRONGLY_API_KEY',
     baseUrl: 'https://api.strongly.ai/v1',
     defaultModel: 'claude-sonnet-4-6',
-    models: ['claude-sonnet-4-6', 'gpt-4.1', 'gemini-2.5-pro'],
+    models: ['claude-sonnet-4-6', 'gpt-5.6-terra', 'gpt-4.1', 'gemini-2.5-pro'],
   },
 ];
 


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Account & Model Management Developer (ID: agt_4e45db7841587e235f8a4794)
- **关联任务**: tsk_cfa7b3c780992a4bfded28dd
- **关联需求**: req_8f8ac26ef990061349517fb1
- **目标分支**: main

## 🎯 背景与动机
OpenAI 于 2026年6月26日 正式发布 GPT-5.6 系列模型（Sol/Terra/Luna 三层产品线）。需要在 Markus 的 LLM Provider 目录中注册这三款新模型。

## 🔧 变更内容
- `packages/shared/src/models.ts`: OpenAI Provider 新增 gpt-5.6-sol/terra/luna，defaultModel 更新为 gpt-5.6-terra
- `packages/shared/src/models.ts`: OpenRouter 新增 openai/gpt-5.6-sol/terra/luna 映射
- `packages/shared/src/models.ts`: Atlas Cloud 新增 gpt-5.6-terra
- `packages/shared/src/models.ts`: Strongly.AI 新增 gpt-5.6-terra

## ✅ 验证方式
- [ ] pnpm lint 通过
- [ ] pnpm typecheck 通过
- [ ] pnpm test 通过

## 👤 评审人
- **Reviewer**: Code Reviewer