### PR TITLE
release v0.9.3: Windows install path fix and download landing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ docs/api-test/
 
 # Paper — independent repo (paper/.git)
 paper/
+
+# Locally downloaded Windows installers
+Markus-Setup-*.exe

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.4
+
+### Bug Fixes
+
+- **升级无需手动删目录** — 安装器解压前自动把旧 `$INSTDIR` 挪到 `__markus_old` 再装入新文件并清理；坏掉的旧安装不用用户手动删除
+
 ## v0.9.3-rc.3
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,12 @@
 # Release Log
 
+## v0.9.3
+
+### Bug Fixes
+
+- **Windows 安装/升级** — 唯一安装路径：跳过会半删目录的旧卸载器；离开 INSTDIR 后杀进程、清空目录、直接 7z 解压并校验 `Markus.exe`；始终重建快捷方式；跳过已有 Authenticode 的 helper 二次签名；启动时自动修复缺失 `.lnk`
+- **升级下载链接** — 客户端更新提示 / 菜单 / CLI / MAS 文案改为 `https://markus.global/#download`（首页下载区）
+
 ## v0.9.3-rc.7
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.6
+
+### Bug Fixes
+
+- **Windows 安装路径彻底收敛** — 删除层层 RC 字符串补丁史；`patch-nsis-templates.mjs` 改为按宏名正则替换（可幂等）。唯一安装路径：离开 INSTDIR → 杀进程 → 清空目录 → 直接 7z 解压 → 校验 `Markus.exe` → 写快捷方式。禁止 Rename/CopyFiles/「无法关闭」弹窗
+
 ## v0.9.3-rc.5
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,12 @@
 # Release Log
 
+## v0.9.3-rc.0
+
+### Bug Fixes
+
+- **Windows 升级安装** — 跳过会半删安装目录的旧卸载器；`--keep-shortcuts` 时不再误删桌面/开始菜单快捷方式；卸载失败 continue 时清零 `$R0`；缺 `Markus.exe` 直接 Abort；启动时若快捷方式缺失则自动修复
+- **升级下载链接** — 客户端更新提示 / 菜单 / CLI / MAS 文案改为 `https://markus.global/#download`（首页下载区），避免落到 Hub SPA browse
+
 ## v0.9.2
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.5
+
+### Bug Fixes
+
+- **Windows 安装丢 Markus.exe（rc.4 回归）** — 根因是解压前 `Rename $INSTDIR` 时进程 CWD 跟随改名，文件解压进 `__markus_old` 后被 `RMDir` 删掉。改为先 `SetOutPath $PLUGINSDIR` 再删除旧目录并直接解压，解压后强制校验 `Markus.exe`
+
 ## v0.9.3-rc.4
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.2
+
+### Bug Fixes
+
+- **Windows「无法关闭」误报** — 根因是解压时 `CopyFiles` 失败后 stock 用同一句 `$(appCannotBeClosed)` 弹窗（并非 Markus 仍在运行）。改为强制 7z 覆盖解压且不再弹窗；并清理 OpenConsole/winpty-agent 等会锁文件的 helper
+
 ## v0.9.3-rc.1
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.7
+
+### Bug Fixes
+
+- **重新发版** — rc.6 的 npm 包已发布成功，但 Publish 流水线因「不可覆盖已发布版本」失败，导致 Windows/mac/linux 桌面构建被跳过；同内容重打 tag 以产出安装包
+
 ## v0.9.3-rc.6
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.3
+
+### Bug Fixes
+
+- **Windows 安装「无法关闭」彻底拆除** — `rc.1` 弹窗来自解压阶段 stock `CopyFiles`（不是 Markus 进程检测）。改为 **直接 7z 解压到 `$INSTDIR`**，删除 CopyFiles/重试/误导弹窗整条路径；并排除 win32-arm64 的 node-pty ConPTY 文件
+
 ## v0.9.3-rc.2
 
 ### Bug Fixes

--- a/RELEASELOG.md
+++ b/RELEASELOG.md
@@ -1,5 +1,11 @@
 # Release Log
 
+## v0.9.3-rc.1
+
+### Bug Fixes
+
+- **Windows 签名** — 跳过已有 Authenticode 的第三方 exe（node-pty `OpenConsole.exe`），避免 ssign「file already has a signature」导致 Windows 构建失败
+
 ## v0.9.3-rc.0
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -12,5 +12,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1920,7 +1920,7 @@ async function startServerCore(
   checkForUpdate().then(info => {
     if (info.updateAvailable) {
       console.log(`\n  \x1b[33m⬆ New version available: v${info.latestVersion} (current: v${info.currentVersion})\x1b[0m`);
-      console.log(`    Visit \x1b[1mhttps://markus.global/download\x1b[0m to download the latest version\n`);
+      console.log(`    Visit \x1b[1mhttps://markus.global/#download\x1b[0m to download the latest version\n`);
     }
   }).catch(() => {});
 

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,5 +25,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/desktop/build/markus-installer.nsh
+++ b/packages/desktop/build/markus-installer.nsh
@@ -1,12 +1,93 @@
-; Markus NSIS extras (protocol + shortcuts).
-; Process-detection / upgrade dialogs are patched in electron-builder templates
-; by scripts/patch-nsis-templates.mjs (do not rely on customCheckAppRunning alone).
+; Windows NSIS customisations for Markus Desktop.
 ;
-; Do NOT name this file "installer.nsh".
+; Do NOT name this file "installer.nsh" — that basename is used by
+; electron-builder stock helpers (installApplicationFiles / addDesktopLink).
+;
+; --- Root cause: upgrade leaves no shortcuts / broken install ---
+; 1) Stock assisted upgrades pass --keep-shortcuts to the OLD uninstaller, then
+;    skip recreating Desktop/Start Menu links ($keepShortcuts=true).
+;    Our customUnInstall used to Delete those .lnk files unconditionally, so
+;    upgrades wiped shortcuts and never put them back.
+; 2) installSection always ExecWait's the previous uninstaller. Silent old
+;    uninstallers often fail (busy files / Path.StartsWith false positives) and
+;    can half-delete INSTDIR. After five failures stock shows $(appCannotBeClosed);
+;    our template patch "continue" without clearing $R0 / without
+;    customUnInstallCheck can report success over a corrupted tree.
+;
+; Fix: kill install-dir processes, clear UninstallString so uninstallOldVersion
+; no-ops (Electron overwrite is safe), recreate protocol + shortcuts ourselves,
+; refuse to finish if Markus.exe is missing, and never delete shortcuts when
+; --keep-shortcuts / --updated is set.
+;
+; Process-detection MessageBoxes are also hard-patched by
+; scripts/patch-nsis-templates.mjs.
+
+!macro markusKillInstallDirProcesses _DIR
+  ${if} `${_DIR}` != ""
+    DetailPrint "Stopping processes under ${_DIR}"
+    nsExec::ExecToStack '"$SYSDIR\cmd.exe" /C taskkill /F /T /IM "Markus.exe" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1'
+    Pop $R9
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$$p=''${_DIR}''; if (-not $$p) { exit 0 }; Get-CimInstance Win32_Process | Where-Object { $$_.Path -and $$_.Path.StartsWith($$p, ''CurrentCultureIgnoreCase'') } | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }; exit 0"'
+    Pop $R9
+    Sleep 800
+  ${endif}
+!macroend
+
+!macro markusSkipBrokenOldUninstaller
+  ; Make uninstallOldVersion return immediately (empty UninstallString).
+  ; Prevents half-deleted INSTDIR and parent $(appCannotBeClosed).
+  DetailPrint "Skipping previous uninstaller (overwrite upgrade)"
+  DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString
+  DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY}" UninstallString
+  !ifdef UNINSTALL_REGISTRY_KEY_2
+    DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY_2}" UninstallString
+    DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY_2}" UninstallString
+  !endif
+!macroend
+
+; Runs from .onInit for every install path (including UAC inner instance).
+!macro customInit
+  DetailPrint "Markus customInit: prepare upgrade"
+  ReadRegStr $R8 HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation
+  ${if} $R8 != ""
+    !insertmacro markusKillInstallDirProcesses "$R8"
+  ${endif}
+  ReadRegStr $R8 HKLM "${INSTALL_REGISTRY_KEY}" InstallLocation
+  ${if} $R8 != ""
+    !insertmacro markusKillInstallDirProcesses "$R8"
+  ${endif}
+  !insertmacro markusSkipBrokenOldUninstaller
+!macroend
+
+!macro customCheckAppRunning
+  DetailPrint "Markus customCheckAppRunning: never blocks install"
+  !insertmacro markusKillInstallDirProcesses "$INSTDIR"
+  ReadRegStr $R8 HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation
+  ${if} $R8 != ""
+    !insertmacro markusKillInstallDirProcesses "$R8"
+  ${endif}
+  !insertmacro markusSkipBrokenOldUninstaller
+!macroend
+
+; Belt-and-suspenders if an uninstaller still runs and fails.
+; handleUninstallResult returns early when this macro exists — so a non-zero
+; $R0 from a failed old uninstall cannot Quit the parent installer.
+!macro customUnInstallCheck
+  DetailPrint "Ignoring previous uninstaller result (upgrade continues)"
+  StrCpy $R0 0
+  ClearErrors
+!macroend
+
+!macro customUnInstallCheckCurrentUser
+  DetailPrint "Ignoring previous per-user uninstaller result (upgrade continues)"
+  StrCpy $R0 0
+  ClearErrors
+!macroend
 
 !macro customInstall
   SetShellVarContext current
 
+  DetailPrint "Registering markus:// URL protocol (HKCU)"
   WriteRegStr HKCU "Software\Classes\markus" "" "URL:Markus Protocol"
   WriteRegStr HKCU "Software\Classes\markus" "URL Protocol" ""
   WriteRegStr HKCU "Software\Classes\markus\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME},0"
@@ -15,10 +96,23 @@
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_EXECUTABLE_FILENAME}" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_EXECUTABLE_FILENAME}" "Path" "$INSTDIR"
 
+  ; Refuse "success" if the main binary never landed (corrupt / aborted extract).
+  IfFileExists "$INSTDIR\${APP_EXECUTABLE_FILENAME}" markus_exe_ok 0
+    DetailPrint "FATAL: $INSTDIR\${APP_EXECUTABLE_FILENAME} missing after install"
+    MessageBox MB_OK|MB_ICONSTOP "Markus installation is incomplete: ${APP_EXECUTABLE_FILENAME} was not found in:$\r$\n$INSTDIR$\r$\n$\r$\nPlease close Markus, delete that folder if it still exists, and run the installer again."
+    SetErrorLevel 2
+    Abort
+  markus_exe_ok:
+
   StrCpy $0 "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
+  DetailPrint "Creating Desktop + Start Menu shortcuts for $0"
+  SetShellVarContext current
   CreateDirectory "$SMPROGRAMS"
   CreateShortCut "$DESKTOP\${PRODUCT_FILENAME}.lnk" "$0" "" "$0" 0
   CreateShortCut "$SMPROGRAMS\${PRODUCT_FILENAME}.lnk" "$0" "" "$0" 0
