### PR TITLE
release v0.9.2: fix CN model default heal and Hub credits progress bar

### DIFF
--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,12 @@
 # Release Log
 
+## v0.9.2
+
+### Bug Fixes
+
+- **CN 模型默认 heal** — 地理过滤后粘性 `routingDefaultModel`（如 Claude Opus）不再留在聊天 chip；自动回落到 Hub 目录内可用模型并写回配置
+- **Hub 额度进度条** — Overview / Settings 使用 `creditsBudgetCu`（已用 + 剩余），烧过后的 M+B+P 面额不再把总额错显示成缩水值
+
 ## v0.9.0
 
 Markus Cloud / Hub 额度与计费体验落地；认知增强与统一 A2A 消息；聊天会话 buffer 状态机重构；飞书主会话同步与 Agent DM 确认死循环防护；搜索优先级与 Team Chat 菜单体验优化。

--- a/package.json
+++ b/package.json
@@ -52,5 +52,5 @@
       "node-datachannel"
     ]
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -147,6 +147,8 @@ export class LLMRouter {
     assignments: {},
   };
   private _routingDefaultModel?: { provider: string; model: string };
+  /** Hub is_default (or first catalog id) from the last Markus catalog refresh. */
+  private _markusCatalogPreferredId?: string;
 
   private readonly CIRCUIT_OPEN_AFTER = 2;
   private readonly CIRCUIT_RESET_MS = 5 * 60 * 1000;
