### PR TITLE
[TASK-tsk_6781b71ba02964dbe9350a24][Account & Model Mgmt Developer] feat: 团队名单按需加载 — 仅注入当前项目相关团队成员

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -196,7 +196,7 @@ export type ApprovalCallback = (request: {
 }) => Promise<{ approved: boolean; comment?: string }>;
 
 export interface TaskProjectContext {
-  project: { id: string; name: string; description: string; status: string };
+  project: { id: string; name: string; description: string; status: string; teamIds?: string[] };
   repositories: Array<{ localPath: string; defaultBranch: string; role: string }>;
 }
 

--- a/packages/core/src/context-engine.ts
+++ b/packages/core/src/context-engine.ts
@@ -139,7 +139,7 @@ export class ContextEngine {
     deliverableContext?: string;
     environment?: EnvironmentProfile;
     projectContext?: {
-      project: { id: string; name: string; description: string; status: string };
+      project: { id: string; name: string; description: string; status: string; teamIds?: string[] };
       repositories?: Array<{ localPath: string; defaultBranch: string; role: string }>;
       governanceRules?: string;
       teamRole?: string;
@@ -387,6 +387,7 @@ export class ContextEngine {
       role: opts.role,
       identity: opts.identity,
       availableSkillCount: opts.availableSkills?.length ?? 0,
+      projectTeamIds: opts.projectContext?.project?.teamIds,
     }));
 
     const orgCtx = this.buildOrgContextSection(opts.orgContext, opts.contextMdPath);
