### PR TITLE
[TASK-tsk_7d457f39abffbb7a6a2f5fcd][Account & Model Mgmt Developer] feat: 实现会话级别模型即时切换

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -40,8 +40,45 @@ All requests require authentication via one of:
 | POST | `/api/agents/:id/message` | Send message to agent (SSE streaming) |
 | GET | `/api/sessions` | List conversation sessions |
 | GET | `/api/sessions/:id/messages` | Get session message history |
+| GET | `/api/sessions/:id/model` | Get session-level model override |
+| POST | `/api/sessions/:id/model` | Set session-level model override `{ provider, model }` |
+| DELETE | `/api/sessions/:id/model` | Clear session-level model override |
 | GET | `/api/channels/:channel/messages` | Get channel history |
 | POST | `/api/channels/:channel/messages` | Send channel message (supports SSE streaming) |
+
+### Session Model Override
+
+Allows switching the LLM model/provider for a specific conversation session without affecting other sessions or global routing. See [design document](design/model-switching.md) for full details.
+
+**GET /api/sessions/:id/model** — Get current override:
+```json
+// 200 Response (override exists)
+{ "provider": "anthropic", "model": "claude-sonnet-4-20250514", "setAt": "2026-07-02T10:30:00.000Z" }
+
+// 200 Response (no override)
+{ "provider": null, "model": null, "setAt": null }
+```
+
+**POST /api/sessions/:id/model** — Set override:
+```json
+// Request body
+{ "provider": "anthropic", "model": "claude-sonnet-4-20250514" }
+
+// 200 Response
+{ "success": true, "provider": "anthropic", "model": "claude-sonnet-4-20250514" }
+```
+
+**DELETE /api/sessions/:id/model** — Clear override:
+```json
+// 204 Response (no body)
+```
+
+**Error responses:**
+| Status | Description |
+|--------|-------------|
+| 400 | Missing `provider` or `model` (POST only) |
+| 403 | Session belongs to another user (non-admin) |
+| 503 | LLM router not available |
 
 ---
 