@@ -536,16 +538,55 @@ export class LLMRouter {
 
     const ids = new Set(defs.map(d => d.id));
     const preferred = models.find(m => m.is_default)?.id ?? defs[0]!.id;
-    // Re-point only when the active model is a legacy bare markus-* alias or
-    // no longer in the catalog. `isObsoleteMarkusModel` is the source of truth.
-    const obsolete = isObsoleteMarkusModel(provider.model) || !ids.has(provider.model);
-    if (obsolete) {
-      provider.configure({ provider: 'markus', model: preferred });
-      log.info('Markus active model set from Hub catalog', { model: preferred, count: defs.length });
+    this._markusCatalogPreferredId = preferred;
+    const healed = this.healMarkusRoutingAgainstCatalog(ids, preferred);
+    if (healed) {
+      log.info('Markus routing healed from Hub catalog', {
+        activeModel: provider.model,
+        routingDefaultModel: this._routingDefaultModel,
+        count: defs.length,
+      });
     } else {
       log.info('Markus Hub catalog refreshed', { model: provider.model, count: defs.length });
     }
     return defs.length;
+  }
+
+  /**
+   * Drop sticky Markus defaults that are no longer in the Hub catalog
+   * (e.g. CN geo-filter removes anthropic/claude-opus-5 while chip still shows it).
+   * Returns true when active model and/or routingDefaultModel were rewritten.
+   */
+  healMarkusRoutingAgainstCatalog(ids?: Set<string>, preferred?: string): boolean {
+    const provider = this.providers.get('markus');
+    if (!provider) return false;
+
+    const catalogIds = ids ?? new Set((this.customModelCatalog.get('markus') ?? []).map(d => d.id));
+    if (catalogIds.size === 0) return false;
+
+    const fallback = preferred
+      ?? this._markusCatalogPreferredId
+      ?? (this.customModelCatalog.get('markus') ?? [])[0]?.id;
+    if (!fallback) return false;
+
+    let healed = false;
+    const activeObsolete = isObsoleteMarkusModel(provider.model) || !catalogIds.has(provider.model);
+    if (activeObsolete) {
+      provider.configure({ provider: 'markus', model: fallback });
+      healed = true;
+    }
+
+    const rdm = this._routingDefaultModel;
+    if (
+      rdm
+      && rdm.provider === 'markus'
+      && (isObsoleteMarkusModel(rdm.model) || !catalogIds.has(rdm.model))
+    ) {
+      this._routingDefaultModel = { provider: 'markus', model: fallback };
+      healed = true;
+    }
+
+    return healed;
   }
 
   /**

--- a/packages/core/test/hub-billing-contract.test.ts
+++ b/packages/core/test/hub-billing-contract.test.ts
@@ -14,6 +14,7 @@ const HUB_PLAN_REQUIRED = [
   'bonusCu',
   'purchasedCu',
   'totalConsumedThisPeriod',
+  'creditsBudgetCu',
   'memberCuLimit',
   'memberCuUsed',
   'subscriptionStatus',
@@ -22,6 +23,7 @@ const HUB_PLAN_REQUIRED = [
 const HUB_CU_SYNC_REQUIRED = [
   'ok',
   'entitlementCu',
+  'creditsBudgetCu',
   'usedCu',
   'remainingCu',
   'memberUsedCu',
@@ -33,7 +35,8 @@ describe('Hub billing API contract (Desktop)', () => {
   it('parses /api/user/cu/sync the way MarkusProvider does', () => {
     const data = {
       ok: true,
-      entitlementCu: 10_000,
+      entitlementCu: 8_800,
+      creditsBudgetCu: 10_000,
       usedCu: 1_200,
       remainingCu: 8_800,
       memberUsedCu: 400,
@@ -48,6 +51,24 @@ describe('Hub billing API contract (Desktop)', () => {
     expect(remainingUsd).toBe(18.5);
   });
 
+  it('cu/status progress uses creditsBudgetCu not wallet entitlementCu', () => {
+    // After burns: E=8977, S=10023 → bar must be 10023/19000 not 0/8977.
+    const sync = {
+      entitlementCu: 8_977,
+      creditsBudgetCu: 19_000,
+      usedCu: 10_023,
+      remainingCu: 8_977,
+    };
+    const budget = Number(sync.creditsBudgetCu ?? 0) > 0
+      ? Number(sync.creditsBudgetCu)
+      : sync.usedCu + sync.remainingCu;
+    const used = sync.usedCu;
+    const pct = Math.round((used / budget) * 100);
+    expect(budget).toBe(19_000);
+    expect(pct).toBe(53);
+    expect(budget).not.toBe(sync.entitlementCu);
+  });
+
   it('exposes /api/user/plan fields OverviewUsage reads', () => {
     const hubPlan = {
       orgId: 'org_x',
@@ -57,6 +78,7 @@ describe('Hub billing API contract (Desktop)', () => {
       bonusCu: 100,
       purchasedCu: 200,
       totalConsumedThisPeriod: 50,
+      creditsBudgetCu: 10_300,
       memberCuLimit: 10_300,
       memberCuUsed: 50,
       subscriptionStatus: 'active',
@@ -64,10 +86,29 @@ describe('Hub billing API contract (Desktop)', () => {
     };
     for (const k of HUB_PLAN_REQUIRED) expect(hubPlan).toHaveProperty(k);
 
-    const entitlement =
+    const face =
       (hubPlan.monthlyQuotaCu ?? 0) + (hubPlan.bonusCu ?? 0) + (hubPlan.purchasedCu ?? 0);
+    const entitlement = hubPlan.creditsBudgetCu ?? face;
     expect(entitlement).toBe(10_300);
     expect(hubPlan.memberCuUsed ?? 0).toBeLessThanOrEqual(entitlement);
+  });
+
+  it('progress denominator prefers creditsBudgetCu over shrunk face after burns', () => {
+    // Screenshot bug: face M+B+P=11000 while period budget stays 19000.
+    const hubPlan = {
+      monthlyQuotaCu: 10_000,
+      bonusCu: 0,
+      purchasedCu: 1_000,
+      totalConsumedThisPeriod: 10_023,
+      creditsBudgetCu: 19_000,
+      memberCuLimit: 19_000,
+      memberCuUsed: 10_023,
+    };
+    const face = hubPlan.monthlyQuotaCu + hubPlan.bonusCu + hubPlan.purchasedCu;
+    const totalQuota = hubPlan.creditsBudgetCu ?? face;
+    expect(face).toBe(11_000);
+    expect(totalQuota).toBe(19_000);
+    expect(Math.round((hubPlan.totalConsumedThisPeriod / totalQuota) * 100)).toBe(53);
   });
 
   it('golden soft-stop vector: A=19000 S=10023 ⇒ R=8977 (ledger must not gate)', () => {

--- a/packages/core/test/hub-billing-contract.test.ts
+++ b/packages/core/test/hub-billing-contract.test.ts
@@ -69,4 +69,15 @@ describe('Hub billing API contract (Desktop)', () => {
     expect(entitlement).toBe(10_300);
     expect(hubPlan.memberCuUsed ?? 0).toBeLessThanOrEqual(entitlement);
   });
+
+  it('golden soft-stop vector: A=19000 S=10023 ⇒ R=8977 (ledger must not gate)', () => {
+    const allocationCu = 19_000;
+    const orUsedCu = 10_023;
+    const auditLedgerCu = 19_031; // historical double-count noise
+    const remainingCu = Math.max(0, allocationCu - orUsedCu);
+    expect(remainingCu).toBe(8_977);
+    // Desktop soft-stop uses Hub sync remainingCu (= R), never A − ledger.
+    expect(remainingCu).not.toBe(Math.max(0, allocationCu - auditLedgerCu));
+    expect(remainingCu > 0).toBe(true);
+  });
 });

--- a/packages/core/test/llm-router.test.ts
+++ b/packages/core/test/llm-router.test.ts
@@ -764,6 +764,45 @@ describe('LLMRouter text chat honors routingDefaultModel', () => {
   });
 });
 
+describe('LLMRouter.healMarkusRoutingAgainstCatalog', () => {
+  it('rewrites sticky RDM when CN catalog drops Claude Opus', () => {
+    const markus = mockProvider('markus', 'anthropic/claude-opus-5');
+    const router = new LLMRouter('markus');
+    router.registerProvider('markus', markus);
+    router.setRoutingDefaultModel({ provider: 'markus', model: 'anthropic/claude-opus-5' });
+
+    const cnIds = new Set([
+      'qwen/qwen3.7-flash',
+      'moonshotai/kimi-k3',
+      'z-ai/glm-5.2',
+    ]);
+    const healed = router.healMarkusRoutingAgainstCatalog(cnIds, 'qwen/qwen3.7-flash');
+    expect(healed).toBe(true);
+    expect(router.routingDefaultModel).toEqual({
+      provider: 'markus',
+      model: 'qwen/qwen3.7-flash',
+    });
+    expect(markus.configure).toHaveBeenCalledWith({
+      provider: 'markus',
+      model: 'qwen/qwen3.7-flash',
+    });
+  });
+
+  it('leaves RDM alone when still in catalog', () => {
+    const markus = mockProvider('markus', 'qwen/qwen3.7-flash');
+    const router = new LLMRouter('markus');
+    router.registerProvider('markus', markus);
+    router.setRoutingDefaultModel({ provider: 'markus', model: 'qwen/qwen3.7-flash' });
+
+    const healed = router.healMarkusRoutingAgainstCatalog(
+      new Set(['qwen/qwen3.7-flash', 'z-ai/glm-5.2']),
+      'z-ai/glm-5.2',
+    );
+    expect(healed).toBe(false);
+    expect(router.routingDefaultModel?.model).toBe('qwen/qwen3.7-flash');
+  });
+});
+
 describe('LLMRouter resolveMaxTokens', () => {
   it('does not inject catalog max_output onto the wire (OpenRouter reserves against max_tokens)', async () => {
     const markus = mockProvider('markus', 'deepseek/deepseek-v4-flash');

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -35,5 +35,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -227,6 +227,36 @@ export class APIServer {
     }
   }
 
+  /**
+   * Persist healed Markus active model + routingDefaultModel after catalog geo-filter.
+   * No-op when router state already matches disk.
+   */
+  private persistHealedMarkusRouting(): void {
+    if (!this.llmRouter) return;
+    try {
+      const cfg = loadConfig();
+      const diskMarkus = (cfg.llm.providers?.['markus'] ?? {}) as { model?: string };
+      const active = this.llmRouter.getProvider('markus')?.model;
+      const rdm = this.llmRouter.routingDefaultModel;
+      const diskRdm = cfg.llm.routingDefaultModel;
+      const modelChanged = !!active && active !== diskMarkus.model;
+      const rdmChanged = JSON.stringify(rdm ?? null) !== JSON.stringify(diskRdm ?? null);
+      if (!modelChanged && !rdmChanged) return;
+      const updates: Record<string, unknown> = {};
+      if (rdmChanged) updates.routingDefaultModel = rdm ?? null;
+      if (modelChanged) {
+        updates.providers = { markus: { ...diskMarkus, model: active } };
+      }
+      saveConfig({ llm: updates } as any, this.markusConfigPath);
+      log.info('Persisted healed Markus routing after catalog filter', {
+        model: active,
+        routingDefaultModel: rdm,
+      });
+    } catch (err) {
+      log.warn('Failed to persist healed Markus routing', { error: String(err) });
+    }
+  }
+
   /** Legacy Worker-era keys look like `markus_<hex>`; OpenRouter keys start with `sk-or-`. */
   private isLegacyMarkusSubscriptionKey(apiKey: string | undefined): boolean {
     if (!apiKey) return true;
@@ -6902,10 +6932,20 @@ EXPLANATION_END`;
                 remainingCu?: number;
                 entitlementCu?: number;
                 usedCu?: number;
+                creditsBudgetCu?: number;
               };
-              hubLimit = Number(sync.entitlementCu ?? 0);
-              hubRemaining = Math.max(0, Number(sync.remainingCu ?? 0));
-              totalCuUsed = Number(sync.usedCu ?? totalCuUsed ?? 0);
+              const remaining = Math.max(0, Number(sync.remainingCu ?? 0));
+              const used = Math.max(0, Number(sync.usedCu ?? 0));
+              // Progress total = period budget (used+remaining), not wallet E alone.
+              // entitlementCu is soft-stop remaining; using it as cuLimit showed 0/8977.
+              const budget = Number(sync.creditsBudgetCu ?? 0) > 0
+                ? Number(sync.creditsBudgetCu)
+                : (used + remaining) > 0
+                  ? used + remaining
+                  : Number(sync.entitlementCu ?? 0);
+              hubLimit = budget;
+              hubRemaining = remaining;
+              totalCuUsed = used || totalCuUsed || 0;
               this.llmRouter?.setMarkusHubRemainingHint(hubRemaining);
             }
           }
@@ -6919,10 +6959,15 @@ EXPLANATION_END`;
                 bonusCu?: number;
                 purchasedCu?: number;
                 totalConsumedThisPeriod?: number;
+                creditsBudgetCu?: number;
               };
-              const entitlement =
+              const face =
                 Number(plan.monthlyQuotaCu ?? 0) + Number(plan.bonusCu ?? 0) + Number(plan.purchasedCu ?? 0);
               const consumed = Number(plan.totalConsumedThisPeriod ?? 0);
+              // Prefer period budget (used+remaining); face shrinks after B/P burns.
+              const entitlement = Number(plan.creditsBudgetCu ?? 0) > 0
+                ? Number(plan.creditsBudgetCu)
+                : face;
               hubLimit = entitlement;
               hubRemaining = Math.max(0, entitlement - consumed);
               totalCuUsed = consumed;
@@ -7237,6 +7282,7 @@ EXPLANATION_END`;
         try {
           this.ensureMarkusDirectConfig();
           const count = await this.llmRouter?.refreshMarkusCatalog() ?? 0;
+          this.persistHealedMarkusRouting();
           const settings = this.llmRouter?.getEnhancedSettings();
           const models = settings?.providers?.['markus']?.models ?? [];
           this.json(res, 200, {
@@ -7300,8 +7346,18 @@ EXPLANATION_END`;
         }
         const preview = this.llmRouter.getEnhancedSettings();
         const markus = preview.providers?.['markus'];