@@ -1236,6 +1237,7 @@ export class ContextEngine {
     role: RoleTemplate;
     identity?: IdentityContext;
     availableSkillCount?: number;
+    projectTeamIds?: string[];
   }): string {
     const lines: string[] = ['\n## Your Identity'];
 
@@ -1290,9 +1292,18 @@ export class ContextEngine {
       }
 
       if (opts.identity.otherTeams && opts.identity.otherTeams.length > 0) {
-        lines.push('\n### Other Teams (for cross-team coordination)');
-        for (const t of opts.identity.otherTeams) {
-          lines.push(`- **${t.name}**: ${t.members.map(m => `${m.name} (${m.role})`).join(', ')}`);
+        // Filter otherTeams when executing within a project: only show teams that
+        // are members of the current project. In non-project contexts (heartbeat,
+        // free chat), retain the full list for cross-team awareness.
+        let relevantTeams = opts.identity.otherTeams;
+        if (opts.projectTeamIds && opts.projectTeamIds.length > 0) {
+          relevantTeams = opts.identity.otherTeams.filter(t => opts.projectTeamIds!.includes(t.id));
+        }
+        if (relevantTeams.length > 0) {
+          lines.push('\n### Other Teams (for cross-team coordination)');
+          for (const t of relevantTeams) {
+            lines.push(`- **${t.name}**: ${t.members.map(m => `${m.name} (${m.role})`).join(', ')}`);
+          }
         }
       }
 

--- a/packages/core/test/context-engine-deep.test.ts
+++ b/packages/core/test/context-engine-deep.test.ts
@@ -116,6 +116,123 @@ describe('ContextEngine identity and trust', () => {
       expect(result.text).toContain(`**${level}**`);
     }
   });
+
+  it('filters otherTeams by project teamIds when projectContext is provided', async () => {
+    const memory = new MemoryStore(tempDir);
+    const engine = makeEngine();
+
+    const result = await engine.buildSystemPrompt({
+      agentId: 'agt_1',
+      agentName: 'Agent',
+      role: MOCK_ROLE,
+      memory,
+      identity: {
+        self: { name: 'Agent', agentRole: 'worker', skills: [] },
+        organization: { id: 'org_1', name: 'Acme Inc' },
+        team: { id: 'team_a', name: 'Team Alpha' },
+        colleagues: [
+          { id: 'agt_a1', name: 'Alpha One', role: 'worker', status: 'idle' },
+        ],
+        humans: [],
+        otherTeams: [
+          {
+            id: 'team_b', name: 'Beta Team',
+            members: [{ id: 'agt_b1', name: 'Beta One', role: 'worker' }],
+          },
+          {
+            id: 'team_c', name: 'Gamma Team',
+            members: [{ id: 'agt_c1', name: 'Gamma One', role: 'worker' }],
+          },
+        ],
+      },
+      projectContext: {
+        project: {
+          id: 'proj_1', name: 'Project X', description: 'Test project',
+          status: 'active', teamIds: ['team_a', 'team_b'],
+        },
+      },
+    });
+
+    // Team Beta is in project's teamIds → should appear
+    expect(result.text).toContain('Beta Team');
+    expect(result.text).toContain('Beta One');
+    // Team Gamma is NOT in project's teamIds → should NOT appear
+    expect(result.text).not.toContain('Gamma Team');
+  });
+
+  it('shows all otherTeams when projectContext has no teamIds', async () => {
+    const memory = new MemoryStore(tempDir);
+    const engine = makeEngine();
+
+    const result = await engine.buildSystemPrompt({
+      agentId: 'agt_1',
+      agentName: 'Agent',
+      role: MOCK_ROLE,
+      memory,
+      identity: {
+        self: { name: 'Agent', agentRole: 'worker', skills: [] },
+        organization: { id: 'org_1', name: 'Acme Inc' },
+        team: { id: 'team_a', name: 'Team Alpha' },
+        colleagues: [],
+        humans: [],
+        otherTeams: [
+          {
+            id: 'team_b', name: 'Beta Team',
+            members: [{ id: 'agt_b1', name: 'Beta One', role: 'worker' }],
+          },
+          {
+            id: 'team_c', name: 'Gamma Team',
+            members: [{ id: 'agt_c1', name: 'Gamma One', role: 'worker' }],
+          },
+        ],
+      },
+      projectContext: {
+        project: {
+          id: 'proj_1', name: 'Project X', description: 'Test project',
+          status: 'active',
+          // No teamIds — should show all teams
+        },
+      },
+    });
+
+    // Both teams should appear since no teamIds filter
+    expect(result.text).toContain('Beta Team');
+    expect(result.text).toContain('Gamma Team');
+  });
+
+  it('shows all otherTeams when no projectContext', async () => {
+    const memory = new MemoryStore(tempDir);
+    const engine = makeEngine();
+
+    const result = await engine.buildSystemPrompt({
+      agentId: 'agt_1',
+      agentName: 'Agent',
+      role: MOCK_ROLE,
+      memory,
+      identity: {
+        self: { name: 'Agent', agentRole: 'worker', skills: [] },
+        organization: { id: 'org_1', name: 'Acme Inc' },
+        team: { id: 'team_a', name: 'Team Alpha' },
+        colleagues: [],
+        humans: [],
+        otherTeams: [
+          {
+            id: 'team_b', name: 'Beta Team',
+            members: [{ id: 'agt_b1', name: 'Beta One', role: 'worker' }],
+          },
+          {
+            id: 'team_c', name: 'Gamma Team',
+            members: [{ id: 'agt_c1', name: 'Gamma One', role: 'worker' }],
+          },
+        ],
+      },
+      // No projectContext at all — should show all teams
+    });
+
+    // Both teams should appear since no project context
+    expect(result.text).toContain('Beta Team');
+    expect(result.text).toContain('Gamma Team');
+  });
 });
 
 describe('ContextEngine task board and mailbox', () => {

--- a/packages/org-manager/src/task-service.ts
+++ b/packages/org-manager/src/task-service.ts
@@ -1252,6 +1252,7 @@ export class TaskService {
             name: project.name,
             description: project.description,
             status: project.status,
+            teamIds: project.teamIds,
           },
           repositories: repos.map(r => ({
             localPath: r.localPath,


### PR DESCRIPTION
## 📋 基本信息
- **提交者**: Account & Model Management Developer (ID: agt_4e45db7841587e235f8a4794)
- **关联任务**: tsk_6781b71ba02964dbe9350a24
- **关联需求**: req_c1419b7c3f507e993973dfc0
- **目标分支**: main

## 🎯 背景与动机 (Why)
当前 system prompt 的 `## Other Teams` 段注入全组织所有团队名单，包含大量与当前项目无关的成员信息。这严重浪费 context window tokens（预估 ~2,500 tokens/次）。本 PR 改为按当前项目过滤：仅注入项目 `teamIds` 关联的团队成员。

## 🔧 变更内容 (What)
- `packages/core/src/agent.ts`: TaskProjectContext.project 新增 `teamIds?: string[]` 字段
- `packages/org-manager/src/task-service.ts`: 构建 TaskProjectContext 时从 project 传递 teamIds
- `packages/core/src/context-engine.ts`:
  - projectContext.project 类型新增 teamIds
  - buildIdentitySection 新增 projectTeamIds 参数
  - 渲染 otherTeams 时按 projectTeamIds 过滤（仅在项目上下文中生效）
- `packages/core/test/context-engine-deep.test.ts`: 新增 3 个测试用例覆盖过滤逻辑

## ✅ 验证方式 (How to Verify)
- [x] pnpm lint 通过（0 errors, 663 warnings 均为预存）
- [x] tsc -b 通过（web-ui 的 rehype-highlight/mermaid 类型错误为预存）
- [x] pnpm vitest run packages/core/test/context-engine-deep.test.ts — 22 tests passed
- [x] pnpm vitest run packages/core/test/ packages/org-manager/test/ — 2812 passed, 2 failed (预存: multimodal-providers API key), 9 skipped

## ✅ 质量自检清单

### Spec / 设计文档
- [x] 设计思路: 复用 TaskProjectContext 的 project.teamIds → ContextEngine 在 buildIdentitySection 中按需过滤
- [x] 代码实现与设计文档逐条匹配

### 测试覆盖
- [x] 新增单元测试: context-engine-deep.test.ts 3 个用例
- [x] 测试覆盖: 有 projectTeamIds ✅ 无 projectTeamIds ✅ 无 projectContext ✅

### 编译验证
- [x] tsc -b 通过
- [x] pnpm test 全部通过（无新增失败）

## 👤 评审人
- **Reviewer**: Code Reviewer (Code Reviewer) — 请按规范检查 Spec/测试/文档/编译