--- a/docs/design/model-switching.md
+++ b/docs/design/model-switching.md
@@ -1,0 +1,357 @@
+# 会话级模型即时切换 — 设计文档
+
+> **文档状态**: 已实现 (v1.0)
+> **实现 PR**: [#233](https://github.com/markus-global/markus/pull/233)
+> **最后更新**: 2026-07-02
+
+---
+
+## 1. 动机
+
+用户在对话中需要临时切换 LLM 模型/提供商，而无需中断会话或修改全局路由配置。典型场景：
+
+- **成本控制**: 简单问题切换到廉价模型（如 DeepSeek），复杂推理切回 Claude
+- **能力需求**: 代码生成任务需要切换到特定模型（如 GPT-4o 的代码能力）
+- **故障容错**: 当前提供商不可用，临时切换到备用提供商
+
+---
+
+## 2. 设计概览
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         LLMRouter                                │
+│                                                                  │
+│  ┌──────────────┐    ┌──────────────────────────┐               │
+│  │  Default      │    │  sessionOverrides Map    │               │
+│  │  Routing      │    │  ┌────────────────────┐  │               │
+│  │  (provider    │    │  │ "session-abc-123"  │  │               │
+│  │   tiers,      │    │  │ → { provider:      │  │               │
+│  │   capability  │    │  │     "anthropic",   │  │               │
+│  │   routing)    │    │  │     model:         │  │               │
+│  │               │    │  │     "claude-sonnet- │  │               │
+│  │               │    │  │      4-20250514",  │  │               │
+│  │               │    │  │     setAt:          │  │               │
+│  │               │    │  │     "2026-07-..."   │  │               │
+│  │               │    │  │   }                │  │               │
+│  │               │    │  └────────────────────┘  │               │
+│  └──────┬────────┘    └──────────┬───────────────┘               │
+│         │                        │                                │
+│         ▼                        ▼                                │
+│  ┌──────────────────────────────────────────┐                    │
+│  │        Priority Chain (high → low)       │                    │
+│  │                                          │                    │
+│  │  ① Per-request metadata override         │                    │
+│  │     (modelOverride / providerOverride    │                    │
+│  │      on LLMRequest.metadata)             │                    │
+│  │  ② Session-level override               │                    │
+│  │     (sessionOverrides map entry)         │                    │
+│  │  ③ Explicit providerName parameter       │                    │
+│  │     (passed to chat/chatStream)          │                    │
+│  │  ④ Capability routing assignments        │                    │
+│  │     (capabilityRouting config)           │                    │
+│  │  ⑤ Route-level default / complexity      │                    │
+│  │     (selectProvider fallback)            │                    │
+│  └──────────────────────────────────────────┘                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 优先级顺序（高 → 低）
+
+| 优先级 | 层级 | 作用域 | 设置方式 |
+|--------|------|--------|---------|
+| **1** (最高) | 请求元数据覆写 | 单次请求 | `LLMRequest.metadata.modelOverride` / `.providerOverride` |
+| **2** | 会话覆写 | 整个会话 | `POST /api/sessions/:sessionId/model` API |
+| **3** | 显式 Provider 参数 | 单次调用 | `chat(request, providerName)` 参数 |
+| **4** | Capability 路由分配 | 全局 | `capabilityRouting.assignments` 配置 |
+| **5** | 默认路由 (复杂度/层级选择) | 全局 | `selectProvider()` / `assessComplexity()` |
+
+---
+
+## 3. 数据结构
+
+### SessionModelOverride (shared 类型)
+
+```typescript
+// packages/shared/src/types/llm.ts
+interface SessionModelOverride {
+  /** Provider name (e.g. "anthropic", "openai") */
+  provider?: string;
+  /** Model ID (e.g. "claude-sonnet-4-20250514") */
+  model?: string;
+  /** ISO timestamp when this override was set */
+  setAt?: string;
+}
+```
+
+### 内部存储
+
+```typescript
+// LLMRouter 内部
+private sessionOverrides = new Map<string, SessionModelOverride>();
+```
+
+Map 以 `sessionId` 为 key。无持久化存储 — 重启后丢失（当前限制）。
+
+### LLMRequest.metadata 扩展
+
+```typescript
+interface LLMMetadata {
+  // ... 已有字段
+  /** Per-request model override — switch model for this request only */
+  modelOverride?: string;
+  /** Per-request provider override — switch provider for this request only */
+  providerOverride?: string;
+}
+```
+
+---
+
+## 4. 核心 API (LLMRouter 方法)
+
+### 4.1 `setSessionModel(sessionId, override)`
+
+```typescript
+setSessionModel(sessionId: string, override: SessionModelOverride): void
+```
+
+- 将 override 存入 `sessionOverrides` Map
+- 自动设置 `setAt` 为当前 ISO 时间戳
+- 不做 provider 存在性校验（允许设置后在后续路由阶段由 `isAvailable()` 检查）
+
+### 4.2 `getSessionModel(sessionId)`
+
+```typescript
+getSessionModel(sessionId: string): SessionModelOverride | undefined
+```
+
+- 返回指定会话的覆写配置
+- 不存在时返回 `undefined`
+
+### 4.3 `clearSessionModel(sessionId)`
+
+```typescript
+clearSessionModel(sessionId: string): void
+```
+
+- 删除指定会话的覆写，恢复默认路由
+
+### 4.4 `clearAllSessionModels()`
+
+```typescript
+clearAllSessionModels(): void
+```
+
+- 清空所有会话的覆写（系统重置/维护场景）
+
+---
+
+## 5. 与核心路由的集成
+
+### 5.1 `selectForCapability()` — 能力路由路径
+
+```
+请求 selectForCapability(capabilityType, request, sessionId)
+  │
+  ├── 检查 sessionOverrides[sessionId]?
+  │     ├── 有且 provider 可用 (isAvailable) → 返回 session 覆写
+  │     └── 无或 provider 不可用 → 继续
+  │
+  ├── 检查 capabilityRouting.assignments?
+  │     ├── 有 → 返回 assignment
+  │     └── 无 → 继续
+  │
+  ├── 检查 routingDefaultModel?
+  │     ├── 有 → 返回默认模型
+  │     └── 无 → 继续
+  │
+  └── selectProvider(request) → 基于复杂度的回退
+```
+
+### 5.2 `chat()` / `chatStream()` — 文本聊天路径
+
+```
+chat(request, providerName?, options?)
+  │
+  ├── 读取 request.metadata 中的 per-request 覆写
+  │     ├── providerOverride → 如果存在且 provider 已注册，设为 providerName
+  │     └── modelOverride → 设为 routedModel
+  │
+  ├── 读取 sessionOverrides[sessionId]
+  │     ├── provider → 如果存在且未设置 providerName，设为 providerName
+  │     └── model → 如果存在且未设置 routedModel，设为 routedModel
+  │
+  ├── 基于 providerName 选择 provider
+  │     ├── 有 → selectProvider(request, providerName)
+  │     └── 无 → selectForCapability() 或 selectProvider()
+  │
+  └── tryChat(provider, request, routedModel)
+```
+
+### 5.3 关键设计决策
+
+| 决策 | 选项 | 选择理由 |
+|------|------|---------|
+| 持久化方案 | 内存 Map vs 数据库 | 内存 Map 足够——会话生命周期较短；数据库增加不必要的延迟 |
+| Provider 校验时机 | 设置时 vs 路由时 | 路由时——允许在设置后动态添加 Provider |
+| Override 作用域 | Session vs 更多粒度 | Session——粒度适中；单个会话内多次请求共享一个覆写 |
+| 单次请求覆写 | metadata 字段 | Per-request 优先级最高，满足临时需求且不影响后续请求 |
+
+---
+
+## 6. HTTP API
+
+3 条 REST 端点，用于管理会话级模型覆写：
+
+### 6.1 GET /api/sessions/:sessionId/model
+
+获取会话的当前模型覆写。
+
+**响应 (200)**:
+```json
+{
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514",
+  "setAt": "2026-07-02T10:30:00.000Z"
+}
+```
+
+**响应 (200, 无覆写)**:
+```json
+{
+  "provider": null,
+  "model": null,
+  "setAt": null
+}
+```
+
+### 6.2 POST /api/sessions/:sessionId/model
+
+设置会话的模型覆写。
+
+**请求体**:
+```json
+{
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514"
+}
+```
+
+**响应 (200)**:
+```json
+{
+  "success": true,
+  "provider": "anthropic",
+  "model": "claude-sonnet-4-20250514"
+}
+```
+
+**错误响应**:
+- `400` — `{ "error": "provider (string) is required" }` 或 `{ "error": "model (string) is required" }`
+- `503` — `{ "error": "LLM router not available" }`
+- `403` — `{ "error": "Access denied: this session belongs to another user" }`
+
+### 6.3 DELETE /api/sessions/:sessionId/model
+
+清除会话的模型覆写。
+
+**响应 (204)**: 无内容
+
+**错误响应**:
+- `503` — `{ "error": "LLM router not available" }`
+- `403` — `{ "error": "Access denied: this session belongs to another user" }`
+
+### 6.4 鉴权
+
+所有端点均需 JWT 认证（`requireAuth` 中间件）。会话所有权检查：
+- 如果 session 存在且属于其他 userId，返回 `403`
+- 如果请求用户是 `admin` 或 `owner` 角色，可以操作任何会话（绕过所有权检查）
+
+### 6.5 审计日志
+
+`POST` 和 `DELETE` 操作记录审计日志：
+- **类型**: `settings_changed`
+- **动作**: `session_model_override` / `session_model_override_clear`
+- **包含**: sessionId, provider, model, userId
+
+---
+
+## 7. 与 Wave 2 前端的对接约定
+
+### 模型选择 UI 组件
+
+Wave 2 前端将新增一个模型选择器组件，位于会话设置面板中：
+
+```typescript
+// 前端 UI 组件预期接口
+interface ModelSwitcherProps {
+  sessionId: string;
+  currentOverride: { provider: string | null; model: string | null };
+  availableProviders: Array<{ name: string; models: Array<{ id: string; name: string }> }>;
+  onSwitch: (sessionId: string, provider: string, model: string) => Promise<void>;
+  onClear: (sessionId: string) => Promise<void>;
+}
+```
+
+### 数据流
+
+```
+用户选择模型 → 前端调用 POST /api/sessions/:id/model
+  → 后端设置 sessionOverride
+  → 后端更新前端状态（可选 WebSocket 广播）
+  → 后续消息自动使用新模型
+  → 用户可随时清除覆写（恢复默认路由）
+```
+
+### 可用 Provider/Model 列表
+
+前端通过现有 `GET /api/models/routing-candidates` 端点获取可用 Provider 和模型列表。
+
+---
+
+## 8. 已知限制与后续优化
+
+### TTL 回收
+
+**当前状态**: 无自动回收。`sessionOverrides` Map 仅通过 `clearSessionModel()` 或 `clearAllSessionModels()` 手动清理。
+
+**对系统的影响**:
+- 内存占用随活跃会话数线性增长（每个条目约 200 字节）
+- 假设 10,000 个活跃会话 → 约 2 MB 内存，可接受
+
+**计划改进**:
+```typescript
+// Wave 2: 添加 TTL 回收
+private SESSION_OVERRIDE_TTL_MS = 24 * 60 * 60 * 1000; // 24 小时
+
+// 在 getSessionModel 中惰性回收
+getSessionModel(sessionId: string): SessionModelOverride | undefined {
+  const override = this.sessionOverrides.get(sessionId);
+  if (override?.setAt) {
+    const age = Date.now() - new Date(override.setAt).getTime();
+    if (age > SESSION_OVERRIDE_TTL_MS) {
+      this.sessionOverrides.delete(sessionId);
+      return undefined;
+    }
+  }
+  return override;
+}
+```
+
+### Provider 可用性检查
+
+当前 `setSessionModel()` 不做 Provider 可用性校验——校验延迟到路由时由 `isAvailable()` 执行。这意味着：
+- ✅ Pro: 可以设置尚未配置的 Provider（先设置，后配置）
+- ⚠️ 副作用: 无效 Provider 设置后不会报错，路由时静默降级
+
+### 持久化
+
+当前无持久化。服务重启后所有会话覆写丢失。如需持久化：
+- `Redis/数据库`: 在 `setSessionModel()` / `clearSessionModel()` 时同步写 DB
+- 在 `createRouter()` 时从 DB 恢复活跃会话的覆写
+
+### 并发安全
+
+当前 `Map` 操作非原子。在高并发场景下可能出现竞态条件：
+- 两个请求同时设置同一个 sessionId → 后者覆盖前者
+- 对于当前使用模式（单用户操作自己的会话），风险可控

--- a/docs/model-routing-architecture.md
+++ b/docs/model-routing-architecture.md
@@ -184,6 +184,22 @@ sequenceDiagram
 
 `resolveModalityCandidates()` returns a list of `{ provider, model, name }` tuples. The caller passes `model` into the provider method's `options` parameter. This prevents a critical bug where mutating `provider.model` (via `configure()`) for a modality call would corrupt subsequent chat requests on the same provider instance.
 
+### Session-Level Override
+
+Markus supports session-level model switching — temporarily overriding the model/provider for a specific conversation session without affecting global routing.
+
+**Priority**: Session overrides sit below per-request metadata overrides but above capability routing assignments:
+
+1. **Per-request** — `LLMRequest.metadata.modelOverride` / `providerOverride` (highest)
+2. **Session-level** — `sessionOverrides` Map (set via API)
+3. **Global routing** — capability assignments → tier-based complexity routing (lowest)
+
+**Storage**: In-memory `Map<string, SessionModelOverride>`, not persisted across restarts.
+
+**TTL**: No automatic TTL in v1 — planned for Wave 2. Override lives until explicitly cleared via API.
+
+See [design document](design/model-switching.md) for full details.
+
 ### Agent-Level Overrides
 
 Each multimodal tool accepts optional `provider` and `model` parameters from the agent. When provided, `resolveEffectiveCandidates()` filters the candidate list: an explicit `provider` restricts to that single provider, and an explicit `model` overrides the routing-assigned model on all candidates. This lets agents dynamically select providers without changing the global routing configuration.
@@ -341,12 +357,15 @@ type ModelCapabilityType = 'text' | 'image_recognition' | 'image_generation' | '
 ## API Endpoints
 
 
-| Endpoint                            | Method | Description                                                          | Caching               |
-| ----------------------------------- | ------ | -------------------------------------------------------------------- | --------------------- |
-| `/api/settings/llm/routing`         | GET    | Current routing config                                               | None                  |
-| `/api/settings/llm`                 | POST   | Update routing config (capabilityRouting, routingDefaultModel, etc.) | None                  |
-| `/api/models/routing-candidates`    | GET    | All available models per provider                                    | 5-min server-side TTL |
-| `/api/models/suggested-assignments` | GET    | Auto-suggested best model per capability                             | None                  |
+| Endpoint                                 | Method | Description                                                          | Caching               |
+| ---------------------------------------- | ------ | -------------------------------------------------------------------- | --------------------- |
+| `/api/settings/llm/routing`              | GET    | Current routing config                                               | None                  |
+| `/api/settings/llm`                      | POST   | Update routing config (capabilityRouting, routingDefaultModel, etc.) | None                  |
+| `/api/models/routing-candidates`         | GET    | All available models per provider                                    | 5-min server-side TTL |
+| `/api/models/suggested-assignments`      | GET    | Auto-suggested best model per capability                             | None                  |
+| `/api/sessions/:sessionId/model`         | GET    | Get session-level model override                                     | None                  |
+| `/api/sessions/:sessionId/model`         | POST   | Set session-level model override                                     | None                  |
+| `/api/sessions/:sessionId/model`         | DELETE | Clear session-level model override                                   | None                  |
 
 
 ---

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -1,4 +1,4 @@
-import { createLogger, getTextContent, LLM_CIRCUIT_RESET_RATE_LIMIT_MS, LLM_MAX_CONCURRENT_PER_PROVIDER, LLM_CONCURRENCY_JITTER_BASE_MS, type LLMRequest, type LLMResponse, type LLMStreamEvent, type LLMProviderConfig, type ModelDefinition, type ModelCostConfig, type EnhancedProviderSettings, type EnhancedLLMSettings, type AuthProfile, type ModelTier, type ModelCapabilityType, type CostTier, type CapabilityRoutingConfig, type CapabilityModelAssignment, type ProviderCapabilities } from '@markus/shared';
+import { createLogger, getTextContent, LLM_CIRCUIT_RESET_RATE_LIMIT_MS, LLM_MAX_CONCURRENT_PER_PROVIDER, LLM_CONCURRENCY_JITTER_BASE_MS, type LLMRequest, type LLMResponse, type LLMStreamEvent, type LLMProviderConfig, type ModelDefinition, type ModelCostConfig, type EnhancedProviderSettings, type EnhancedLLMSettings, type AuthProfile, type ModelTier, type ModelCapabilityType, type CostTier, type CapabilityRoutingConfig, type CapabilityModelAssignment, type ProviderCapabilities, type SessionModelOverride } from '@markus/shared';
 import { startSpan } from '../tracing.js';
 import type { LLMProviderInterface, MultiModalProviderInterface } from './provider.js';
 import { AnthropicProvider } from './anthropic.js';
@@ -130,6 +130,7 @@ export class LLMRouter {
   private customModelConfigs = new Map<string, { contextWindow?: number; maxOutputTokens?: number; cost?: ModelCostConfig }>();
   private customModelCatalog = new Map<string, ModelDefinition[]>();
   private disabledProviders = new Set<string>();
+  private sessionOverrides = new Map<string, SessionModelOverride>();
 
   /** Per-provider in-flight request counter for concurrency-aware jitter */
   private inFlight = new Map<string, number>();
@@ -607,7 +608,15 @@ export class LLMRouter {
    * Select a provider+model for a given capability type.
    * Pure lookup: explicit assignment -> default model -> any available provider.
    */
-  selectForCapability(capabilityType: ModelCapabilityType, request: LLMRequest, _sessionId?: string): { provider: string; model?: string } {
+  selectForCapability(capabilityType: ModelCapabilityType, request: LLMRequest, sessionId?: string): { provider: string; model?: string } {
+    // 0. Check session-level override first (highest priority for capability routing)
+    if (sessionId) {
+      const sessionOverride = this.sessionOverrides.get(sessionId);
+      if (sessionOverride?.provider && this.isAvailable(sessionOverride.provider)) {
+        return { provider: sessionOverride.provider, model: sessionOverride.model };
+      }
+    }
+
     // 1. Check explicit assignment
     const assignment = this._capabilityRouting.assignments[capabilityType];
     if (assignment) {
@@ -886,6 +895,30 @@ export class LLMRouter {
   async chat(request: LLMRequest, providerName?: string, options?: ChatOptions): Promise<LLMResponse> {
     let primary: string;
     let routedModel: string | undefined;
+    const sessionId = request?.metadata?.sessionId || options?.sessionId;
+
+    // Check per-request modelOverride from metadata (highest priority)
+    if (!providerName && request?.metadata?.providerOverride) {
+      if (this.providers.has(request.metadata.providerOverride)) {
+        providerName = request.metadata.providerOverride;
+      }
+    }
+    if (request?.metadata?.modelOverride) {
+      routedModel = request.metadata.modelOverride;
+    }
+
+    // Check per-session override (lower than per-request, higher than default)
+    if (sessionId) {
+      const sessionOverride = this.sessionOverrides.get(sessionId);
+      if (sessionOverride && !providerName) {
+        if (sessionOverride.provider && this.providers.has(sessionOverride.provider)) {
+          providerName = sessionOverride.provider;
+        }
+        if (sessionOverride.model && !routedModel) {
+          routedModel = sessionOverride.model;
+        }
+      }
+    }
 
     if (providerName) {
       primary = this.selectProvider(request, providerName);
@@ -894,7 +927,7 @@ export class LLMRouter {
       if (capabilityType === 'text' && !this._capabilityRouting.assignments.text) {
         primary = this.selectProvider(request);
       } else {
-        const routeResult = this.selectForCapability(capabilityType, request, options?.sessionId);
+        const routeResult = this.selectForCapability(capabilityType, request, sessionId);
         primary = routeResult.provider;
         routedModel = routeResult.model;
       }
@@ -1021,6 +1054,30 @@ export class LLMRouter {
   async chatStream(request: LLMRequest, onEvent: (event: LLMStreamEvent) => void, providerName?: string, signal?: AbortSignal, options?: ChatOptions): Promise<LLMResponse> {
     let primary: string;
     let routedModel: string | undefined;
+    const sessionId = request?.metadata?.sessionId || options?.sessionId;
+
+    // Check per-request modelOverride from metadata (highest priority)
+    if (!providerName && request?.metadata?.providerOverride) {
+      if (this.providers.has(request.metadata.providerOverride)) {
+        providerName = request.metadata.providerOverride;
+      }
+    }
+    if (request?.metadata?.modelOverride) {
+      routedModel = request.metadata.modelOverride;
+    }
+
+    // Check per-session override (lower than per-request, higher than default)
+    if (sessionId) {
+      const sessionOverride = this.sessionOverrides.get(sessionId);
+      if (sessionOverride && !providerName) {
+        if (sessionOverride.provider && this.providers.has(sessionOverride.provider)) {
+          providerName = sessionOverride.provider;
+        }
+        if (sessionOverride.model && !routedModel) {
+          routedModel = sessionOverride.model;
+        }
+      }
+    }
 
     if (providerName) {
       primary = this.selectProvider(request, providerName);
@@ -1029,7 +1086,7 @@ export class LLMRouter {
       if (capabilityType === 'text' && !this._capabilityRouting.assignments.text) {
         primary = this.selectProvider(request);
       } else {
-        const routeResult = this.selectForCapability(capabilityType, request, options?.sessionId);
+        const routeResult = this.selectForCapability(capabilityType, request, sessionId);
         primary = routeResult.provider;
         routedModel = routeResult.model;
       }
@@ -1216,6 +1273,32 @@ export class LLMRouter {
       ...config,
     });
     log.info(`Updated model config for ${providerName}`, config);
+  }
+
+  // ── Session model override API ──────────────────────────────────────
+
+  /** Set a per-session model override. Subsequent requests with this sessionId
+   *  will use the specified provider/model instead of the default routing. */
+  setSessionModel(sessionId: string, override: SessionModelOverride): void {
+    this.sessionOverrides.set(sessionId, {
+      ...override,
+      setAt: new Date().toISOString(),
+    });
+  }
+
+  /** Get the current per-session model override, if any. */
+  getSessionModel(sessionId: string): SessionModelOverride | undefined {
+    return this.sessionOverrides.get(sessionId);
+  }
+
+  /** Clear a per-session model override (revert to default routing). */
+  clearSessionModel(sessionId: string): void {
+    this.sessionOverrides.delete(sessionId);
+  }
+
+  /** Clear ALL session overrides (e.g. system reset / maintenance). */
+  clearAllSessionModels(): void {
+    this.sessionOverrides.clear();
   }
 
   /**

--- a/packages/core/test/llm-router.test.ts
+++ b/packages/core/test/llm-router.test.ts
@@ -912,4 +912,65 @@ describe('LLMRouter session model override', () => {
     // Should not throw - valid ISO string
     expect(() => new Date(result.setAt!).toISOString()).not.toThrow();
   });
+
+  it('duplicate overwrite updates provider, model, and setAt', () => {
+    const router = new LLMRouter('anthropic');
+    router.setSessionModel('sess-1', { provider: 'anthropic', model: 'claude-sonnet-4' });
+    const first = router.getSessionModel('sess-1')!;
+    const firstSetAt = first.setAt!;
+
+    // Small delay so second setAt is strictly later
+    const later = new Date(Date.now() + 100);
+    vi.useFakeTimers();
+    vi.setSystemTime(later);
+    router.setSessionModel('sess-1', { provider: 'openai', model: 'gpt-4o' });
+    vi.useRealTimers();
+
+    const second = router.getSessionModel('sess-1')!;
+    expect(second.provider).toBe('openai');
+    expect(second.model).toBe('gpt-4o');
+    expect(new Date(second.setAt!).getTime()).toBeGreaterThan(new Date(firstSetAt).getTime());
+  });
+
+  it('stores session model for unregistered provider (validation deferred to routing)', () => {
+    const router = new LLMRouter('anthropic');
+    // Provider 'nonexistent' is not registered — setSessionModel still stores it
+    router.setSessionModel('sess-1', { provider: 'nonexistent', model: 'v1' });
+    const stored = router.getSessionModel('sess-1');
+    expect(stored).toBeDefined();
+    expect(stored!.provider).toBe('nonexistent');
+    expect(stored!.model).toBe('v1');
+    // selectForCapability should skip it because isAvailable returns false
+    const result = router.selectForCapability('text', { messages: [] }, 'sess-1');
+    // Should fall through to default routing since 'nonexistent' isn't registered
+    expect(result.provider).toBe('anthropic');
+  });
+
+  it('selectForCapability returns session override when sessionId is provided', () => {
+    const router = new LLMRouter('anthropic');
+    router.registerProvider('anthropic', mockProvider('anthropic', 'claude-sonnet-4-20250514'));
+    router.setSessionModel('sess-1', { provider: 'anthropic', model: 'claude-sonnet-4' });
+
+    // Without sessionId — falls through to default routing
+    const withoutSession = router.selectForCapability('text', { messages: [] });
+    expect(withoutSession.provider).toBe('anthropic');
+
+    // With sessionId — returns session override
+    const withSession = router.selectForCapability('text', { messages: [] }, 'sess-1');
+    expect(withSession.provider).toBe('anthropic');
+    expect(withSession.model).toBe('claude-sonnet-4');
+  });
+
+  it('selectForCapability ignores session override when provider is disabled', () => {
+    const router = new LLMRouter('anthropic');
+    router.registerProvider('anthropic', mockProvider('anthropic', 'claude-sonnet-4-20250514'));
+    router.registerProvider('openai', mockProvider('openai', 'gpt-4o'));
+    router.setSessionModel('sess-1', { provider: 'openai', model: 'gpt-4o' });
+    router.setProviderEnabled('openai', false);
+
+    // Session override points to disabled provider → selectForCapability skips it
+    const result = router.selectForCapability('text', { messages: [] }, 'sess-1');
+    // Falls through to default
+    expect(result.provider).toBe('anthropic');
+  });
 });

--- a/packages/core/test/llm-router.test.ts
+++ b/packages/core/test/llm-router.test.ts
@@ -869,3 +869,47 @@ describe('LLMRouter OAuth integration', () => {
     })).toThrow('OAuth not initialized');
   });
 });
+
+describe('LLMRouter session model override', () => {
+  it('setSessionModel and getSessionModel store/retrieve override', () => {
+    const router = new LLMRouter('anthropic');
+    router.setSessionModel('sess-1', { provider: 'anthropic', model: 'claude-sonnet-4-20250514' });
+    const result = router.getSessionModel('sess-1');
+    expect(result).toBeDefined();
+    expect(result!.provider).toBe('anthropic');
+    expect(result!.model).toBe('claude-sonnet-4-20250514');
+    expect(result!.setAt).toBeDefined();
+  });
+
+  it('getSessionModel returns undefined for unknown session', () => {
+    const router = new LLMRouter('anthropic');
+    expect(router.getSessionModel('nonexistent')).toBeUndefined();
+  });
+
+  it('clearSessionModel removes only the specified override', () => {
+    const router = new LLMRouter('anthropic');
+    router.setSessionModel('sess-1', { provider: 'anthropic', model: 'claude-sonnet-4' });
+    router.setSessionModel('sess-2', { provider: 'openai', model: 'gpt-4' });
+    router.clearSessionModel('sess-1');
+    expect(router.getSessionModel('sess-1')).toBeUndefined();
+    expect(router.getSessionModel('sess-2')).toBeDefined();
+  });
+
+  it('clearAllSessionModels removes all overrides', () => {
+    const router = new LLMRouter('anthropic');
+    router.setSessionModel('sess-1', { provider: 'anthropic' });
+    router.setSessionModel('sess-2', { provider: 'openai' });
+    router.clearAllSessionModels();
+    expect(router.getSessionModel('sess-1')).toBeUndefined();
+    expect(router.getSessionModel('sess-2')).toBeUndefined();
+  });
+
+  it('setAt is set to a valid ISO timestamp', () => {
+    const router = new LLMRouter('anthropic');
+    router.setSessionModel('sess-1', { provider: 'anthropic', model: 'claude-sonnet-4' });
+    const result = router.getSessionModel('sess-1')!;
+    expect(result.setAt).toBeDefined();
+    // Should not throw - valid ISO string
+    expect(() => new Date(result.setAt!).toISOString()).not.toThrow();
+  });
+});

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -2575,6 +2575,16 @@ export class APIServer {
         return;
       }
       const sessionId = path.split('/')[3]!;
+      if (this.storage) {
+        const session = this.storage.chatSessionRepo.getSession(sessionId);
+        if (session && session.userId && session.userId !== authUser.userId) {
+          const isAdminOrOwner = authUser.role === 'owner' || authUser.role === 'admin';
+          if (!isAdminOrOwner) {
+            this.json(res, 403, { error: 'Access denied: this session belongs to another user' });
+            return;
+          }
+        }
+      }
       const override = this.llmRouter.getSessionModel(sessionId);
       this.json(res, 200, {
         provider: override?.provider ?? null,
@@ -2592,6 +2602,16 @@ export class APIServer {
         return;
       }
       const sessionId = path.split('/')[3]!;
+      if (this.storage) {
+        const session = this.storage.chatSessionRepo.getSession(sessionId);
+        if (session && session.userId && session.userId !== authUser.userId) {
+          const isAdminOrOwner = authUser.role === 'owner' || authUser.role === 'admin';
+          if (!isAdminOrOwner) {
+            this.json(res, 403, { error: 'Access denied: this session belongs to another user' });
+            return;
+          }
+        }
+      }
       const body = await this.readBody(req);
       const { provider, model } = body as { provider?: string; model?: string };
       if (!provider || typeof provider !== 'string') {
@@ -2624,10 +2644,20 @@ export class APIServer {
       const authUser = await this.requireAuth(req, res);
       if (!authUser) return;
       if (!this.llmRouter) {
-        this.json(res, 204, {});
+        this.json(res, 503, { error: 'LLM router not available' });
         return;
       }
       const sessionId = path.split('/')[3]!;
+      if (this.storage) {
+        const session = this.storage.chatSessionRepo.getSession(sessionId);
+        if (session && session.userId && session.userId !== authUser.userId) {
+          const isAdminOrOwner = authUser.role === 'owner' || authUser.role === 'admin';
+          if (!isAdminOrOwner) {
+            this.json(res, 403, { error: 'Access denied: this session belongs to another user' });
+            return;
+          }
+        }
+      }
       this.llmRouter.clearSessionModel(sessionId);
       this.auditService?.record({
         orgId: 'system',

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -2566,6 +2566,82 @@ export class APIServer {
       return;
     }
 
+    // ── Session model override ────────────────────────────────────────────
+    if (path.match(/^\/api\/sessions\/[^/]+\/model$/) && req.method === 'GET') {
+      const authUser = await this.requireAuth(req, res);
+      if (!authUser) return;
+      if (!this.llmRouter) {
+        this.json(res, 200, { provider: undefined, model: undefined });
+        return;
+      }
+      const sessionId = path.split('/')[3]!;
+      const override = this.llmRouter.getSessionModel(sessionId);
+      this.json(res, 200, {
+        provider: override?.provider ?? null,
+        model: override?.model ?? null,
+        setAt: override?.setAt ?? null,
+      });
+      return;
+    }
+
+    if (path.match(/^\/api\/sessions\/[^/]+\/model$/) && req.method === 'POST') {
+      const authUser = await this.requireAuth(req, res);
+      if (!authUser) return;
+      if (!this.llmRouter) {
+        this.json(res, 503, { error: 'LLM router not available' });
+        return;
+      }
+      const sessionId = path.split('/')[3]!;
+      const body = await this.readBody(req);
+      const { provider, model } = body as { provider?: string; model?: string };
+      if (!provider || typeof provider !== 'string') {
+        this.json(res, 400, { error: 'provider (string) is required' });
+        return;
+      }
+      if (!model || typeof model !== 'string') {
+        this.json(res, 400, { error: 'model (string) is required' });
+        return;
+      }
+      try {
+        this.llmRouter.setSessionModel(sessionId, { provider, model });
+        this.auditService?.record({
+          orgId: 'system',
+          type: 'settings_changed',
+          action: 'session_model_override',
+          detail: `Session ${sessionId} model → ${provider}/${model}`,
+          userId: authUser.userId,
+          success: true,
+          metadata: { sessionId, provider, model },
+        });
+        this.json(res, 200, { success: true, provider, model });
+      } catch (err) {
+        this.json(res, 400, { error: String(err) });
+      }
+      return;
+    }
+
+    if (path.match(/^\/api\/sessions\/[^/]+\/model$/) && req.method === 'DELETE') {
+      const authUser = await this.requireAuth(req, res);
+      if (!authUser) return;
+      if (!this.llmRouter) {
+        this.json(res, 204, {});
+        return;
+      }
+      const sessionId = path.split('/')[3]!;
+      this.llmRouter.clearSessionModel(sessionId);
+      this.auditService?.record({
+        orgId: 'system',
+        type: 'settings_changed',
+        action: 'session_model_override_clear',
+        detail: `Session ${sessionId} model override cleared`,
+        userId: authUser.userId,
+        success: true,
+        metadata: { sessionId },
+      });
+      this.json(res, 204, {});
+      return;
+    }
+
     // ── Channel messages ───────────────────────────────────────────────────
     if (path.match(/^\/api\/channels\/[^/]+\/messages$/) && req.method === 'GET') {
       const channel = decodeURIComponent(path.split('/')[3]!);

--- a/packages/org-manager/test/api-server.test.ts
+++ b/packages/org-manager/test/api-server.test.ts
@@ -2572,5 +2572,64 @@ describe('APIServer route handlers', () => {
       expect(res.status).toBe(403);
       spy.mockRestore();
     });
+
+    // ── Admin bypass ──────────────────────────────────────────────────────
+
+    it('GET bypasses ownership check when user is admin', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockImplementationOnce((sessionId: string) => ({
+        id: sessionId, userId: 'other-user', title: 'Private',
+      }));
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'admin-user', orgId: 'default', role: 'admin' });
+      const res = await request(ctx.server, 'GET', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(200);
+      spy.mockRestore();
+    });
+
+    it('POST bypasses ownership check when user is owner', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockImplementationOnce((sessionId: string) => ({
+        id: sessionId, userId: 'other-user', title: 'Private',
+      }));
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'owner-user', orgId: 'default', role: 'owner' });
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-1/model', {
+        provider: 'anthropic', model: 'claude-sonnet-4',
+      });
+      expect(res.status).toBe(200);
+      spy.mockRestore();
+    });
+
+    it('DELETE bypasses ownership check when user is admin', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockImplementationOnce((sessionId: string) => ({
+        id: sessionId, userId: 'other-user', title: 'Private',
+      }));
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'admin-user', orgId: 'default', role: 'admin' });
+      const res = await request(ctx.server, 'DELETE', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(204);
+      spy.mockRestore();
+    });
+
+    // ── Session not found edge case ────────────────────────────────────────
+
+    it('GET returns 200 when session does not exist in storage', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockReturnValueOnce(undefined);
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'alice', orgId: 'default', role: 'member' });
+      const res = await request(ctx.server, 'GET', '/api/sessions/sess-nonexist/model');
+      expect(res.status).toBe(200);
+      spy.mockRestore();
+    });
+
+    it('POST returns 200 when session does not exist in storage (treats as own session)', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockReturnValueOnce(undefined);
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'alice', orgId: 'default', role: 'member' });
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-nonexist/model', {
+        provider: 'anthropic', model: 'claude-sonnet-4',
+      });
+      expect(res.status).toBe(200);
+      spy.mockRestore();
+    });
   });
 });

--- a/packages/org-manager/test/api-server.test.ts
+++ b/packages/org-manager/test/api-server.test.ts
@@ -662,6 +662,10 @@ function createTestServer(): TestContext {
     setRoutingDefaultModel: vi.fn(),
     capabilityRouting: { assignments: {} },
     getModelCatalog: vi.fn(() => [{ id: 'gpt-4', provider: 'openai' }]),
+    setSessionModel: vi.fn(),
+    getSessionModel: vi.fn(() => undefined),
+    clearSessionModel: vi.fn(),
+    clearAllSessionModels: vi.fn(),
   } as never);
   server.setModelCatalog({
     getModelsByProvider: vi.fn(() => [{ id: 'gpt-4', name: 'GPT-4' }]),
@@ -2452,6 +2456,121 @@ describe('APIServer route handlers', () => {
     it('GET /api/auth/login with auth enabled still needs POST', async () => {
       const res = await request(ctx.server, 'GET', '/api/auth/login');
       expect(res.status).toBe(405);
+    });
+  });
+
+  // ── Session model override ────────────────────────────────────────────────
+
+  describe('Session model override', () => {
+    it('GET /api/sessions/:id/model returns null when no override set', async () => {
+      const res = await request(ctx.server, 'GET', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(200);
+      expect(res.json).toMatchObject({ provider: null, model: null });
+    });
+
+    it('GET /api/sessions/:id/model returns override when one is set', async () => {
+      vi.mocked(ctx.server['llmRouter']!.getSessionModel).mockReturnValueOnce({
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+        setAt: Date.now(),
+      });
+      const res = await request(ctx.server, 'GET', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(200);
+      expect(res.json).toMatchObject({ provider: 'anthropic', model: 'claude-sonnet-4-20250514' });
+    });
+
+    it('POST /api/sessions/:id/model sets a model override', async () => {
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-1/model', {
+        provider: 'anthropic',
+        model: 'claude-sonnet-4-20250514',
+      });
+      expect(res.status).toBe(200);
+      expect(res.json).toMatchObject({ success: true, provider: 'anthropic', model: 'claude-sonnet-4-20250514' });
+    });
+
+    it('POST /api/sessions/:id/model returns 400 when provider is missing', async () => {
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-1/model', {
+        model: 'gpt-4',
+      });
+      expect(res.status).toBe(400);
+      expect(res.json).toMatchObject({ error: expect.stringContaining('provider') });
+    });
+
+    it('POST /api/sessions/:id/model returns 400 when model is missing', async () => {
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-1/model', {
+        provider: 'openai',
+      });
+      expect(res.status).toBe(400);
+      expect(res.json).toMatchObject({ error: expect.stringContaining('model') });
+    });
+
+    it('DELETE /api/sessions/:id/model clears a model override', async () => {
+      const res = await request(ctx.server, 'DELETE', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(204);
+    });
+
+    it('GET /api/sessions/:id/model returns 200 with empty body when llmRouter is unavailable', async () => {
+      const saved = ctx.server['llmRouter'];
+      ctx.server['llmRouter'] = undefined as never;
+      const res = await request(ctx.server, 'GET', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(200);
+      expect(res.raw).toBe('{}');
+      ctx.server['llmRouter'] = saved;
+    });
+
+    it('POST /api/sessions/:id/model returns 503 when llmRouter is unavailable', async () => {
+      const saved = ctx.server['llmRouter'];
+      ctx.server['llmRouter'] = undefined as never;
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-1/model', {
+        provider: 'anthropic', model: 'claude-sonnet-4',
+      });
+      expect(res.status).toBe(503);
+      expect(res.json).toMatchObject({ error: 'LLM router not available' });
+      ctx.server['llmRouter'] = saved;
+    });
+
+    it('DELETE /api/sessions/:id/model returns 503 when llmRouter is unavailable', async () => {
+      const saved = ctx.server['llmRouter'];
+      ctx.server['llmRouter'] = undefined as never;
+      const res = await request(ctx.server, 'DELETE', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(503);
+      expect(res.json).toMatchObject({ error: 'LLM router not available' });
+      ctx.server['llmRouter'] = saved;
+    });
+
+    it('GET /api/sessions/:id/model returns 403 when session belongs to another user', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockImplementationOnce((sessionId: string) => ({
+        id: sessionId, userId: 'other-user', title: 'Private',
+      }));
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'alice', orgId: 'default', role: 'member' });
+      const res = await request(ctx.server, 'GET', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(403);
+      spy.mockRestore();
+    });
+
+    it('POST /api/sessions/:id/model returns 403 when session belongs to another user', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockImplementationOnce((sessionId: string) => ({
+        id: sessionId, userId: 'other-user', title: 'Private',
+      }));
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'alice', orgId: 'default', role: 'member' });
+      const res = await request(ctx.server, 'POST', '/api/sessions/sess-1/model', {
+        provider: 'anthropic', model: 'claude-sonnet-4',
+      });
+      expect(res.status).toBe(403);
+      spy.mockRestore();
+    });
+
+    it('DELETE /api/sessions/:id/model returns 403 when session belongs to another user', async () => {
+      vi.mocked(ctx.storage.chatSessionRepo.getSession).mockImplementationOnce((sessionId: string) => ({
+        id: sessionId, userId: 'other-user', title: 'Private',
+      }));
+      const spy = vi.spyOn(ctx.server as never as { requireAuth: Function }, 'requireAuth')
+        .mockResolvedValueOnce({ userId: 'alice', orgId: 'default', role: 'member' });
+      const res = await request(ctx.server, 'DELETE', '/api/sessions/sess-1/model');
+      expect(res.status).toBe(403);
+      spy.mockRestore();
     });
   });
 });

--- a/packages/shared/src/types/llm.ts
+++ b/packages/shared/src/types/llm.ts
@@ -103,6 +103,10 @@ export interface LLMRequest {
     taskId?: string;
     sessionId?: string;
     purpose?: string;
+    /** Per-request model override — switch model for this request only */
+    modelOverride?: string;
+    /** Per-request provider override — switch provider for this request only */
+    providerOverride?: string;
   };
   /** Enable Anthropic server-side context compaction (beta) */
   compaction?: boolean;
@@ -110,6 +114,19 @@ export interface LLMRequest {
    *  segment with `cacheBreakpoint: true` hints the provider to insert a
    *  cache checkpoint at the end of that segment (e.g. Anthropic cache_control). */
   systemCacheSegments?: Array<{ content: string; cacheBreakpoint?: boolean }>;
+}
+
+/**
+ * Per-session model override — persists across multiple requests in a session.
+ * Set via API (e.g. POST /api/sessions/:sessionId/model) or via message metadata.
+ */
+export interface SessionModelOverride {
+  /** Provider name to use for this session (e.g. "anthropic", "openai") */
+  provider?: string;
+  /** Model ID to use for this session (e.g. "claude-sonnet-4-20250514") */
+  model?: string;
+  /** ISO timestamp when this override was set */
+  setAt?: string;
 }
 
 export type LLMContentPart =


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Account & Model Management Developer (ID: agt_4e45db7841587e235f8a4794)
- **关联任务**: tsk_7d457f39abffbb7a6a2f5fcd
- **关联需求**: req_6cf0926e12b516bdd6e5cd14 (Wave 1: Markus 竞品短板补齐工程)
- **目标分支**: feature/gap-filling

## 🎯 背景与动机
实现会话级别（session-level）模型即时切换功能。用户可以在聊天过程中动态切换 LLM 提供商/模型，而无需退出会话进行全局配置。对标 Hermes Agent 的 /model 命令。

## 🔧 变更内容
- **packages/shared/src/types/llm.ts**: 新增 SessionModelOverride 接口定义（provider, model, setAt），LLMRequest.metadata 增加 modelOverride/providerOverride 可选字段
- **packages/core/src/llm/router.ts**: 新增 sessionOverrides Map + setSessionModel/getSessionModel/clearSessionModel/clearAllSessionModels 方法 + chat()/chatStream() 优先使用 session override 逻辑 + selectForCapability() 优先使用 session override
- **packages/org-manager/src/api-server.ts**: 新增 GET/POST/DELETE /api/sessions/:sessionId/model 三个端点 + 审计日志记录

## ✅ 验证方式
- [x] pnpm typecheck (backend tsc -b: clean; web-ui: 3 pre-existing type errors unrelated)
- [x] llm-router.test.ts: 68 ✅ passed
- [x] api-server.test.ts: 288 ✅ passed
- [x] api-server-routes / extended: 202 ✅ passed
- [x] api-server-deep / final: 125 ✅ passed
- [x] 总计 683 tests passed

## 👤 评审人
- **Reviewer**: Code Reviewer (ID: agt_42fc22d8cd79900a089eea09)