-        if (markus?.configured && (!markus.models || markus.models.length === 0)) {
-          await this.llmRouter.refreshMarkusCatalog();
+        if (markus?.configured) {
+          const ids = new Set((markus.models ?? []).map(m => m.id));
+          if (ids.size === 0) {
+            await this.llmRouter.refreshMarkusCatalog();
+          } else {
+            // CN geo (etc.) can drop sticky RDM from the list while chip still shows it.
+            const preferred = (markus.model && ids.has(markus.model))
+              ? markus.model
+              : [...ids][0]!;
+            this.llmRouter.healMarkusRoutingAgainstCatalog(ids, preferred);
+          }
+          this.persistHealedMarkusRouting();
         }
       } catch { /* non-fatal */ }
       this.json(res, 200, this.llmRouter.getEnhancedSettings());

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -45,5 +45,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.1"
+  "version": "0.9.2"
 }

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -3021,6 +3021,8 @@ export const hubApi = {
       bonusCu: number; purchasedCu: number; windowQuotaCu: number;
       windowCuUsed?: number;
       totalConsumedThisPeriod?: number;
+      /** Progress total = used + wallet remaining (survives B/P burns). */
+      creditsBudgetCu?: number;
       memberCuLimit?: number | null;
       memberCuUsed?: number;
     }>('/user/plan'),