+  ; OneDrive / redirected Desktop: also write via known folder API.
+  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$$exe=''$INSTDIR\${APP_EXECUTABLE_FILENAME}''; $$name=''${PRODUCT_FILENAME}''; $$ws=New-Object -ComObject WScript.Shell; foreach ($$dir in @([Environment]::GetFolderPath(''Desktop''), [Environment]::GetFolderPath(''StartMenu''))) { if (-not $$dir) { continue }; $$lnk=Join-Path $$dir ($$name + ''.lnk''); $$s=$$ws.CreateShortcut($$lnk); $$s.TargetPath=$$exe; $$s.WorkingDirectory=Split-Path $$exe; $$s.IconLocation=$$exe + '',0''; $$s.Save() }"'
+  Pop $R9
   System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
 !macroend
 
@@ -26,6 +120,14 @@
   SetShellVarContext current
   DeleteRegKey HKCU "Software\Classes\markus"
   DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_EXECUTABLE_FILENAME}"
-  Delete "$DESKTOP\${PRODUCT_FILENAME}.lnk"
-  Delete "$SMPROGRAMS\${PRODUCT_FILENAME}.lnk"
+
+  ; Stock uninstaller keeps shortcuts when --keep-shortcuts is passed during
+  ; assisted upgrades. We must do the same — otherwise upgrades delete .lnk
+  ; files and stock install skips recreating them ($keepShortcuts=true).
+  ${ifNot} ${isKeepShortcuts}
+    Delete "$DESKTOP\${PRODUCT_FILENAME}.lnk"
+    Delete "$SMPROGRAMS\${PRODUCT_FILENAME}.lnk"
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$$name=''${PRODUCT_FILENAME}.lnk''; foreach ($$dir in @([Environment]::GetFolderPath(''Desktop''), [Environment]::GetFolderPath(''StartMenu''))) { if ($$dir) { Remove-Item (Join-Path $$dir $$name) -Force -ErrorAction SilentlyContinue } }"'
+    Pop $R9
+  ${endIf}
 !macroend

--- a/packages/desktop/build/markus-installer.nsh
+++ b/packages/desktop/build/markus-installer.nsh
@@ -19,13 +19,15 @@
 ; refuse to finish if Markus.exe is missing, and never delete shortcuts when
 ; --keep-shortcuts / --updated is set.
 ;
-; Process-detection MessageBoxes are also hard-patched by
+; Process-detection AND extract CopyFiles MessageBoxes (same misleading
+; $(appCannotBeClosed) string) are hard-patched by
 ; scripts/patch-nsis-templates.mjs.
 
 !macro markusKillInstallDirProcesses _DIR
   ${if} `${_DIR}` != ""
     DetailPrint "Stopping processes under ${_DIR}"
-    nsExec::ExecToStack '"$SYSDIR\cmd.exe" /C taskkill /F /T /IM "Markus.exe" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1'
+    ; Markus.exe + installer helper + node-pty ConPTY helpers that lock INSTDIR
+    nsExec::ExecToStack '"$SYSDIR\cmd.exe" /C taskkill /F /T /IM "Markus.exe" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
     Pop $R9
     nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$$p=''${_DIR}''; if (-not $$p) { exit 0 }; Get-CimInstance Win32_Process | Where-Object { $$_.Path -and $$_.Path.StartsWith($$p, ''CurrentCultureIgnoreCase'') } | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }; exit 0"'
     Pop $R9
@@ -39,9 +41,13 @@
   DetailPrint "Skipping previous uninstaller (overwrite upgrade)"
   DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString
   DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY}" UninstallString
+  DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" QuietUninstallString
+  DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY}" QuietUninstallString
   !ifdef UNINSTALL_REGISTRY_KEY_2
     DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY_2}" UninstallString
     DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY_2}" UninstallString
+    DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY_2}" QuietUninstallString
+    DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY_2}" QuietUninstallString
   !endif
 !macroend
 

--- a/packages/desktop/build/markus-installer.nsh
+++ b/packages/desktop/build/markus-installer.nsh
@@ -1,32 +1,16 @@
-; Windows NSIS customisations for Markus Desktop.
+; Markus Desktop — NSIS customisations.
 ;
-; Do NOT name this file "installer.nsh" — that basename is used by
-; electron-builder stock helpers (installApplicationFiles / addDesktopLink).
+; Do NOT name this file "installer.nsh" (reserved by electron-builder).
 ;
-; --- Root cause: upgrade leaves no shortcuts / broken install ---
-; 1) Stock assisted upgrades pass --keep-shortcuts to the OLD uninstaller, then
-;    skip recreating Desktop/Start Menu links ($keepShortcuts=true).
-;    Our customUnInstall used to Delete those .lnk files unconditionally, so
-;    upgrades wiped shortcuts and never put them back.
-; 2) installSection always ExecWait's the previous uninstaller. Silent old
-;    uninstallers often fail (busy files / Path.StartsWith false positives) and
-;    can half-delete INSTDIR. After five failures stock shows $(appCannotBeClosed);
-;    our template patch "continue" without clearing $R0 / without
-;    customUnInstallCheck can report success over a corrupted tree.
-;
-; Fix: kill install-dir processes, clear UninstallString so uninstallOldVersion
-; no-ops (Electron overwrite is safe), recreate protocol + shortcuts ourselves,
-; refuse to finish if Markus.exe is missing, and never delete shortcuts when
-; --keep-shortcuts / --updated is set.
-;
-; Process-detection AND extract CopyFiles MessageBoxes (same misleading
-; $(appCannotBeClosed) string) are hard-patched by
-; scripts/patch-nsis-templates.mjs.
+; Install contract (paired with scripts/patch-nsis-templates.mjs):
+;   1. Never block the user with "Markus cannot be closed".
+;   2. Never run the previous uninstaller (it half-deletes INSTDIR).
+;   3. Wipe INSTDIR → extract → verify Markus.exe → write shortcuts.
+;   4. Real uninstall (not upgrade) may remove shortcuts; upgrades must not.
 
 !macro markusKillInstallDirProcesses _DIR
   ${if} `${_DIR}` != ""
     DetailPrint "Stopping processes under ${_DIR}"
-    ; Markus.exe + installer helper + node-pty ConPTY helpers that lock INSTDIR
     nsExec::ExecToStack '"$SYSDIR\cmd.exe" /C taskkill /F /T /IM "Markus.exe" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
     Pop $R9
     nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$$p=''${_DIR}''; if (-not $$p) { exit 0 }; Get-CimInstance Win32_Process | Where-Object { $$_.Path -and $$_.Path.StartsWith($$p, ''CurrentCultureIgnoreCase'') } | ForEach-Object { Stop-Process -Id $$_.ProcessId -Force -ErrorAction SilentlyContinue }; exit 0"'
@@ -35,10 +19,9 @@
   ${endif}
 !macroend
 
-!macro markusSkipBrokenOldUninstaller
-  ; Make uninstallOldVersion return immediately (empty UninstallString).
-  ; Prevents half-deleted INSTDIR and parent $(appCannotBeClosed).
-  DetailPrint "Skipping previous uninstaller (overwrite upgrade)"
+!macro markusSkipOldUninstaller
+  ; Empty UninstallString ⇒ uninstallOldVersion is a no-op.
+  DetailPrint "Skipping previous uninstaller (overwrite install)"
   DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" UninstallString
   DeleteRegValue HKLM "${UNINSTALL_REGISTRY_KEY}" UninstallString
   DeleteRegValue HKCU "${UNINSTALL_REGISTRY_KEY}" QuietUninstallString
@@ -51,9 +34,7 @@
   !endif
 !macroend
 
-; Runs from .onInit for every install path (including UAC inner instance).
 !macro customInit
-  DetailPrint "Markus customInit: prepare upgrade"
   ReadRegStr $R8 HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation
   ${if} $R8 != ""
     !insertmacro markusKillInstallDirProcesses "$R8"
@@ -62,30 +43,25 @@
   ${if} $R8 != ""
     !insertmacro markusKillInstallDirProcesses "$R8"
   ${endif}
-  !insertmacro markusSkipBrokenOldUninstaller
+  !insertmacro markusSkipOldUninstaller
 !macroend
 
 !macro customCheckAppRunning
-  DetailPrint "Markus customCheckAppRunning: never blocks install"
   !insertmacro markusKillInstallDirProcesses "$INSTDIR"
   ReadRegStr $R8 HKCU "${INSTALL_REGISTRY_KEY}" InstallLocation
   ${if} $R8 != ""
     !insertmacro markusKillInstallDirProcesses "$R8"
   ${endif}
-  !insertmacro markusSkipBrokenOldUninstaller
+  !insertmacro markusSkipOldUninstaller
 !macroend
 
-; Belt-and-suspenders if an uninstaller still runs and fails.
-; handleUninstallResult returns early when this macro exists — so a non-zero
-; $R0 from a failed old uninstall cannot Quit the parent installer.
+; If an old uninstaller still runs and fails, do not Quit the parent installer.
 !macro customUnInstallCheck
-  DetailPrint "Ignoring previous uninstaller result (upgrade continues)"
   StrCpy $R0 0
   ClearErrors
 !macroend
 
 !macro customUnInstallCheckCurrentUser
-  DetailPrint "Ignoring previous per-user uninstaller result (upgrade continues)"
   StrCpy $R0 0
   ClearErrors
 !macroend
@@ -93,30 +69,25 @@
 !macro customInstall
   SetShellVarContext current
 
-  DetailPrint "Registering markus:// URL protocol (HKCU)"
   WriteRegStr HKCU "Software\Classes\markus" "" "URL:Markus Protocol"
   WriteRegStr HKCU "Software\Classes\markus" "URL Protocol" ""
   WriteRegStr HKCU "Software\Classes\markus\DefaultIcon" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME},0"
   WriteRegStr HKCU "Software\Classes\markus\shell\open\command" "" '"$INSTDIR\${APP_EXECUTABLE_FILENAME}" "%1"'
-
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_EXECUTABLE_FILENAME}" "" "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
   WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_EXECUTABLE_FILENAME}" "Path" "$INSTDIR"
 
-  ; Refuse "success" if the main binary never landed (corrupt / aborted extract).
   IfFileExists "$INSTDIR\${APP_EXECUTABLE_FILENAME}" markus_exe_ok 0
-    DetailPrint "FATAL: $INSTDIR\${APP_EXECUTABLE_FILENAME} missing after install"
-    MessageBox MB_OK|MB_ICONSTOP "Markus installation is incomplete: ${APP_EXECUTABLE_FILENAME} was not found in:$\r$\n$INSTDIR$\r$\n$\r$\nPlease run this installer again — it will automatically clean up and retry."
+    MessageBox MB_OK|MB_ICONSTOP "Markus installation is incomplete: ${APP_EXECUTABLE_FILENAME} missing from:$\r$\n$INSTDIR$\r$\n$\r$\nPlease run the installer again."
     SetErrorLevel 2
     Abort
   markus_exe_ok:
 
+  ; Always (re)create shortcuts — stock keepShortcuts can skip this on upgrades.
   StrCpy $0 "$INSTDIR\${APP_EXECUTABLE_FILENAME}"
-  DetailPrint "Creating Desktop + Start Menu shortcuts for $0"
-  SetShellVarContext current
+  DetailPrint "Creating Desktop + Start Menu shortcuts"
   CreateDirectory "$SMPROGRAMS"
   CreateShortCut "$DESKTOP\${PRODUCT_FILENAME}.lnk" "$0" "" "$0" 0
   CreateShortCut "$SMPROGRAMS\${PRODUCT_FILENAME}.lnk" "$0" "" "$0" 0
