### PR TITLE
release v0.9.0-rc.1: CI test fixes for agents, preview, models, and browser isolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
       "node-datachannel"
     ]
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -35,5 +35,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -45,5 +45,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.0-rc.0"
+  "version": "0.9.0-rc.1"
 }


### PR DESCRIPTION
Version bump v0.9.0-rc.0 → v0.9.0-rc.1