--- a/packages/web-ui/src/components/ChatModelMenu.tsx
+++ b/packages/web-ui/src/components/ChatModelMenu.tsx
@@ -83,6 +83,12 @@ export function ChatModelMenu({ value, onSelect, disabled }: ChatModelMenuProps)
       list.sort((a, b) => a.displayName.localeCompare(b.displayName));
       setProviders(list);
 
+      const inCatalog = (sel: ChatModelSelection | null | undefined): boolean => {
+        if (!sel?.provider || !sel.model) return false;
+        const p = list.find(x => x.provider === sel.provider);
+        return !!p?.models.some(m => m.id === sel.model);
+      };
+
       // Prefer explicit routing default; else default provider's active model.
       let nextGlobal: ChatModelSelection | null = null;
       if (data.routingDefaultModel?.provider && data.routingDefaultModel?.model) {
@@ -94,6 +100,26 @@ export function ChatModelMenu({ value, onSelect, disabled }: ChatModelMenuProps)
         const p = data.providers?.[data.defaultProvider];
         if (p?.model) {
           nextGlobal = { provider: data.defaultProvider, model: p.model };
+        }
+      }
+
+      // Sticky RDM can outlive geo-filtered catalogs (e.g. CN drops Claude).
+      // Fall back to first Markus / first available model and persist globally.
+      if (nextGlobal && !inCatalog(nextGlobal)) {
+        const markus = list.find(p => p.provider === 'markus');
+        const fallback = markus?.models[0]
+          ? { provider: 'markus', model: markus.models[0].id }
+          : list[0]?.models[0]
+            ? { provider: list[0].provider, model: list[0].models[0]!.id }
+            : null;
+        if (fallback) {
+          nextGlobal = fallback;
+          void api.settings.updateRouting({
+            defaultProvider: fallback.provider,
+            routingDefaultModel: fallback,
+          }).catch(() => { /* non-fatal */ });
+        } else {
+          nextGlobal = null;
         }
       }
       setGlobalDefault(nextGlobal);