-  ; OneDrive / redirected Desktop: also write via known folder API.
   nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -ExecutionPolicy Bypass -Command "$$exe=''$INSTDIR\${APP_EXECUTABLE_FILENAME}''; $$name=''${PRODUCT_FILENAME}''; $$ws=New-Object -ComObject WScript.Shell; foreach ($$dir in @([Environment]::GetFolderPath(''Desktop''), [Environment]::GetFolderPath(''StartMenu''))) { if (-not $$dir) { continue }; $$lnk=Join-Path $$dir ($$name + ''.lnk''); $$s=$$ws.CreateShortcut($$lnk); $$s.TargetPath=$$exe; $$s.WorkingDirectory=Split-Path $$exe; $$s.IconLocation=$$exe + '',0''; $$s.Save() }"'
   Pop $R9
   System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
@@ -127,9 +98,7 @@
   DeleteRegKey HKCU "Software\Classes\markus"
   DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\App Paths\${APP_EXECUTABLE_FILENAME}"
 
-  ; Stock uninstaller keeps shortcuts when --keep-shortcuts is passed during
-  ; assisted upgrades. We must do the same — otherwise upgrades delete .lnk
-  ; files and stock install skips recreating them ($keepShortcuts=true).
+  ; Upgrades pass --keep-shortcuts; must not delete .lnk in that case.
   ${ifNot} ${isKeepShortcuts}
     Delete "$DESKTOP\${PRODUCT_FILENAME}.lnk"
     Delete "$SMPROGRAMS\${PRODUCT_FILENAME}.lnk"

--- a/packages/desktop/build/markus-installer.nsh
+++ b/packages/desktop/build/markus-installer.nsh
@@ -105,7 +105,7 @@
   ; Refuse "success" if the main binary never landed (corrupt / aborted extract).
   IfFileExists "$INSTDIR\${APP_EXECUTABLE_FILENAME}" markus_exe_ok 0
     DetailPrint "FATAL: $INSTDIR\${APP_EXECUTABLE_FILENAME} missing after install"
-    MessageBox MB_OK|MB_ICONSTOP "Markus installation is incomplete: ${APP_EXECUTABLE_FILENAME} was not found in:$\r$\n$INSTDIR$\r$\n$\r$\nPlease close Markus, delete that folder if it still exists, and run the installer again."
+    MessageBox MB_OK|MB_ICONSTOP "Markus installation is incomplete: ${APP_EXECUTABLE_FILENAME} was not found in:$\r$\n$INSTDIR$\r$\n$\r$\nPlease run this installer again — it will automatically clean up and retry."
     SetErrorLevel 2
     Abort
   markus_exe_ok:

--- a/packages/desktop/build/sign.cjs
+++ b/packages/desktop/build/sign.cjs
@@ -4,12 +4,17 @@
 // "Code Signing in the Cloud" (SimplySign) certificate via the `ssign` client.
 //
 // electron-builder calls this once per file that needs signing — the app
-// executable (Markus.exe), the NSIS uninstaller, and the final installer —
-// signing each in place with an RFC3161 timestamp. Because signing happens
-// inside electron-builder's pipeline, the .blockmap and latest.yml are
+// executable (Markus.exe), nested helper .exe files pulled in via asarUnpack
+// (e.g. node-pty's OpenConsole.exe), the NSIS uninstaller, and the final
+// installer — signing each in place with an RFC3161 timestamp. Because signing
+// happens inside electron-builder's pipeline, the .blockmap and latest.yml are
 // generated from the already-signed installer, so electron-updater stays
 // consistent. (DLLs / .node addons are intentionally NOT signed — that is
 // electron-builder's default and the industry norm.)
+//
+// Already-signed vendor binaries (OpenConsole.exe ships Microsoft-signed) must
+// be skipped: ssign refuses to assemble a second signature ("file already has
+// a signature"). Keeping the vendor Authenticode is correct for those helpers.
 //
 // TOTP window handling — the important bit:
 //   `ssign` performs one SimplySign OAuth login per run, using a 6-digit TOTP
@@ -30,6 +35,7 @@
 // When the credentials are absent (forks, local `--dir` builds, dry runs) the
 // file is left unsigned instead of failing the build.
 const { execFileSync } = require("node:child_process");
+const fs = require("node:fs");
 
 const TOTP_WINDOW_MS = 30_000;
 // Fire slightly after the window boundary so the freshly-rolled code has its
@@ -53,11 +59,65 @@ async function waitForFreshWindow() {
   }
 }
 