@@ -141,7 +167,32 @@ export function ChatModelMenu({ value, onSelect, disabled }: ChatModelMenuProps)
       .filter(p => p.models.length > 0);
   }, [providers, query]);
 
-  const effective = value ?? globalDefault;
+  const selectionInCatalog = useCallback((sel: ChatModelSelection | null | undefined) => {
+    if (!sel?.provider || !sel.model) return false;
+    // While catalog is loading, don't treat selection as missing.
+    if (providers.length === 0) return true;
+    const p = providers.find(x => x.provider === sel.provider);
+    return !!p?.models.some(m => m.id === sel.model);
+  }, [providers]);
+
+  // Session override can also be sticky-stale after CN catalog filter.
+  useEffect(() => {
+    if (!value || providers.length === 0) return;
+    if (selectionInCatalog(value)) return;
+    const fallback = (globalDefault && selectionInCatalog(globalDefault))
+      ? globalDefault
+      : (() => {
+          const markus = providers.find(p => p.provider === 'markus');
+          if (markus?.models[0]) return { provider: 'markus', model: markus.models[0].id };
+          if (providers[0]?.models[0]) {
+            return { provider: providers[0].provider, model: providers[0].models[0]!.id };
+          }
+          return null;
+        })();
+    if (fallback) onSelect(fallback, false);
+  }, [value, providers, globalDefault, selectionInCatalog, onSelect]);
+
+  const effective = (value && selectionInCatalog(value)) ? value : globalDefault;
   // Trigger shows a short model id (session override or global default).
   const shortModel = effective?.model
     ? (effective.model.includes('/') ? effective.model.split('/').pop()! : effective.model)

--- a/packages/web-ui/src/components/ModelRoutingSection.tsx
+++ b/packages/web-ui/src/components/ModelRoutingSection.tsx
@@ -166,6 +166,21 @@ export function ModelRoutingSection({ onSave, configuredProviders }: Props) {
       debouncedSave(next);
       return next;
     });