+/**
+ * True when the PE already has an Authenticode certificate table.
+ * Avoids burning a SimplySign login on vendor-signed helpers that ssign
+ * cannot re-sign (error: "file already has a signature").
+ */
+function peHasAuthenticode(filePath) {
+  let fd;
+  try {
+    fd = fs.openSync(filePath, "r");
+    const header = Buffer.alloc(4096);
+    const n = fs.readSync(fd, header, 0, header.length, 0);
+    if (n < 0x40 || header.readUInt16LE(0) !== 0x5a4d) return false; // MZ
+
+    const peOffset = header.readUInt32LE(0x3c);
+    const need = peOffset + 24 + 112; // COFF + PE32+ optional with data dirs
+    let buf = header;
+    if (need > n) {
+      buf = Buffer.alloc(need);
+      fs.readSync(fd, buf, 0, need, 0);
+    }
+    if (buf.length < peOffset + 6) return false;
+    if (buf.readUInt32LE(peOffset) !== 0x00004550) return false; // PE\0\0
+
+    const optionalMagic = buf.readUInt16LE(peOffset + 24);
+    // PE32 = 0x10b (data dirs at +96 from optional start → pe+120)
+    // PE32+ = 0x20b (data dirs at +112 from optional start → pe+136)
+    let certDirOffset;
+    if (optionalMagic === 0x20b) certDirOffset = peOffset + 24 + 144; // DataDirectory[4]
+    else if (optionalMagic === 0x10b) certDirOffset = peOffset + 24 + 128;
+    else return false;
+
+    if (buf.length < certDirOffset + 8) return false;
+    const certTableRva = buf.readUInt32LE(certDirOffset);
+    const certTableSize = buf.readUInt32LE(certDirOffset + 4);
+    return certTableRva !== 0 && certTableSize !== 0;
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
+  }
+}
+
+function isAlreadySignedError(err) {
+  const msg = `${err && err.message ? err.message : err}`;
+  // ssign prints the cause on stderr (stdio inherit); Node's error is usually
+  // just "Command failed". Also match the cause text if ever captured.
+  return /already has a signature/i.test(msg);
+}
+
 exports.default = async function sign(configuration) {
   const file = configuration.path;
 
   if (!process.env.CERTUM_EMAIL || !process.env.CERTUM_OTP) {
     console.warn(`[sign] CERTUM_EMAIL/CERTUM_OTP not set — leaving ${file} UNSIGNED`);
+    return;
+  }
+
+  if (peHasAuthenticode(file)) {
+    console.log(`[sign] skip (already Authenticode-signed): ${file}`);
     return;
   }
 
@@ -70,11 +130,21 @@ exports.default = async function sign(configuration) {
 
     console.log(`[sign] signing ${file} (attempt ${attempt}/${MAX_ATTEMPTS})`);
     try {
-      // ssign reads CERTUM_EMAIL / CERTUM_OTP from the environment and signs in
-      // place with a Certum RFC3161 timestamp. Inherit stdio so failures surface.
-      execFileSync(ssign, [file], { stdio: "inherit", env: process.env });
+      // Capture stderr so "file already has a signature" can be treated as skip
+      // even if the PE probe missed an edge case.
+      execFileSync(ssign, [file], {
+        stdio: ["ignore", "inherit", "pipe"],
+        env: process.env,
+        encoding: "utf8",
+      });
       return;
     } catch (e) {
+      const stderr = e && e.stderr ? String(e.stderr) : "";
+      if (stderr) process.stderr.write(stderr);
+      if (isAlreadySignedError(e) || /already has a signature/i.test(stderr)) {
+        console.log(`[sign] skip (ssign: already signed): ${file}`);
+        return;
+      }
       if (attempt === MAX_ATTEMPTS) {
         throw new Error(`[sign] failed to sign ${file} after ${MAX_ATTEMPTS} attempts: ${e.message}`);
       }

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -83,15 +83,12 @@ nsis:
   # No elevate helper binary — avoids extra processes that confuse "app running" checks
   # and is unnecessary when allowElevation is false.
   packElevateHelper: false
-  # Stock "always" still skips desktop recreation when $keepShortcuts=true on
-  # assisted upgrades. markus-installer.nsh force-creates .lnk and skips the
-  # broken previous-uninstaller path (see build/markus-installer.nsh).
+  # Stock keepShortcuts can still skip recreation on upgrades; markus-installer.nsh
+  # always recreates Desktop/Start Menu .lnk after a verified extract.
   createDesktopShortcut: always
   createStartMenuShortcut: true
   shortcutName: Markus
-  # Must NOT be named installer.nsh — that basename is reserved by electron-builder's
-  # stock include (installApplicationFiles).
-  # customInit / customCheckAppRunning / customUnInstallCheck: see markus-installer.nsh.
+  # Must NOT be named installer.nsh (reserved by electron-builder).
   # (menuCategory must stay unset — YAML false becomes MENU_FILENAME=false.)
   include: markus-installer.nsh
 

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -15,6 +15,10 @@ files:
   - "!dist/**/*.map"
   - node_modules/node-pty/**/*
   - node_modules/node-addon-api/**/*
+  # Windows x64 builds must not ship arm64 ConPTY helpers (wrong arch + extra
+  # OpenConsole.exe copies that complicate upgrades / file locks).
+  - "!**/node-pty/prebuilds/win32-arm64/**"
+  - "!**/node-pty/third_party/conpty/**/win10-arm64/**"
 asar: true
 asarUnpack:
   - dist/preload.js
@@ -24,6 +28,8 @@ asarUnpack:
   - dist/markus-browser-extension.zip
   - dist/data/**
   - node_modules/node-pty/**/*
+  - "!**/node-pty/prebuilds/win32-arm64/**"
+  - "!**/node-pty/third_party/conpty/**/win10-arm64/**"
 compression: maximum
 
 mac:

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -77,14 +77,15 @@ nsis:
   # No elevate helper binary — avoids extra processes that confuse "app running" checks
   # and is unnecessary when allowElevation is false.
   packElevateHelper: false
-  # "always" recreates the desktop shortcut on upgrade even if the user deleted it.
-  # markus-installer.nsh also force-creates Desktop + Start Menu .lnk (current user).
+  # Stock "always" still skips desktop recreation when $keepShortcuts=true on
+  # assisted upgrades. markus-installer.nsh force-creates .lnk and skips the
+  # broken previous-uninstaller path (see build/markus-installer.nsh).
   createDesktopShortcut: always
   createStartMenuShortcut: true
   shortcutName: Markus
   # Must NOT be named installer.nsh — that basename is reserved by electron-builder's
   # stock include (installApplicationFiles).
-  # customCheckAppRunning + customUnInstallCheck: see build/markus-installer.nsh.
+  # customInit / customCheckAppRunning / customUnInstallCheck: see markus-installer.nsh.
   # (menuCategory must stay unset — YAML false becomes MENU_FILENAME=false.)
   include: markus-installer.nsh
 

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -36,5 +36,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/desktop/scripts/patch-nsis-templates.mjs
+++ b/packages/desktop/scripts/patch-nsis-templates.mjs
@@ -192,6 +192,58 @@ patchFirstMatch(
 // Markus: always extract straight into $INSTDIR. No CopyFiles, no dialog.
 
 const extractUsing7zaDirect = `!macro extractUsing7za FILE
+  ; Markus patch: safe auto-clean + direct extract into $INSTDIR.
+  ; Never CopyFiles, never MessageBox $(appCannotBeClosed).
+  ;
+  ; CRITICAL: do NOT Rename $INSTDIR while it is the current OutPath.
+  ; On Windows the process CWD follows the rename, so Nsis7z can extract
+  ; into $INSTDIR.__markus_old — and the subsequent RMDir then deletes
+  ; the freshly extracted app (Markus.exe disappears; install "succeeds"
+  ; with only leftovers + Uninstall). Leave INSTDIR before wiping it.
+  DetailPrint "Markus: safe auto-clean INSTDIR + direct 7z extract"
+  SetOutPath "$PLUGINSDIR"
+
+  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
+  Pop $0
+  Sleep 800
+
+  ; Clean leftovers from the broken rc.4 rename approach
+  RMDir /r "$INSTDIR.__markus_old"
+  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C if exist "$INSTDIR.__markus_old" rmdir /s /q "$INSTDIR.__markus_old" >nul 2>&1'
+  Pop $0
+
+  IfFileExists "$INSTDIR" 0 markus_extract_fresh
+    DetailPrint "Removing previous install (automatic — no user action needed)"
+    RMDir /r "$INSTDIR"
+    nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C if exist "$INSTDIR" rmdir /s /q "$INSTDIR" >nul 2>&1'
+    Pop $0
+    Sleep 300
+  markus_extract_fresh:
+
+  ClearErrors
+  CreateDirectory "$INSTDIR"
+  SetOutPath "$INSTDIR"
+  DetailPrint "Extracting application files into $INSTDIR"
+  Nsis7z::Extract "\${FILE}"
+
+  IfFileExists "$INSTDIR\\\${APP_EXECUTABLE_FILENAME}" markus_extract_ok 0
+    DetailPrint "Missing \${APP_EXECUTABLE_FILENAME} after extract — retrying once"
+    Sleep 500
+    nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1'
+    Pop $0
+    SetOutPath "$INSTDIR"
+    Nsis7z::Extract "\${FILE}"
+  IfFileExists "$INSTDIR\\\${APP_EXECUTABLE_FILENAME}" markus_extract_ok 0
+    DetailPrint "FATAL: \${APP_EXECUTABLE_FILENAME} still missing after extract"
+    MessageBox MB_OK|MB_ICONSTOP "Markus failed to install: \${APP_EXECUTABLE_FILENAME} was not written to:$\\r$\\n$INSTDIR$\\r$\\n$\\r$\\nPlease run the installer again. If it keeps failing, temporarily pause antivirus for that folder."
+    SetErrorLevel 2
+    Abort
+  markus_extract_ok:
+  DetailPrint "Verified \${APP_EXECUTABLE_FILENAME} present"
+!macroend`;
+
+// rc.4: rename-aside approach (unsafe — CWD follows rename)
+const extractUsing7zaRc4 = `!macro extractUsing7za FILE
   ; Markus patch: automatic cleanup + direct extract into $INSTDIR.
   ; Never CopyFiles, never MessageBox $(appCannotBeClosed), never ask the
   ; user to manually delete a broken install folder.
@@ -224,7 +276,7 @@ const extractUsing7zaDirect = `!macro extractUsing7za FILE
   markus_extract_done:
 !macroend`;
 
-// rc.3: direct extract but no automatic INSTDIR swap/cleanup
+// rc.3: direct extract but no automatic INSTDIR cleanup
 const extractUsing7zaRc3 = `!macro extractUsing7za FILE
   ; Markus patch: direct extract into $INSTDIR. Never CopyFiles, never
   ; MessageBox $(appCannotBeClosed).
@@ -327,10 +379,10 @@ const extractUsing7zaRc2 = `!macro extractUsing7za FILE
 
 patchFirstMatch(
   extractAppPackage,
-  [extractUsing7zaStock, extractUsing7zaRc2, extractUsing7zaRc3],
+  [extractUsing7zaStock, extractUsing7zaRc2, extractUsing7zaRc3, extractUsing7zaRc4],
   extractUsing7zaDirect,
   'extractAppPackage.nsh',
-  'auto-clean INSTDIR + direct 7z extract',
+  'safe auto-clean INSTDIR + direct 7z extract',
 );
 
 // ── Sanity checks (live symbols only; comments may mention these names) ───
@@ -357,11 +409,14 @@ if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.te
 if (/CopyFiles \/SILENT/.test(extractSrc)) {
   throw new Error('[patch-nsis] extractAppPackage.nsh must not use atomic CopyFiles');
 }
-if (!/auto-clean INSTDIR \+ direct 7z extract/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh missing auto-clean direct-extract path');
+if (!/safe auto-clean INSTDIR \+ direct 7z extract/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh missing safe auto-clean direct-extract path');
 }
-if (!/INSTDIR\.__markus_old/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh must move aside previous INSTDIR automatically');
+if (/Rename "\$INSTDIR" "\$INSTDIR\.__markus_old"/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh must not Rename INSTDIR (CWD-follow bug)');
+}
+if (!extractSrc.includes('Verified ${APP_EXECUTABLE_FILENAME} present')) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh must verify APP_EXECUTABLE_FILENAME after extract');
 }
 
 // Neutralize leftover MessageBox inside unused stock _CHECK_APP_RUNNING

--- a/packages/desktop/scripts/patch-nsis-templates.mjs
+++ b/packages/desktop/scripts/patch-nsis-templates.mjs
@@ -192,6 +192,40 @@ patchFirstMatch(
 // Markus: always extract straight into $INSTDIR. No CopyFiles, no dialog.
 
 const extractUsing7zaDirect = `!macro extractUsing7za FILE
+  ; Markus patch: automatic cleanup + direct extract into $INSTDIR.
+  ; Never CopyFiles, never MessageBox $(appCannotBeClosed), never ask the
+  ; user to manually delete a broken install folder.
+  DetailPrint "Markus: auto-clean INSTDIR + direct 7z extract"
+  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
+  Pop $0
+  Sleep 800
+
+  ; Leftover from a previous interrupted upgrade
+  RMDir /r "$INSTDIR.__markus_old"
+
+  IfFileExists "$INSTDIR\\*.*" 0 markus_extract_fresh
+    DetailPrint "Moving previous install aside (automatic — no user action needed)"
+    ClearErrors
+    Rename "$INSTDIR" "$INSTDIR.__markus_old"
+    IfErrors 0 markus_extract_fresh
+      DetailPrint "Rename failed; removing previous files in place"
+      RMDir /r "$INSTDIR"
+  markus_extract_fresh:
+  ClearErrors
+  CreateDirectory "$INSTDIR"
+  SetOutPath "$INSTDIR"
+  Nsis7z::Extract "\${FILE}"
+
+  ; Best-effort delete of the aside tree after files are replaced
+  IfFileExists "$INSTDIR.__markus_old" 0 markus_extract_done
+    RMDir /r "$INSTDIR.__markus_old"
+    nsExec::ExecToStack '"$SYSDIR\\cmd.exe" /C if exist "$INSTDIR.__markus_old" rmdir /s /q "$INSTDIR.__markus_old" >nul 2>&1'
+    Pop $0
+  markus_extract_done:
+!macroend`;
+
+// rc.3: direct extract but no automatic INSTDIR swap/cleanup
+const extractUsing7zaRc3 = `!macro extractUsing7za FILE
   ; Markus patch: direct extract into $INSTDIR. Never CopyFiles, never
   ; MessageBox $(appCannotBeClosed).
   DetailPrint "Markus: direct 7z extract into $INSTDIR"
@@ -293,10 +327,10 @@ const extractUsing7zaRc2 = `!macro extractUsing7za FILE
 
 patchFirstMatch(
   extractAppPackage,
-  [extractUsing7zaStock, extractUsing7zaRc2],
+  [extractUsing7zaStock, extractUsing7zaRc2, extractUsing7zaRc3],
   extractUsing7zaDirect,
   'extractAppPackage.nsh',
-  'direct 7z extract (no CopyFiles / no dialog)',
+  'auto-clean INSTDIR + direct 7z extract',
 );
 
 // ── Sanity checks (live symbols only; comments may mention these names) ───
@@ -323,8 +357,11 @@ if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.te
 if (/CopyFiles \/SILENT/.test(extractSrc)) {
   throw new Error('[patch-nsis] extractAppPackage.nsh must not use atomic CopyFiles');
 }
-if (!/direct 7z extract into \$INSTDIR/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh missing direct-extract path');
+if (!/auto-clean INSTDIR \+ direct 7z extract/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh missing auto-clean direct-extract path');
+}
+if (!/INSTDIR\.__markus_old/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh must move aside previous INSTDIR automatically');
 }
 
 // Neutralize leftover MessageBox inside unused stock _CHECK_APP_RUNNING

--- a/packages/desktop/scripts/patch-nsis-templates.mjs
+++ b/packages/desktop/scripts/patch-nsis-templates.mjs
@@ -2,14 +2,16 @@
 /**
  * Patch electron-builder NSIS templates before packaging.
  *
- * Why: nsis.include custom macros have not been reliably overriding stock
- * CHECK_APP_RUNNING / uninstallOldVersion dialogs in our published builds
- * (rc.11–rc.12 still showed $(appCannotBeClosed)). Patching the templates
- * that makensis always compiles guarantees the dialog cannot appear.
+ * Design (keep this simple — do not re-introduce layered RC history):
+ *
+ *   1. Never block on "app running" / "cannot be closed" dialogs.
+ *   2. Never run the fragile stock CopyFiles extract path.
+ *   3. Upgrade = kill helpers → wipe INSTDIR → extract → verify Markus.exe.
+ *
+ * Strategy: replace whole `!macro NAME ... !macroend` blocks by name (regex),
+ * so the script is idempotent and does not depend on exact prior patch text.
  *
  * CRITICAL: makensis treats unused-symbol warnings as errors (6001/6010/6012).
- * When removing a MessageBox/Call, also remove the labels, Vars, and includes
- * that only existed for that path.
  */
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
@@ -29,28 +31,45 @@ function resolveTemplatesDir() {
   return join(dirname(pkgJson), 'templates', 'nsis');
 }
 
-/** Replace the first matching candidate (supports re-entrant / intermediate patches). */
-function patchFirstMatch(filePath, candidates, to, label, name) {
+/** Replace `!macro name ... !macroend` (non-greedy, first match). */
+function replaceMacro(filePath, macroName, newMacroSource, label) {
   if (!existsSync(filePath)) {
     throw new Error(`NSIS template not found: ${filePath}`);
   }
   const src = readFileSync(filePath, 'utf8');
-  const marker = to.trim().slice(0, 48);
-  if (marker && src.includes(marker) && !candidates.some((c) => src.includes(c))) {
+  const re = new RegExp(
+    String.raw`!macro\s+${macroName}\b[\s\S]*?!macroend`,
+    'm',
+  );
+  if (!re.test(src)) {
+    // Already at desired end-state?
+    if (src.includes(newMacroSource.trim().slice(0, 60))) {
+      console.log(`[patch-nsis] ${label}: ${macroName} already applied`);
+      return;
+    }
+    throw new Error(`[patch-nsis] ${label}: !macro ${macroName} not found`);
+  }
+  const next = src.replace(re, newMacroSource.trim());
+  writeFileSync(filePath, next);
+  console.log(`[patch-nsis] ${label}: replaced !macro ${macroName}`);
+}
+
+/** Replace a unique exact snippet (for non-macro blocks like UninstallLoop). */
+function replaceSnippet(filePath, fromCandidates, to, label, name) {
+  if (!existsSync(filePath)) {
+    throw new Error(`NSIS template not found: ${filePath}`);
+  }
+  const src = readFileSync(filePath, 'utf8');
+  if (src.includes(to.trim())) {
     console.log(`[patch-nsis] ${label}: ${name} already applied`);
     return;
   }
-  for (const from of candidates) {
+  for (const from of fromCandidates) {
     if (src.includes(from)) {
       writeFileSync(filePath, src.replace(from, to));
       console.log(`[patch-nsis] ${label}: patched ${name}`);
       return;
     }
-  }
-  // Already at desired end state?
-  if (marker && src.includes(marker)) {
-    console.log(`[patch-nsis] ${label}: ${name} already applied`);
-    return;
   }
   throw new Error(`[patch-nsis] ${label}: pattern not found for ${name}`);
 }
@@ -62,10 +81,8 @@ const allowOnlyOne = join(templatesDir, 'include', 'allowOnlyOneInstallerInstanc
 const installUtil = join(templatesDir, 'include', 'installUtil.nsh');
 const extractAppPackage = join(templatesDir, 'include', 'extractAppPackage.nsh');
 
-// ── 1) allowOnlyOneInstallerInstance.nsh ─────────────────────────────────
-
-// Drop getProcessInfo.nsh + Var pid (unused after CHECK_APP_RUNNING rewrite).
-patchFirstMatch(
+// ── 1) Drop unused getProcessInfo include / Var pid ───────────────────────
+replaceSnippet(
   allowOnlyOne,
   [
     `!ifmacrondef customCheckAppRunning
@@ -77,6 +94,9 @@ patchFirstMatch(
 !ifmacrondef customCheckAppRunning
   Var pid
 !endif`,
+    `; Markus patch: omit getProcessInfo.nsh and Var pid.
+; Unused un._GetProcessInfo / pid → makensis warning-as-error (6010 / 6001).
+`,
   ],
   `; Markus patch: omit getProcessInfo.nsh and Var pid.
 ; Unused un._GetProcessInfo / pid → makensis warning-as-error (6010 / 6001).
@@ -85,77 +105,52 @@ patchFirstMatch(
   'omit getProcessInfo + pid',
 );
 
-// Never MessageBox/Quit on "app running" — best-effort taskkill only.
-const checkAppRunningNew = `!macro CHECK_APP_RUNNING
-  ; Markus patch: never block install/uninstall on process detection.
-  ; Stock PowerShell Path.StartsWith($INSTDIR) false-positives and shows
-  ; $(appCannotBeClosed). Only best-effort kill; always continue.
-  ; Also kill node-pty helpers that can lock INSTDIR during upgrades.
+// ── 2) CHECK_APP_RUNNING: never dialog, only taskkill ─────────────────────
+replaceMacro(
+  allowOnlyOne,
+  'CHECK_APP_RUNNING',
+  `!macro CHECK_APP_RUNNING
+  ; Markus: never MessageBox/Quit. Best-effort kill only.
   DetailPrint "Best-effort stop of \${APP_EXECUTABLE_FILENAME} + helpers (never blocks)..."
   nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
   Pop $0
   Sleep 600
-!macroend`;
-
-const checkAppRunningOldPatch = `!macro CHECK_APP_RUNNING
-  ; Markus patch: never block install/uninstall on process detection.
-  ; Stock PowerShell Path.StartsWith($INSTDIR) false-positives and shows
-  ; $(appCannotBeClosed). Only best-effort kill; always continue.
-  DetailPrint "Best-effort stop of \${APP_EXECUTABLE_FILENAME} (never blocks)..."
-  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1'
-  Pop $0
-  Sleep 600
-!macroend`;
-
-patchFirstMatch(
-  allowOnlyOne,
-  [
-    `!macro CHECK_APP_RUNNING
-  Var /GLOBAL CmdPath
-  Var /GLOBAL PowerShellPath
-  StrCpy $CmdPath "$SYSDIR\\cmd.exe"
-  StrCpy $PowerShellPath "$SYSDIR\\WindowsPowerShell\\v1.0\\powershell.exe"
-  !ifmacrodef customCheckAppRunning
-    !insertmacro customCheckAppRunning
-  !else
-    !insertmacro IS_POWERSHELL_AVAILABLE
-    !insertmacro _CHECK_APP_RUNNING
-  !endif
 !macroend`,
-    checkAppRunningOldPatch,
-  ],
-  checkAppRunningNew,
   'allowOnlyOneInstallerInstance.nsh',
-  'CHECK_APP_RUNNING',
 );
 
-// ── 2) installUtil.nsh — UninstallLoop must also drop OneMoreAttempt label ─
-// Stock MessageBox jumps to OneMoreAttempt; fall-through does NOT count as a
-// label reference in makensis. Removing only the MessageBox → warning 6012.
+// Neutralize MessageBox inside unused stock _CHECK_APP_RUNNING (not inserted,
+// but keep templates free of $(appCannotBeClosed) MessageBox lines).
+replaceSnippet(
+  allowOnlyOne,
+  [
+    `        \${if} $R1 > 1
+          MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY loop
+          Quit
+        \${else}
+          Goto loop
+        \${endIf}`,
+    `        \${if} $R1 > 1
+          ; Markus patch: unused _CHECK_APP_RUNNING must not MessageBox either.
+          DetailPrint "app still running after kills; continuing (no dialog)"
+          Goto not_running
+        \${else}
+          Goto loop
+        \${endIf}`,
+  ],
+  `        \${if} $R1 > 1
+          ; Markus: unused _CHECK_APP_RUNNING — never dialog.
+          DetailPrint "app still running after kills; continuing (no dialog)"
+          Goto not_running
+        \${else}
+          Goto loop
+        \${endIf}`,
+  'allowOnlyOneInstallerInstance.nsh',
+  'neutralize _CHECK_APP_RUNNING dialog',
+);
 
-// CRITICAL: must clear $R0 to 0. handleUninstallResult Quits when $R0 != 0
-// unless customUnInstallCheck is defined. Returning with a stale non-zero $R0
-// after "continue" either aborts the upgrade or (with a weak check macro)
-// continues over a half-deleted tree while still looking failed.
-const uninstallContinue = `    \${if} $R5 > 5
-      ; Markus patch: continue with overwrite install instead of blocking.
-      DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
-      StrCpy $R0 0
-      ClearErrors
-      Return
-    \${endIf}
-`;
-
-// Already-patched variant that forgot StrCpy $R0 0 (rc.13–0.9.2).
-const uninstallContinueBroken = `    \${if} $R5 > 5
-      ; Markus patch: continue with overwrite install instead of blocking.
-      DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
-      ClearErrors
-      Return
-    \${endIf}
-`;
-
-patchFirstMatch(
+// ── 3) UninstallLoop: never dialog; clear $R0 and continue overwrite ──────
+replaceSnippet(
   installUtil,
   [
     // Stock
@@ -165,7 +160,7 @@ patchFirstMatch(
     \${endIf}
 
   OneMoreAttempt:`,
-    // Intermediate: MessageBox patched but label left behind (rc.13–rc.16)
+    // Prior Markus patches (with/without $R0 clear, with/without label)
     `    \${if} $R5 > 5
       ; Markus patch: continue with overwrite install instead of blocking.
       DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
@@ -174,46 +169,64 @@ patchFirstMatch(
     \${endIf}
 
   OneMoreAttempt:`,
-    // Applied continue patch without clearing $R0
-    uninstallContinueBroken,
+    `    \${if} $R5 > 5
+      ; Markus patch: continue with overwrite install instead of blocking.
+      DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
+      ClearErrors
+      Return
+    \${endIf}
+`,
+    `    \${if} $R5 > 5
+      ; Markus patch: continue with overwrite install instead of blocking.
+      DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
+      StrCpy $R0 0
+      ClearErrors
+      Return
+    \${endIf}
+`,
   ],
-  `${uninstallContinue}
+  `    \${if} $R5 > 5
+      ; Markus: old uninstall failed — continue overwrite (never dialog).
+      DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
+      StrCpy $R0 0
+      ClearErrors
+      Return
+    \${endIf}
 `,
   'installUtil.nsh',
-  'UninstallLoop continue + clear $R0 + drop OneMoreAttempt',
+  'UninstallLoop continue',
 );
 
-// ── 3) extractAppPackage.nsh — kill the atomic CopyFiles path entirely ───
-// Stock flow: 7z → $PLUGINSDIR\7z-out → CopyFiles → $INSTDIR. When CopyFiles
-// fails (AV, indexer, leftover OpenConsole, half-deleted tree) it shows the
-// SAME $(appCannotBeClosed) dialog as the process check — even when Markus
-// is not running. Cancel → Quit → incomplete install → no shortcuts.
+// ── 4) extractUsing7za: the one true install path ─────────────────────────
 //
-// Markus: always extract straight into $INSTDIR. No CopyFiles, no dialog.
-
-const extractUsing7zaDirect = `!macro extractUsing7za FILE
-  ; Markus patch: safe auto-clean + direct extract into $INSTDIR.
-  ; Never CopyFiles, never MessageBox $(appCannotBeClosed).
-  ;
-  ; CRITICAL: do NOT Rename $INSTDIR while it is the current OutPath.
-  ; On Windows the process CWD follows the rename, so Nsis7z can extract
-  ; into $INSTDIR.__markus_old — and the subsequent RMDir then deletes
-  ; the freshly extracted app (Markus.exe disappears; install "succeeds"
-  ; with only leftovers + Uninstall). Leave INSTDIR before wiping it.
-  DetailPrint "Markus: safe auto-clean INSTDIR + direct 7z extract"
+//   SetOutPath $PLUGINSDIR   ← leave INSTDIR before wiping (CWD-safe)
+//   taskkill helpers
+//   RMDir /r $INSTDIR        ← automatic cleanup, no user action
+//   CreateDirectory $INSTDIR
+//   SetOutPath $INSTDIR
+//   Nsis7z::Extract
+//   verify Markus.exe or Abort
+//
+replaceMacro(
+  extractAppPackage,
+  'extractUsing7za',
+  `!macro extractUsing7za FILE
+  ; Markus install path (do not complicate this):
+  ; leave INSTDIR → kill helpers → wipe INSTDIR → extract → verify exe.
+  DetailPrint "Markus: wipe INSTDIR + direct 7z extract + verify exe"
   SetOutPath "$PLUGINSDIR"
 
   nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
   Pop $0
   Sleep 800
 
-  ; Clean leftovers from the broken rc.4 rename approach
+  ; Leftovers from the broken rc.4 Rename approach
   RMDir /r "$INSTDIR.__markus_old"
   nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C if exist "$INSTDIR.__markus_old" rmdir /s /q "$INSTDIR.__markus_old" >nul 2>&1'
   Pop $0
 
   IfFileExists "$INSTDIR" 0 markus_extract_fresh
-    DetailPrint "Removing previous install (automatic — no user action needed)"
+    DetailPrint "Removing previous install (automatic)"
     RMDir /r "$INSTDIR"
     nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C if exist "$INSTDIR" rmdir /s /q "$INSTDIR" >nul 2>&1'
     Pop $0
@@ -223,235 +236,61 @@ const extractUsing7zaDirect = `!macro extractUsing7za FILE
   ClearErrors
   CreateDirectory "$INSTDIR"
   SetOutPath "$INSTDIR"
-  DetailPrint "Extracting application files into $INSTDIR"
+  DetailPrint "Extracting into $INSTDIR"
   Nsis7z::Extract "\${FILE}"
 
   IfFileExists "$INSTDIR\\\${APP_EXECUTABLE_FILENAME}" markus_extract_ok 0
-    DetailPrint "Missing \${APP_EXECUTABLE_FILENAME} after extract — retrying once"
+    DetailPrint "Missing \${APP_EXECUTABLE_FILENAME} — retry extract once"
     Sleep 500
     nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1'
     Pop $0
     SetOutPath "$INSTDIR"
     Nsis7z::Extract "\${FILE}"
   IfFileExists "$INSTDIR\\\${APP_EXECUTABLE_FILENAME}" markus_extract_ok 0
-    DetailPrint "FATAL: \${APP_EXECUTABLE_FILENAME} still missing after extract"
-    MessageBox MB_OK|MB_ICONSTOP "Markus failed to install: \${APP_EXECUTABLE_FILENAME} was not written to:$\\r$\\n$INSTDIR$\\r$\\n$\\r$\\nPlease run the installer again. If it keeps failing, temporarily pause antivirus for that folder."
+    DetailPrint "FATAL: \${APP_EXECUTABLE_FILENAME} missing after extract"
+    MessageBox MB_OK|MB_ICONSTOP "Markus failed to install: \${APP_EXECUTABLE_FILENAME} was not written to:$\\r$\\n$INSTDIR$\\r$\\n$\\r$\\nPlease run the installer again."
     SetErrorLevel 2
     Abort
   markus_extract_ok:
   DetailPrint "Verified \${APP_EXECUTABLE_FILENAME} present"
-!macroend`;
-
-// rc.4: rename-aside approach (unsafe — CWD follows rename)
-const extractUsing7zaRc4 = `!macro extractUsing7za FILE
-  ; Markus patch: automatic cleanup + direct extract into $INSTDIR.
-  ; Never CopyFiles, never MessageBox $(appCannotBeClosed), never ask the
-  ; user to manually delete a broken install folder.
-  DetailPrint "Markus: auto-clean INSTDIR + direct 7z extract"
-  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
-  Pop $0
-  Sleep 800
-
-  ; Leftover from a previous interrupted upgrade
-  RMDir /r "$INSTDIR.__markus_old"
-
-  IfFileExists "$INSTDIR\\*.*" 0 markus_extract_fresh
-    DetailPrint "Moving previous install aside (automatic — no user action needed)"
-    ClearErrors
-    Rename "$INSTDIR" "$INSTDIR.__markus_old"
-    IfErrors 0 markus_extract_fresh
-      DetailPrint "Rename failed; removing previous files in place"
-      RMDir /r "$INSTDIR"
-  markus_extract_fresh:
-  ClearErrors
-  CreateDirectory "$INSTDIR"
-  SetOutPath "$INSTDIR"
-  Nsis7z::Extract "\${FILE}"
-
-  ; Best-effort delete of the aside tree after files are replaced
-  IfFileExists "$INSTDIR.__markus_old" 0 markus_extract_done
-    RMDir /r "$INSTDIR.__markus_old"
-    nsExec::ExecToStack '"$SYSDIR\\cmd.exe" /C if exist "$INSTDIR.__markus_old" rmdir /s /q "$INSTDIR.__markus_old" >nul 2>&1'
-    Pop $0
-  markus_extract_done:
-!macroend`;
-
-// rc.3: direct extract but no automatic INSTDIR cleanup
-const extractUsing7zaRc3 = `!macro extractUsing7za FILE
-  ; Markus patch: direct extract into $INSTDIR. Never CopyFiles, never
-  ; MessageBox $(appCannotBeClosed).
-  DetailPrint "Markus: direct 7z extract into $INSTDIR"
-  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
-  Pop $0
-  Sleep 500
-  ClearErrors
-  SetOutPath "$INSTDIR"
-  Nsis7z::Extract "\${FILE}"
-!macroend`;
-
-const extractUsing7zaStock = `!macro extractUsing7za FILE
-  Push $OUTDIR
-  CreateDirectory "$PLUGINSDIR\\7z-out"
-  ClearErrors
-  SetOutPath "$PLUGINSDIR\\7z-out"
-  Nsis7z::Extract "\${FILE}"
-  Pop $R0
-  SetOutPath $R0
-
-  # Retry counter
-  StrCpy $R1 0
-
-  LoopExtract7za:
-    IntOp $R1 $R1 + 1
-
-    # Attempt to copy files in atomic way
-    CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR
-    IfErrors 0 DoneExtract7za
-
-    DetailPrint \`Can't modify "\${PRODUCT_NAME}"'s files.\`
-    \${if} $R1 < 5
-      # Try copying a few times before asking for a user action.
-      Goto RetryExtract7za
-    \${else}
-      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDRETRY IDCANCEL AbortExtract7za
-    \${endIf}
-
-    # As an absolutely last resort after a few automatic attempts and user
-    # intervention - we will just overwrite everything with \`Nsis7z::Extract\`
-    # even though it is not atomic and will ignore errors.
-
-    # Clear the temporary folder first to make sure we don't use twice as
-    # much disk space.
-    RMDir /r "$PLUGINSDIR\\7z-out"
-
-    Nsis7z::Extract "\${FILE}"
-    Goto DoneExtract7za
-
-  AbortExtract7za:
-    Quit
-
-  RetryExtract7za:
-    Sleep 1000
-    Goto LoopExtract7za
-
-  DoneExtract7za:
-!macroend`;
-
-// Intermediate (rc.2): kept CopyFiles loop but removed MessageBox.
-const extractUsing7zaRc2 = `!macro extractUsing7za FILE
-  Push $OUTDIR
-  CreateDirectory "$PLUGINSDIR\\7z-out"
-  ClearErrors
-  SetOutPath "$PLUGINSDIR\\7z-out"
-  Nsis7z::Extract "\${FILE}"
-  Pop $R0
-  SetOutPath $R0
-
-  # Retry counter
-  StrCpy $R1 0
-
-  LoopExtract7za:
-    IntOp $R1 $R1 + 1
-
-    # Attempt to copy files in atomic way
-    CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR
-    IfErrors 0 DoneExtract7za
-
-    DetailPrint \`Can't modify "\${PRODUCT_NAME}"'s files.\`
-    \${if} $R1 < 5
-      # Retry a few times, then force-extract (never ask the user).
-      Sleep 1000
-      Goto LoopExtract7za
-    \${endIf}
-
-    ; Markus patch: never show $(appCannotBeClosed) during extract.
-    ; AV / indexer / leftover OpenConsole can lock INSTDIR even when Markus
-    ; itself is not running. Force non-atomic 7z extract into $OUTDIR.
-    DetailPrint "CopyFiles into INSTDIR failed; forcing direct 7z extract (no dialog)"
-    nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
-    Pop $0
-    Sleep 500
-    RMDir /r "$PLUGINSDIR\\7z-out"
-    Nsis7z::Extract "\${FILE}"
-
-  DoneExtract7za:
-!macroend`;
-
-patchFirstMatch(
-  extractAppPackage,
-  [extractUsing7zaStock, extractUsing7zaRc2, extractUsing7zaRc3, extractUsing7zaRc4],
-  extractUsing7zaDirect,
+!macroend`,
   'extractAppPackage.nsh',
-  'safe auto-clean INSTDIR + direct 7z extract',
 );
 
-// ── Sanity checks (live symbols only; comments may mention these names) ───
+// ── Sanity: final templates must match the contract ───────────────────────
 const allowSrc = readFileSync(allowOnlyOne, 'utf8');
-if (/!include\s+"getProcessInfo\.nsh"/.test(allowSrc) || /^\s*Var pid\s*$/m.test(allowSrc)) {
-  throw new Error('[patch-nsis] allowOnlyOneInstallerInstance.nsh still has getProcessInfo include or Var pid');
-}
-
 const utilSrc = readFileSync(installUtil, 'utf8');
-if (/^\s*OneMoreAttempt:\s*$/m.test(utilSrc) || /IDRETRY OneMoreAttempt/.test(utilSrc)) {
-  throw new Error('[patch-nsis] installUtil.nsh still references OneMoreAttempt');
+const extractSrc = readFileSync(extractAppPackage, 'utf8');
+
+if (/!include\s+"getProcessInfo\.nsh"/.test(allowSrc) || /^\s*Var pid\s*$/m.test(allowSrc)) {
+  throw new Error('[patch-nsis] allowOnlyOne still has getProcessInfo / Var pid');
 }
-if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.test(utilSrc)) {
-  throw new Error('[patch-nsis] installUtil.nsh still has appCannotBeClosed MessageBox');
+if (/^\s*MessageBox[^\n]*\$\(appCannotBeClosed\)/m.test(allowSrc)) {
+  throw new Error('[patch-nsis] allowOnlyOne still MessageBox appCannotBeClosed');
+}
+if (/^\s*MessageBox[^\n]*\$\(appCannotBeClosed\)/m.test(utilSrc)) {
+  throw new Error('[patch-nsis] installUtil still MessageBox appCannotBeClosed');
+}
+if (/^\s*OneMoreAttempt:\s*$/m.test(utilSrc)) {
+  throw new Error('[patch-nsis] installUtil still has OneMoreAttempt label');
 }
 if (!/StrCpy \$R0 0/.test(utilSrc)) {
-  throw new Error('[patch-nsis] installUtil.nsh continue path must clear $R0 (StrCpy $R0 0)');
-}
-
-const extractSrc = readFileSync(extractAppPackage, 'utf8');
-if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh still has appCannotBeClosed MessageBox');
+  throw new Error('[patch-nsis] installUtil continue path must clear $R0');
 }
 if (/CopyFiles \/SILENT/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh must not use atomic CopyFiles');
+  throw new Error('[patch-nsis] extractAppPackage must not use CopyFiles');
 }
-if (!/safe auto-clean INSTDIR \+ direct 7z extract/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh missing safe auto-clean direct-extract path');
+if (/Rename "\$INSTDIR"/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage must not Rename INSTDIR');
 }
-if (/Rename "\$INSTDIR" "\$INSTDIR\.__markus_old"/.test(extractSrc)) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh must not Rename INSTDIR (CWD-follow bug)');
+if (/^\s*MessageBox[^\n]*\$\(appCannotBeClosed\)/m.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage still MessageBox appCannotBeClosed');
+}
+if (!extractSrc.includes('SetOutPath "$PLUGINSDIR"')) {
+  throw new Error('[patch-nsis] extract must leave INSTDIR before wipe');
 }
 if (!extractSrc.includes('Verified ${APP_EXECUTABLE_FILENAME} present')) {
-  throw new Error('[patch-nsis] extractAppPackage.nsh must verify APP_EXECUTABLE_FILENAME after extract');
+  throw new Error('[patch-nsis] extract must verify APP_EXECUTABLE_FILENAME');
 }
 
-// Neutralize leftover MessageBox inside unused stock _CHECK_APP_RUNNING
-// (never inserted after our CHECK_APP_RUNNING rewrite, but keep templates clean).
-patchFirstMatch(
-  allowOnlyOne,
-  [
-    `        \${if} $R1 > 1
-          MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY loop
-          Quit
-        \${else}
-          Goto loop
-        \${endIf}`,
-  ],
-  `        \${if} $R1 > 1
-          ; Markus patch: unused _CHECK_APP_RUNNING must not MessageBox either.
-          DetailPrint "app still running after kills; continuing (no dialog)"
-          Goto not_running
-        \${else}
-          Goto loop
-        \${endIf}`,
-  'allowOnlyOneInstallerInstance.nsh',
-  'neutralize _CHECK_APP_RUNNING appCannotBeClosed',
-);
-
-// Absolute: no MessageBox with that string in the templates we ship.
-for (const rel of [
-  'include/allowOnlyOneInstallerInstance.nsh',
-  'include/installUtil.nsh',
-  'include/extractAppPackage.nsh',
-]) {
-  const src = readFileSync(join(templatesDir, rel), 'utf8');
-  if (/^\s*MessageBox[^\n]*\$\(appCannotBeClosed\)/m.test(src)) {
-    throw new Error(`[patch-nsis] ${rel} still MessageBox $(appCannotBeClosed)`);
-  }
-}
-
-console.log('[patch-nsis] done');
+console.log('[patch-nsis] done — contract OK');

--- a/packages/desktop/scripts/patch-nsis-templates.mjs
+++ b/packages/desktop/scripts/patch-nsis-templates.mjs
@@ -60,6 +60,7 @@ console.log(`[patch-nsis] templates: ${templatesDir}`);
 
 const allowOnlyOne = join(templatesDir, 'include', 'allowOnlyOneInstallerInstance.nsh');
 const installUtil = join(templatesDir, 'include', 'installUtil.nsh');
+const extractAppPackage = join(templatesDir, 'include', 'extractAppPackage.nsh');
 
 // ── 1) allowOnlyOneInstallerInstance.nsh ─────────────────────────────────
 
@@ -85,6 +86,27 @@ patchFirstMatch(
 );
 
 // Never MessageBox/Quit on "app running" — best-effort taskkill only.
+const checkAppRunningNew = `!macro CHECK_APP_RUNNING
+  ; Markus patch: never block install/uninstall on process detection.
+  ; Stock PowerShell Path.StartsWith($INSTDIR) false-positives and shows
+  ; $(appCannotBeClosed). Only best-effort kill; always continue.
+  ; Also kill node-pty helpers that can lock INSTDIR during upgrades.
+  DetailPrint "Best-effort stop of \${APP_EXECUTABLE_FILENAME} + helpers (never blocks)..."
+  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
+  Pop $0
+  Sleep 600
+!macroend`;
+
+const checkAppRunningOldPatch = `!macro CHECK_APP_RUNNING
+  ; Markus patch: never block install/uninstall on process detection.
+  ; Stock PowerShell Path.StartsWith($INSTDIR) false-positives and shows
+  ; $(appCannotBeClosed). Only best-effort kill; always continue.
+  DetailPrint "Best-effort stop of \${APP_EXECUTABLE_FILENAME} (never blocks)..."
+  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1'
+  Pop $0
+  Sleep 600
+!macroend`;
+
 patchFirstMatch(
   allowOnlyOne,
   [
@@ -100,16 +122,9 @@ patchFirstMatch(
     !insertmacro _CHECK_APP_RUNNING
   !endif
 !macroend`,
+    checkAppRunningOldPatch,
   ],
-  `!macro CHECK_APP_RUNNING
-  ; Markus patch: never block install/uninstall on process detection.
-  ; Stock PowerShell Path.StartsWith($INSTDIR) false-positives and shows
-  ; $(appCannotBeClosed). Only best-effort kill; always continue.
-  DetailPrint "Best-effort stop of \${APP_EXECUTABLE_FILENAME} (never blocks)..."
-  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1'
-  Pop $0
-  Sleep 600
-!macroend`,
+  checkAppRunningNew,
   'allowOnlyOneInstallerInstance.nsh',
   'CHECK_APP_RUNNING',
 );
@@ -168,6 +183,85 @@ patchFirstMatch(
   'UninstallLoop continue + clear $R0 + drop OneMoreAttempt',
 );
 
+// ── 3) extractAppPackage.nsh — THE dialog users still see on upgrades ─────
+// Stock CopyFiles into $INSTDIR can fail (AV, indexer, leftover OpenConsole,
+// half-deleted tree) and then shows the SAME $(appCannotBeClosed) string as
+// the process check — even when Markus.exe is not running. After a few
+// retries, force non-atomic 7z extract and never MessageBox/Quit.
+
+// Replace the whole retry/MessageBox/force/Abort block so AbortExtract7za
+// is removed (unused label → makensis 6012 warning-as-error).
+const extractStock = `  LoopExtract7za:
+    IntOp $R1 $R1 + 1
+
+    # Attempt to copy files in atomic way
+    CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR
+    IfErrors 0 DoneExtract7za
+
+    DetailPrint \`Can't modify "\${PRODUCT_NAME}"'s files.\`
+    \${if} $R1 < 5
+      # Try copying a few times before asking for a user action.
+      Goto RetryExtract7za
+    \${else}
+      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDRETRY IDCANCEL AbortExtract7za
+    \${endIf}
+
+    # As an absolutely last resort after a few automatic attempts and user
+    # intervention - we will just overwrite everything with \`Nsis7z::Extract\`
+    # even though it is not atomic and will ignore errors.
+
+    # Clear the temporary folder first to make sure we don't use twice as
+    # much disk space.
+    RMDir /r "$PLUGINSDIR\\7z-out"
+
+    Nsis7z::Extract "\${FILE}"
+    Goto DoneExtract7za
+
+  AbortExtract7za:
+    Quit
+
+  RetryExtract7za:
+    Sleep 1000
+    Goto LoopExtract7za
+
+  DoneExtract7za:
+!macroend`;
+
+const extractForce = `  LoopExtract7za:
+    IntOp $R1 $R1 + 1
+
+    # Attempt to copy files in atomic way
+    CopyFiles /SILENT "$PLUGINSDIR\\7z-out\\*" $OUTDIR
+    IfErrors 0 DoneExtract7za
+
+    DetailPrint \`Can't modify "\${PRODUCT_NAME}"'s files.\`
+    \${if} $R1 < 5
+      # Retry a few times, then force-extract (never ask the user).
+      Sleep 1000
+      Goto LoopExtract7za
+    \${endIf}
+
+    ; Markus patch: never show $(appCannotBeClosed) during extract.
+    ; AV / indexer / leftover OpenConsole can lock INSTDIR even when Markus
+    ; itself is not running. Force non-atomic 7z extract into $OUTDIR.
+    DetailPrint "CopyFiles into INSTDIR failed; forcing direct 7z extract (no dialog)"
+    nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
+    Pop $0
+    Sleep 500
+    RMDir /r "$PLUGINSDIR\\7z-out"
+    Nsis7z::Extract "\${FILE}"
+
+  DoneExtract7za:
+!macroend`;
+
+patchFirstMatch(
+  extractAppPackage,
+  [extractStock],
+  extractForce,
+  'extractAppPackage.nsh',
+  'force extract without appCannotBeClosed dialog',
+);
+
 // ── Sanity checks (live symbols only; comments may mention these names) ───
 const allowSrc = readFileSync(allowOnlyOne, 'utf8');
 if (/!include\s+"getProcessInfo\.nsh"/.test(allowSrc) || /^\s*Var pid\s*$/m.test(allowSrc)) {
@@ -183,6 +277,46 @@ if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.te
 }
 if (!/StrCpy \$R0 0/.test(utilSrc)) {
   throw new Error('[patch-nsis] installUtil.nsh continue path must clear $R0 (StrCpy $R0 0)');
+}
+
+const extractSrc = readFileSync(extractAppPackage, 'utf8');
+if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh still has appCannotBeClosed MessageBox');
+}
+
+// Neutralize leftover MessageBox inside unused stock _CHECK_APP_RUNNING
+// (never inserted after our CHECK_APP_RUNNING rewrite, but keep templates clean).
+patchFirstMatch(
+  allowOnlyOne,
+  [
+    `        \${if} $R1 > 1
+          MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(appCannotBeClosed)" /SD IDCANCEL IDRETRY loop
+          Quit
+        \${else}
+          Goto loop
+        \${endIf}`,
+  ],
+  `        \${if} $R1 > 1
+          ; Markus patch: unused _CHECK_APP_RUNNING must not MessageBox either.
+          DetailPrint "app still running after kills; continuing (no dialog)"
+          Goto not_running
+        \${else}
+          Goto loop
+        \${endIf}`,
+  'allowOnlyOneInstallerInstance.nsh',
+  'neutralize _CHECK_APP_RUNNING appCannotBeClosed',
+);
+
+// Absolute: no MessageBox with that string in the templates we ship.
+for (const rel of [
+  'include/allowOnlyOneInstallerInstance.nsh',
+  'include/installUtil.nsh',
+  'include/extractAppPackage.nsh',
+]) {
+  const src = readFileSync(join(templatesDir, rel), 'utf8');
+  if (/^\s*MessageBox[^\n]*\$\(appCannotBeClosed\)/m.test(src)) {
+    throw new Error(`[patch-nsis] ${rel} still MessageBox $(appCannotBeClosed)`);
+  }
 }
 
 console.log('[patch-nsis] done');

--- a/packages/desktop/scripts/patch-nsis-templates.mjs
+++ b/packages/desktop/scripts/patch-nsis-templates.mjs
@@ -118,7 +118,21 @@ patchFirstMatch(
 // Stock MessageBox jumps to OneMoreAttempt; fall-through does NOT count as a
 // label reference in makensis. Removing only the MessageBox → warning 6012.
 
+// CRITICAL: must clear $R0 to 0. handleUninstallResult Quits when $R0 != 0
+// unless customUnInstallCheck is defined. Returning with a stale non-zero $R0
+// after "continue" either aborts the upgrade or (with a weak check macro)
+// continues over a half-deleted tree while still looking failed.
 const uninstallContinue = `    \${if} $R5 > 5
+      ; Markus patch: continue with overwrite install instead of blocking.
+      DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
+      StrCpy $R0 0
+      ClearErrors
+      Return
+    \${endIf}
+`;
+
+// Already-patched variant that forgot StrCpy $R0 0 (rc.13–0.9.2).
+const uninstallContinueBroken = `    \${if} $R5 > 5
       ; Markus patch: continue with overwrite install instead of blocking.
       DetailPrint "Previous uninstaller failed after retries; continuing overwrite install"
       ClearErrors
@@ -145,11 +159,13 @@ patchFirstMatch(
     \${endIf}
 
   OneMoreAttempt:`,
+    // Applied continue patch without clearing $R0
+    uninstallContinueBroken,
   ],
   `${uninstallContinue}
 `,
   'installUtil.nsh',
-  'UninstallLoop continue + drop OneMoreAttempt',
+  'UninstallLoop continue + clear $R0 + drop OneMoreAttempt',
 );
 
 // ── Sanity checks (live symbols only; comments may mention these names) ───
@@ -164,6 +180,9 @@ if (/^\s*OneMoreAttempt:\s*$/m.test(utilSrc) || /IDRETRY OneMoreAttempt/.test(ut
 }
 if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.test(utilSrc)) {
   throw new Error('[patch-nsis] installUtil.nsh still has appCannotBeClosed MessageBox');
+}
+if (!/StrCpy \$R0 0/.test(utilSrc)) {
+  throw new Error('[patch-nsis] installUtil.nsh continue path must clear $R0 (StrCpy $R0 0)');
 }
 
 console.log('[patch-nsis] done');

--- a/packages/desktop/scripts/patch-nsis-templates.mjs
+++ b/packages/desktop/scripts/patch-nsis-templates.mjs
@@ -183,15 +183,39 @@ patchFirstMatch(
   'UninstallLoop continue + clear $R0 + drop OneMoreAttempt',
 );
 
-// ── 3) extractAppPackage.nsh — THE dialog users still see on upgrades ─────
-// Stock CopyFiles into $INSTDIR can fail (AV, indexer, leftover OpenConsole,
-// half-deleted tree) and then shows the SAME $(appCannotBeClosed) string as
-// the process check — even when Markus.exe is not running. After a few
-// retries, force non-atomic 7z extract and never MessageBox/Quit.
+// ── 3) extractAppPackage.nsh — kill the atomic CopyFiles path entirely ───
+// Stock flow: 7z → $PLUGINSDIR\7z-out → CopyFiles → $INSTDIR. When CopyFiles
+// fails (AV, indexer, leftover OpenConsole, half-deleted tree) it shows the
+// SAME $(appCannotBeClosed) dialog as the process check — even when Markus
+// is not running. Cancel → Quit → incomplete install → no shortcuts.
+//
+// Markus: always extract straight into $INSTDIR. No CopyFiles, no dialog.
 
-// Replace the whole retry/MessageBox/force/Abort block so AbortExtract7za
-// is removed (unused label → makensis 6012 warning-as-error).
-const extractStock = `  LoopExtract7za:
+const extractUsing7zaDirect = `!macro extractUsing7za FILE
+  ; Markus patch: direct extract into $INSTDIR. Never CopyFiles, never
+  ; MessageBox $(appCannotBeClosed).
+  DetailPrint "Markus: direct 7z extract into $INSTDIR"
+  nsExec::ExecToLog '"$SYSDIR\\cmd.exe" /C taskkill /F /T /IM "\${APP_EXECUTABLE_FILENAME}" >nul 2>&1 & taskkill /F /T /IM "elevate.exe" >nul 2>&1 & taskkill /F /T /IM "OpenConsole.exe" >nul 2>&1 & taskkill /F /T /IM "winpty-agent.exe" >nul 2>&1'
+  Pop $0
+  Sleep 500
+  ClearErrors
+  SetOutPath "$INSTDIR"
+  Nsis7z::Extract "\${FILE}"
+!macroend`;
+
+const extractUsing7zaStock = `!macro extractUsing7za FILE
+  Push $OUTDIR
+  CreateDirectory "$PLUGINSDIR\\7z-out"
+  ClearErrors
+  SetOutPath "$PLUGINSDIR\\7z-out"
+  Nsis7z::Extract "\${FILE}"
+  Pop $R0
+  SetOutPath $R0
+
+  # Retry counter
+  StrCpy $R1 0
+
+  LoopExtract7za:
     IntOp $R1 $R1 + 1
 
     # Attempt to copy files in atomic way
@@ -227,7 +251,20 @@ const extractStock = `  LoopExtract7za:
   DoneExtract7za:
 !macroend`;
 
-const extractForce = `  LoopExtract7za:
+// Intermediate (rc.2): kept CopyFiles loop but removed MessageBox.
+const extractUsing7zaRc2 = `!macro extractUsing7za FILE
+  Push $OUTDIR
+  CreateDirectory "$PLUGINSDIR\\7z-out"
+  ClearErrors
+  SetOutPath "$PLUGINSDIR\\7z-out"
+  Nsis7z::Extract "\${FILE}"
+  Pop $R0
+  SetOutPath $R0
+
+  # Retry counter
+  StrCpy $R1 0
+
+  LoopExtract7za:
     IntOp $R1 $R1 + 1
 
     # Attempt to copy files in atomic way
@@ -256,10 +293,10 @@ const extractForce = `  LoopExtract7za:
 
 patchFirstMatch(
   extractAppPackage,
-  [extractStock],
-  extractForce,
+  [extractUsing7zaStock, extractUsing7zaRc2],
+  extractUsing7zaDirect,
   'extractAppPackage.nsh',
-  'force extract without appCannotBeClosed dialog',
+  'direct 7z extract (no CopyFiles / no dialog)',
 );
 
 // ── Sanity checks (live symbols only; comments may mention these names) ───
@@ -282,6 +319,12 @@ if (!/StrCpy \$R0 0/.test(utilSrc)) {
 const extractSrc = readFileSync(extractAppPackage, 'utf8');
 if (/MessageBox MB_RETRYCANCEL\|MB_ICONEXCLAMATION "\$\(appCannotBeClosed\)"/.test(extractSrc)) {
   throw new Error('[patch-nsis] extractAppPackage.nsh still has appCannotBeClosed MessageBox');
+}
+if (/CopyFiles \/SILENT/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh must not use atomic CopyFiles');
+}
+if (!/direct 7z extract into \$INSTDIR/.test(extractSrc)) {
+  throw new Error('[patch-nsis] extractAppPackage.nsh missing direct-extract path');
 }
 
 // Neutralize leftover MessageBox inside unused stock _CHECK_APP_RUNNING

--- a/packages/desktop/src/menu.ts
+++ b/packages/desktop/src/menu.ts
@@ -238,7 +238,7 @@ export function setupMenu(backendUrl: string): void {
         { type: 'separator' },
         ...(IS_MAS ? [{
           label: t['upgradeToFull'],
-          click: () => shell.openExternal('https://markus.global/download'),
+          click: () => shell.openExternal('https://markus.global/#download'),
         }] : [{
           label: t['checkForUpdates'],
           click: async () => {

--- a/packages/desktop/src/windows-shortcuts.ts
+++ b/packages/desktop/src/windows-shortcuts.ts
@@ -2,14 +2,17 @@ import { app } from 'electron';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { join } from 'node:path';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 
 const execFileAsync = promisify(execFile);
 
 /**
  * Ensure Desktop + Start Menu shortcuts exist on Windows.
- * NSIS assisted upgrades often skip desktop shortcut recreation; this runs
- * once per version from the app itself as a reliable fallback.
+ *
+ * NSIS assisted upgrades historically delete .lnk in customUnInstall while
+ * stock install skips recreation ($keepShortcuts). Repair whenever either
+ * shortcut is missing — not only once per version — so a broken upgrade can
+ * self-heal on the next successful launch.
  */
 export async function ensureWindowsShortcuts(): Promise<void> {
   if (process.platform !== 'win32' || !app.isPackaged) return;
@@ -17,11 +20,42 @@ export async function ensureWindowsShortcuts(): Promise<void> {
   const exePath = process.execPath;
   if (!exePath || !existsSync(exePath)) return;
 
-  const marker = join(app.getPath('userData'), `.shortcuts-${app.getVersion()}`);
-  if (existsSync(marker)) return;
-
   const name = 'Markus';
-  const ps = `
+  const marker = join(app.getPath('userData'), `.shortcuts-${app.getVersion()}`);
+
+  const checkPs = `
+$ErrorActionPreference = 'Stop'
+$name = ${JSON.stringify(name)}
+$missing = $false
+foreach ($dir in @([Environment]::GetFolderPath('Desktop'), [Environment]::GetFolderPath('StartMenu'))) {
+  if (-not $dir) { continue }
+  $lnk = Join-Path $dir ($name + '.lnk')
+  if (-not (Test-Path -LiteralPath $lnk)) { $missing = $true; break }
+}
+if ($missing) { exit 2 } else { exit 0 }
+`;
+
+  let needsRepair = !existsSync(marker);
+  if (!needsRepair) {
+    try {
+      await execFileAsync(
+        'powershell.exe',
+        ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', checkPs],
+        { windowsHide: true, timeout: 10000 },
+      );
+    } catch (err: unknown) {
+      const code = typeof err === 'object' && err && 'code' in err ? (err as { code?: number }).code : undefined;
+      if (code === 2) needsRepair = true;
+      else {
+        // Checker failed unexpectedly — still try to recreate once.
+        needsRepair = true;
+      }
+    }
+  }
+
+  if (!needsRepair) return;
+
+  const createPs = `
 $ErrorActionPreference = 'Stop'
 $exe = ${JSON.stringify(exePath)}
 $name = ${JSON.stringify(name)}
@@ -40,10 +74,9 @@ foreach ($dir in @([Environment]::GetFolderPath('Desktop'), [Environment]::GetFo
   try {
     await execFileAsync(
       'powershell.exe',
-      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', ps],
+      ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-Command', createPs],
       { windowsHide: true, timeout: 15000 },
     );
-    const { writeFileSync } = await import('node:fs');
     writeFileSync(marker, new Date().toISOString(), 'utf8');
     console.log('[shortcuts] Desktop/Start Menu shortcuts ensured');
   } catch (err) {

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -21,5 +21,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -17,5 +17,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,5 +9,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/shared/src/mas.ts
+++ b/packages/shared/src/mas.ts
@@ -37,5 +37,5 @@ export function isToolRestrictedInMAS(toolName: string): boolean {
 export function getMASToolBlockedMessage(toolName: string): string {
   return `This action (${toolName}) requires the full version of Markus. ` +
     `The App Store version cannot execute shell commands or access arbitrary files due to macOS sandbox restrictions. ` +
-    `Download the full version at https://markus.global/download for unrestricted access.`;
+    `Download the full version at https://markus.global/#download for unrestricted access.`;
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,5 +12,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.0"
+  "version": "0.9.3-rc.1"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.1"
+  "version": "0.9.3-rc.2"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.4"
+  "version": "0.9.3-rc.5"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.3"
+  "version": "0.9.3-rc.4"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.6"
+  "version": "0.9.3-rc.7"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.5"
+  "version": "0.9.3-rc.6"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.2"
+  "version": "0.9.3-rc.3"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.2"
+  "version": "0.9.3-rc.0"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -61,5 +61,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.3-rc.7"
+  "version": "0.9.3"
 }

--- a/packages/web-ui/src/App.tsx
+++ b/packages/web-ui/src/App.tsx
@@ -854,7 +854,7 @@ export function App() {
               {t('update.available', { latest: updateInfo.latestVersion, current: updateInfo.currentVersion })}
             </span>
             <span className="flex items-center gap-3 shrink-0">
-              <a href="https://markus.global/download" target="_blank" rel="noopener noreferrer" className="text-xs font-medium text-brand-400 hover:text-brand-300 transition-colors">{t('update.download')}</a>
+              <a href="https://markus.global/#download" target="_blank" rel="noopener noreferrer" className="text-xs font-medium text-brand-400 hover:text-brand-300 transition-colors">{t('update.download')}</a>
               <button onClick={() => { setUpdateBannerDismissed(updateInfo.latestVersion); localStorage.setItem('markus_update_dismissed', updateInfo.latestVersion); }} className="text-fg-tertiary hover:text-fg-secondary text-xs shrink-0">{t('dismiss')}</button>
             </span>
           </div>


### PR DESCRIPTION
## Summary
- Promote `0.9.3-rc.7` → stable **`0.9.3`** (`npm` tag `latest`)
- Windows NSIS: single verified install/upgrade path + shortcut repair
- Update/download links point to `https://markus.global/#download`

## Test plan
- [ ] Publish workflow succeeds (npm + Windows/macOS/Linux desktop artifacts)
- [ ] GitHub Release `v0.9.3` is marked stable (not pre-release)
- [ ] `npm view @markus-global/cli version` → `0.9.3`
- [ ] Windows: clean install / upgrade from 0.9.2 / reinstall all produce `Markus.exe` + shortcuts


Made with [Cursor](https://cursor.com)