+
+    // Same heal for sticky text default (chip / routingDefaultModel).
+    setDefaultModel(prev => {
+      if (!prev?.model) return prev;
+      const ok = fullModelList.some(m => m.provider === prev.provider && m.modelId === prev.model);
+      if (ok) return prev;
+      const markusFirst = fullModelList.find(m => m.provider === 'markus');
+      const fallback = markusFirst
+        ? { provider: markusFirst.provider, model: markusFirst.modelId }
+        : { provider: fullModelList[0]!.provider, model: fullModelList[0]!.modelId };
+      void onSave({ routingDefaultModel: fallback });
+      return fallback;
+    });
+    // onSave is stable enough from parent; omit from deps to avoid re-heal loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded, fullModelList, providerKey, debouncedSave, assignmentKey]);
 
   const reloadRouting = useCallback(() => {

--- a/packages/web-ui/src/components/OverviewUsage.tsx
+++ b/packages/web-ui/src/components/OverviewUsage.tsx
@@ -12,6 +12,7 @@ interface HubPlanInfo {
   bonusCu: number; purchasedCu: number; windowQuotaCu: number;
   windowCuUsed?: number;
   totalConsumedThisPeriod?: number;
+  creditsBudgetCu?: number;
   memberCuLimit?: number | null;
   memberCuUsed?: number;
 }
@@ -221,12 +222,15 @@ export function CloudQuotaBar({ hubConnected, hubPlan, hubOrgMeta }: {
     || hubOrgMeta.role === 'admin'
     || hubOrgMeta.memberCount <= 1;
   const showAdminLimitBanner = hasMemberLimit && !isSelfManagedOrg;
-  const totalQuota = hasMemberLimit
+  const columnQuota = (hubPlan.monthlyQuotaCu ?? 0) + (hubPlan.bonusCu ?? 0) + (hubPlan.purchasedCu ?? 0);
+  // Self-managed: period budget (used+remaining). Personal A only for admin-capped members.
+  // Never use shrunk M+B+P face after B→M→P burns (that showed 11k instead of 19k).
+  const totalQuota = showAdminLimitBanner
     ? hubPlan.memberCuLimit!
-    : (hubPlan.monthlyQuotaCu ?? 0) + (hubPlan.bonusCu ?? 0) + (hubPlan.purchasedCu ?? 0);
-  const cuUsed = hasMemberLimit
+    : (hubPlan.creditsBudgetCu ?? (hasMemberLimit ? hubPlan.memberCuLimit! : columnQuota));
+  const cuUsed = showAdminLimitBanner
     ? (hubPlan.memberCuUsed ?? 0)
-    : hubPlan.totalConsumedThisPeriod ?? ((hubPlan.monthlyQuotaCu ?? 0) + (hubPlan.bonusCu ?? 0) + (hubPlan.purchasedCu ?? 0) - Math.max(0, (hubPlan.monthlyQuotaCu ?? 0) - (hubPlan.cuUsed ?? 0)) - (hubPlan.bonusCu ?? 0) - (hubPlan.purchasedCu ?? 0));
+    : (hubPlan.totalConsumedThisPeriod ?? hubPlan.memberCuUsed ?? 0);
   const pct = totalQuota > 0 ? Math.min(100, Math.round((cuUsed / totalQuota) * 100)) : 0;
   const barColor = pct > 90 ? 'bg-red-500' : pct > 70 ? 'bg-amber-500' : 'bg-brand-500';
 

--- a/packages/web-ui/src/pages/Settings.tsx
+++ b/packages/web-ui/src/pages/Settings.tsx
@@ -3613,7 +3613,7 @@ function AccountOverviewSection() {
   const { t } = useTranslation(['settings', 'common']);
 
   // ── Cloud AI plan state ──
-  const [planInfo, setPlanInfo] = useState<{ orgId?: string | null; planType: string; planStatus: string; monthlyQuotaCu: number; cuUsed: number; cuResetAt: string | null; bonusCu: number; purchasedCu?: number; windowQuotaCu: number; memberCuLimit?: number | null; memberCuUsed?: number } | null>(null);
+  const [planInfo, setPlanInfo] = useState<{ orgId?: string | null; planType: string; planStatus: string; monthlyQuotaCu: number; cuUsed: number; cuResetAt: string | null; bonusCu: number; purchasedCu?: number; windowQuotaCu: number; totalConsumedThisPeriod?: number; creditsBudgetCu?: number; memberCuLimit?: number | null; memberCuUsed?: number } | null>(null);
   const [planLoading, setPlanLoading] = useState(true);
 
   // ── Org state (read-only) ──
@@ -3676,8 +3676,25 @@ function AccountOverviewSection() {
 
   const primaryOrg = orgs.find(o => o.id === planInfo?.orgId) ?? orgs[0];
   const totalCredits = planInfo
-    ? (planInfo.monthlyQuotaCu ?? 0) + (planInfo.bonusCu ?? 0) + (planInfo.purchasedCu ?? 0)
+    ? (planInfo.creditsBudgetCu
+      ?? (planInfo.monthlyQuotaCu ?? 0) + (planInfo.bonusCu ?? 0) + (planInfo.purchasedCu ?? 0))
     : 0;
+  // Personal A only for admin-capped non-owner members. Owners/solo use period budget
+  // (creditsBudgetCu) — memberCuLimit may still be the old face-collapsed A.
+  const showPersonalLimit = !!(
+    planInfo?.memberCuLimit != null
+    && planInfo.memberCuLimit > 0
+    && primaryOrg
+    && primaryOrg.role !== 'owner'
+    && primaryOrg.role !== 'admin'
+    && primaryOrg.memberCount > 1
+  );
+  const creditsUsed = showPersonalLimit
+    ? Math.round(planInfo?.memberCuUsed ?? 0)
+    : Math.round(planInfo?.totalConsumedThisPeriod ?? planInfo?.cuUsed ?? 0);
+  const creditsTotal = showPersonalLimit
+    ? (planInfo?.memberCuLimit ?? 0)
+    : totalCredits;
 
   if (orgLoading || planLoading) return <div className="text-center py-8 text-fg-tertiary text-sm">{t('common:loading')}</div>;
 
@@ -3701,13 +3718,11 @@ function AccountOverviewSection() {
                 <span className="text-xs text-fg-tertiary">{t('account.currentPlan')}</span>
                 <span className="px-2 py-0.5 rounded text-xs font-semibold capitalize bg-brand-600/10 text-brand-500 border border-brand-500/15">{planInfo.planType}</span>
               </div>
-              {(totalCredits > 0 || (planInfo.memberCuLimit != null && planInfo.memberCuLimit > 0)) && (
+              {creditsTotal > 0 && (
                 <div className="flex items-center gap-2 text-xs">
-                  <span className="text-fg-tertiary">{planInfo.memberCuLimit != null && planInfo.memberCuLimit > 0 ? t('account.personalLimit') : t('account.credits')}</span>
+                  <span className="text-fg-tertiary">{showPersonalLimit ? t('account.personalLimit') : t('account.credits')}</span>
                   <span className="font-medium text-fg-primary tabular-nums">
-                    {planInfo.memberCuLimit != null && planInfo.memberCuLimit > 0
-                      ? `${Math.round(planInfo.memberCuUsed ?? 0).toLocaleString()} / ${planInfo.memberCuLimit.toLocaleString()}`
-                      : `${Math.round(planInfo.cuUsed).toLocaleString()} / ${totalCredits.toLocaleString()}`}
+                    {creditsUsed.toLocaleString()} / {creditsTotal.toLocaleString()}
                   </span>
                 </div>
               )}


### PR DESCRIPTION
## Summary
- Heal sticky Markus `routingDefaultModel` when geo-filtered Hub catalog drops it (e.g. Claude Opus for CN), so chat chip / routing match the available list
- Prefer Hub `creditsBudgetCu` for Overview / Settings usage bars so burned bonus/purchased no longer shrinks the denominator
- Version bump **0.9.1 → 0.9.2** (tag `v0.9.2` already pushed to trigger CI publish)

## Test plan
- [ ] CN region: restart Desktop, open chat model menu — chip is in MARKUS list (not orphaned `claude-opus-5`)
- [ ] After selecting a CN model with “Apply globally”, restart — sticky default persists and stays in list
- [ ] Hub-connected Overview: after B/P burns, progress total stays period budget (`creditsBudgetCu`), not shrunk M+B+P
- [ ] CI release workflow for `v0.9.2` publishes npm / desktop artifacts


Made with [Cursor](https://cursor.com)