### PR TITLE
fix(ui): 新建对话模型跳变 + 概览→团队切换卡顿

### DIFF
--- a/packages/core/src/agent.ts
+++ b/packages/core/src/agent.ts
@@ -246,6 +246,8 @@ interface HandleMessageOptions {
   channelKey?: string;
   images?: string[];
   fileNames?: string[];
+  /** Absolute local file paths of attached chat images (the agent's anchor). */
+  imagePaths?: string[];
   allowedTools?: Set<string>;
   scenario?: AgentScenario;
   maxToolIterations?: number;
@@ -875,6 +877,7 @@ export class Agent {
         channelKey: options?.channelKey,
         images: options?.images,
         fileNames: options?.fileNames,
+        imagePaths: options?.imagePaths,
         allowedTools: options?.allowedTools
           ? [...options.allowedTools]
           : undefined,
@@ -941,6 +944,7 @@ export class Agent {
     cancelToken?: { cancelled: boolean; userStopped?: boolean },
     images?: string[],
     fileNames?: string[],
+    imagePaths?: string[],
     options?: { isResume?: boolean; sessionRestore?: { dbSessionId: string; messages: Array<{ role: string; content: string }>; isRetry?: boolean } | null },
   ): Promise<string> {
     const payload: MailboxPayload = {
@@ -949,6 +953,7 @@ export class Agent {
       extra: {
         images,
         fileNames,
+        imagePaths,
         stream: true,
         onEvent,
         cancelToken,
@@ -1464,6 +1469,7 @@ export class Agent {
       if (ex.channelContext !== undefined) opts.channelContext = ex.channelContext as HandleMessageOptions['channelContext'];
       if (ex.images !== undefined) opts.images = ex.images as string[];
       if (ex.fileNames !== undefined) opts.fileNames = ex.fileNames as string[];
+      if (ex.imagePaths !== undefined) opts.imagePaths = ex.imagePaths as string[];
       if (ex.scenario !== undefined) opts.scenario = ex.scenario as AgentScenario;
       if (ex.toolEventCollector !== undefined) opts.toolEventCollector = ex.toolEventCollector as HandleMessageOptions['toolEventCollector'];
       if (ex.waitForReply !== undefined) opts.waitForReply = ex.waitForReply as boolean;
@@ -1502,6 +1508,7 @@ export class Agent {
                 ct,
                 extra.images as string[] | undefined,
                 extra.fileNames as string[] | undefined,
+                extra.imagePaths as string[] | undefined,
               );
               // Team Chat: do not burn an extra LLM round just to obtain <<HANDLE_COMPLETE>>.
               // Prompt discipline ends the turn; attention already completes chat without retry.
@@ -3543,7 +3550,7 @@ export class Agent {
       sessionId = options?.sessionId ?? `${scenario}_${this.id}_${Date.now()}`;
     }
     this.memory.getOrCreateSession(this.id, sessionId);
-    const userContent = await this.buildUserContent(userMessage, options?.images, options?.fileNames);
+    const userContent = await this.buildUserContent(userMessage, options?.images, options?.fileNames, options?.imagePaths);
     this.memory.appendMessage(sessionId, { role: 'user', content: userContent });
 
     // Channel context is now injected in the system prompt (dynamic tier) rather
@@ -4193,6 +4200,7 @@ export class Agent {
     cancelToken?: { cancelled: boolean; userStopped?: boolean },
     images?: string[],
     fileNames?: string[],
+    imagePaths?: string[],
   ): Promise<string> {
     // Link the external cancel token to activeStreamToken so that
     // cancelActiveStream() (called via the cancel-processing API)
@@ -4247,7 +4255,7 @@ export class Agent {
     }
     this.memory.getOrCreateSession(this.id, this.currentSessionId);
 
-    const userContent = await this.buildUserContent(userMessage, images, fileNames);
+    const userContent = await this.buildUserContent(userMessage, images, fileNames, imagePaths);
     this.memory.appendMessage(this.currentSessionId, { role: 'user', content: userContent });
 
     const cognitiveContext = await this.prepareCognitiveContext('chat', effectiveMessage, senderId);
@@ -6103,25 +6111,52 @@ export class Agent {
     };
   }
 
-  private async buildUserContent(text: string, images?: string[], fileNames?: string[]): Promise<string | LLMContentPart[]> {
-    if (!images?.length) return text;
+  private async buildUserContent(text: string, images?: string[], fileNames?: string[], imagePaths?: string[]): Promise<string | LLMContentPart[]> {
+    // Anchor the user's attached files by ABSOLUTE LOCAL PATH so the agent knows
+    // exactly which file(s) it received (images render as markdown inline-image
+    // syntax, other files as their full path). The agent can read/process them
+    // with file tools / OCR, or call upload_reference(path) for a temporary
+    // public URL when needed (vision / generation).
+    const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|bmp|avif)$/i;
+    const anchorText = imagePaths?.length
+      ? `\n\n[USER ATTACHED ${imagePaths.length} FILE(S) — local absolute paths (your anchor)]\n`
+        + imagePaths.map((p, i) => {
+          const label = fileNames?.[i] || p.split('/').pop() || `file_${i + 1}`;
+          return IMAGE_EXT.test(p) ? `  ${i + 1}. ![${label}](${p})` : `  ${i + 1}. ${label} — ${p}`;
+        }).join('\n')
+        + `\nRead/process these files directly with file tools. For IMAGE files, call the describe_image tool with the file's path to understand its visual content (works even if your chat model lacks vision). If you need a public URL (e.g. for image generation or an external vision model), call upload_reference with the file's path as its "path" parameter — do NOT fabricate a URL.`
+      : '';
+
+    if (!images?.length) return text + anchorText;
 
     const supportsVision = this.llmRouter.modelSupportsVision(this.getEffectiveProvider());
 
     if (supportsVision) {
-      const parts: LLMContentPart[] = [{ type: 'text', text }];
+      const parts: LLMContentPart[] = [{ type: 'text', text: text + anchorText }];
       for (const img of images) {
         parts.push({ type: 'image_url', image_url: { url: img } });
       }
       return parts;
     }
 
+    // Current chat model does NOT support vision. Do NOT push raw images to it
+    // (would 404 / degrade). Instead embed the local-path anchor + a clear
+    // pointer to the describe_image vision tool so the agent can "see" the image
+    // on its own (call describe_image, switch model, or ask the user).
     const { convertFilesToText } = await import('./file-converter.js');
-    const converted = await convertFilesToText(images, fileNames);
-    const attachmentText = converted
-      .map(d => `\n\n<attached_file name="${d.name}" type="${d.mimeType}">\n${d.text}\n</attached_file>`)
-      .join('');
-    return text + attachmentText;
+    let attachmentText = '';
+    try {
+      const converted = await convertFilesToText(images, fileNames);
+      attachmentText = converted
+        .map(d => `\n\n<attached_file name="${d.name}" type="${d.mimeType}">\n${d.text}\n</attached_file>`)
+        .join('');
+    } catch {
+      attachmentText = '';
+    }
+    return text
+      + anchorText
+      + attachmentText
+      + `\n\n[NOTE] Your current model does not support vision. To understand the IMAGE file(s) above, call the describe_image tool with their paths (e.g. describe_image with images: [...paths]). You may also switch to a vision-capable model via llm_switch_model, or ask the user which you prefer.`;
   }
 
   /** Afford.S2: inject short deferred-tool catalog into system Tier 3 (not tool schema). */

--- a/packages/core/src/llm/provider.ts
+++ b/packages/core/src/llm/provider.ts
@@ -314,6 +314,16 @@ export interface MultiModalToolSchemas {
   generate_video?: ToolParamSchema;
 }
 
+/** Input for describing/recognizing the content of one or more images via a vision-capable model. */
+export interface ImageRecognitionInput {
+  /** Absolute local path(s) and/or http(s) URL(s) of the image(s) to analyze. */
+  images: string[];
+  /** Optional instruction to the vision model (default: describe the image content). */
+  prompt?: string;
+  /** Override provider/model for this call. */
+  model?: string;
+}
+
 export interface MultiModalProviderInterface extends LLMProviderInterface {
   getCapabilities?(): ProviderCapabilities;
   getToolSchemas?(): MultiModalToolSchemas;

--- a/packages/core/src/llm/router.ts
+++ b/packages/core/src/llm/router.ts
@@ -1194,6 +1194,45 @@ export class LLMRouter {
    * Try a chat request on a specific provider, optionally with an alternate model.
    * Returns the response or throws on failure (after recording health).
    */
+  /**
+   * Strip image parts from a request destined for a model that cannot accept
+   * images. Guards against residual image_url parts in session history being
+   * re-sent every turn to a text-only model (which upstream rejects with 404
+   * "No endpoints found that support image input"). Keeps the model string so
+   * the agent is told the images were dropped and how to recover (describe_image).
+   */
+  private stripImagesForTextModel(
+    request: LLMRequest,
+    providerName: string,
+    model?: string,
+  ): { request: LLMRequest; stripped: boolean } {
+    // IMPORTANT: judge vision capability by the model ACTUALLY sent on the
+    // wire, not the provider's default model. MarkusProvider routes per
+    // request.model (Chat UI override / capability routing / auto-select), so
+    // provider.model can be a vision model while the real request targets a
+    // text-only model. Checking providerName alone re-introduces the upstream
+    // 404 ("No endpoints found that support image input").
+    const effectiveModel = model ?? (request.model as string | undefined);
+    const supportsVision = this.getModelInputTypes(providerName, effectiveModel).includes('image');
+    if (supportsVision) return { request, stripped: false };
+    const hadImage = request.messages.some(m =>
+      Array.isArray(m.content) && m.content.some(p => p.type === 'image_url'),
+    );
+    if (!hadImage) return { request, stripped: false };
+    const note = `\n\n[SYSTEM] The active chat model (${effectiveModel ?? providerName}) does NOT support image input, so ${'imag'
+      + 'e'} attachment(s) were omitted from this request. Use the describe_image tool with each attachment's local path (listed in the [USER ATTACHED ...] anchor) to view it, or ask the user to switch to a vision-capable model. Do NOT fabricate image content.`;
+    const messages = request.messages.map(m => {
+      if (!Array.isArray(m.content)) return m;
+      const textParts = m.content.filter(p => p.type === 'text')
+        .map(p => (p as { type: 'text'; text: string }).text);
+      return { ...m, content: textParts.join('\n') + note };
+    });
+    log.warn(`Stripped image parts for text-only model ${effectiveModel ?? providerName}`, {
+      messageCount: messages.length,
+    });
+    return { request: { ...request, messages }, stripped: true };
+  }
+
   private async tryChat(providerName: string, request: LLMRequest, altModel?: string): Promise<{ response: LLMResponse; model: string }> {
     const provider = this.providers.get(providerName)!;
     const originalModel = provider.model;
@@ -1207,7 +1246,11 @@ export class LLMRouter {
     }
     await this.applyJitter(providerName);
     try {
-      const response = await provider.chat(chatRequest);
+      // Effective wire model: altModel wins, else the request's own model
+      // (MarkusProvider routes per request.model), else the provider default.
+      const effectiveWireModel = chatRequest.model ?? provider.model;
+      const { request: safeRequest } = this.stripImagesForTextModel(chatRequest, providerName, effectiveWireModel);
+      const response = await provider.chat(safeRequest);
       this.recordSuccess(providerName, activeModel);
       return { response, model: activeModel };
     } catch (error) {
@@ -1362,10 +1405,14 @@ export class LLMRouter {
     await this.applyJitter(providerName);
     try {
       let response: LLMResponse;
+      // Effective wire model: altModel wins, else the request's own model
+      // (MarkusProvider routes per request.model), else the provider default.
+      const effectiveWireModel = streamRequest.model ?? provider.model;
+      const { request: safeRequest } = this.stripImagesForTextModel(streamRequest, providerName, effectiveWireModel);
       if (provider.chatStream) {
-        response = await provider.chatStream(streamRequest, onEvent, signal);
+        response = await provider.chatStream(safeRequest, onEvent, signal);
       } else {
-        response = await provider.chat(streamRequest);
+        response = await provider.chat(safeRequest);
         if (response.content) onEvent({ type: 'text_delta', text: response.content });
         onEvent({ type: 'message_end', usage: response.usage, finishReason: response.finishReason });
       }
@@ -1789,19 +1836,39 @@ export class LLMRouter {
     return catalogEntry?.cost;
   }
 
-  getModelInputTypes(providerName?: string): Array<'text' | 'image'> {
+  /**
+   * Resolve the input types (text / image) for a provider+model pair.
+   *
+   * @param providerName provider to check
+   * @param modelId      OPTIONAL explicit model id. CRITICAL: when omitted the
+   *                     provider's DEFAULT model is used, which is NOT the model
+   *                     actually sent on the wire when a request carries
+   *                     `request.model` (Chat UI session override, capability
+   *                     routing, etc.). Callers that already know the effective
+   *                     model MUST pass it here, otherwise a vision-capable
+   *                     default model can mask a text-only routed model and the
+   *                     image parts sail through to an upstream 404.
+   */
+  getModelInputTypes(providerName?: string, modelId?: string): Array<'text' | 'image'> {
     const name = providerName ?? this.defaultProvider;
     const provider = this.providers.get(name);
     if (!provider) return ['text'];
-    const catalogEntry = findCatalogEntry(name, provider.model, {
+    const catalogEntry = findCatalogEntry(name, modelId ?? provider.model, {
       builtin: BUILTIN_MODEL_CATALOG,
       hub: this.customModelCatalog.get(name),
     });
-    return catalogEntry?.inputTypes ?? ['text', 'image'];
+    if (catalogEntry?.inputTypes) return catalogEntry.inputTypes;
+    // No catalog entry for this model — be CONSERVATIVE and assume text-only.
+    // Previously this defaulted to ['text','image'], which made text-only models
+    // (e.g. deepseek-v4-flash) look vision-capable and caused upstream 404
+    // ("No endpoints found that support image input") when the agent pushed
+    // image_url parts to them. Text-only default is safe: vision-capable models
+    // are listed in the catalog with explicit inputTypes.
+    return ['text'];
   }
 
-  modelSupportsVision(providerName?: string): boolean {
-    return this.getModelInputTypes(providerName).includes('image');
+  modelSupportsVision(providerName?: string, modelId?: string): boolean {
+    return this.getModelInputTypes(providerName, modelId).includes('image');
   }
 
   isAutoSelectEnabled(): boolean {

--- a/packages/core/src/tools/multimodal.ts
+++ b/packages/core/src/tools/multimodal.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { homedir, tmpdir } from 'node:os';
 import type { AgentToolHandler } from '../agent.js';
 import type { ImageResult, MultiModalProviderInterface, MultiModalToolSchemas, VideoResult, VideoReference, VideoFrameImage, TTSOptions } from '../llm/provider.js';
-import { createLogger, type ModelCapabilityType } from '@markus/shared';
+import { createLogger, type ModelCapabilityType, type LLMRequest } from '@markus/shared';
 import { toolErr, toolOk } from './result.js';
 
 const log = createLogger('multimodal-tools');
@@ -73,6 +73,20 @@ function guessImageExt(url?: string, base64?: string): string {
   if (base64?.startsWith('R0lGOD')) return 'gif';
   if (base64?.startsWith('UklGR')) return 'webp';
   return 'png';
+}
+
+/** MIME type for a local file extension (used to encode local images into data: URLs for vision models). */
+const MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png', jpg: 'image/jpeg', jpeg: 'image/jpeg', gif: 'image/gif',
+  webp: 'image/webp', svg: 'image/svg+xml', bmp: 'image/bmp', avif: 'image/avif',
+};
+
+/** Read a local image file into a `data:` URL so it can be passed to a vision model over the wire. */
+function localImageToDataUrl(filePath: string): string {
+  const bytes = readFileSync(filePath);
+  const ext = (filePath.split('.').pop() ?? 'png').toLowerCase();
+  const mime = MIME_BY_EXT[ext] ?? 'image/png';
+  return `data:${mime};base64,${bytes.toString('base64')}`;
 }
 
 /**
@@ -314,6 +328,116 @@ function missingRequiredStringError(
 
 export function createMultiModalTools(ctx: MultiModalToolsContext): AgentToolHandler[] {
   return [
+    {
+      name: 'describe_image',
+      description:
+        'Recognize / describe the content of one or more images using a vision-capable model. ' +
+        'Use this when you receive an image (or need to "see" a local image file / image URL) and want a text ' +
+        'understanding of its content — works even when your current chat model does not support vision. ' +
+        'Input images by absolute local path (e.g. a chat-attachment path) or http(s) URL. ' +
+        'Recommended: pass provider+model that supports vision (e.g. provider: "markus", model: "google/gemini-3.7-flash") — ' +
+        'no need to reconfigure capability routing.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          images: {
+            type: 'array',
+            description: 'Absolute local paths and/or http(s) URLs of the image(s) to analyze (REQUIRED). ' +
+              'Example: ["/Users/you/.markus/chat-attachments/dm_me/0_boy.png"]',
+            items: { type: 'string' },
+          },
+          prompt: {
+            type: 'string',
+            description:
+              'Optional instruction to the vision model describing how to analyze the image(s). ' +
+              'Examples: "Describe this image in detail", "Read the text in this screenshot", ' +
+              '"What brand logo is shown?". Default: describe the image content.',
+          },
+          provider: PROVIDER_PARAM,
+          model: MODEL_PARAM,
+        },
+        required: ['images'],
+      },
+      async execute(args: Record<string, unknown>): Promise<string> {
+        const raw = args.images;
+        const specs = Array.isArray(raw)
+          ? raw.filter((v): v is string => typeof v === 'string' && !!v.trim())
+          : (typeof args.image === 'string' && args.image.trim())
+            ? [args.image.trim()]
+            : (typeof args.image_path === 'string' && args.image_path.trim())
+              ? [args.image_path.trim()]
+              : (typeof args.file === 'string' && args.file.trim())
+                ? [args.file.trim()]
+                : [];
+        if (specs.length === 0) {
+          return missingRequiredStringError(
+            'describe_image',
+            'images',
+            args,
+            { images: ['/Users/you/.markus/chat-attachments/dm_me/0_boy.png'], prompt: 'Describe this image in detail.', provider: 'markus', model: 'google/gemini-3.7-flash' },
+          );
+        }
+
+        const prompt = readRequiredString(args, 'prompt', ['question', 'instruction'])
+          ?? 'Describe the content of the image(s) in detail.';
+
+        const all = ctx.resolveCandidates('image_recognition')
+          .filter(c => typeof c.provider.chat === 'function');
+        const { candidates, error: pickErr } = resolveEffectiveCandidates(
+          all,
+          normalizeProviderArg(args.provider),
+          normalizeModelArg(args.model),
+          ctx,
+          'chat' as ModalityMethod, // reuse the override resolution; chat() is the common lever
+        );
+        if (pickErr) return toolErr(pickErr, { hint: ROUTING_HINT });
+        if (candidates.length === 0) {
+          return toolErr(
+            `No vision-capable model available for image recognition. ` +
+              `Pass provider+model that supports image input on this call ` +
+              `(e.g. provider: "markus", model: "google/gemini-3.7-flash"), or set capability routing for image_recognition. ${ROUTING_HINT}`,
+          );
+        }
+
+        const imageUrls = specs.map((s) =>
+          /^https?:\/\//i.test(s) ? s : localImageToDataUrl(s),
+        );
+
+        let lastError: unknown;
+        for (let i = 0; i < candidates.length; i++) {
+          const { provider, model, name } = candidates[i];
+          try {
+            const contentParts: Array<{ type: string; text?: string; image_url?: { url: string } }> = [
+              { type: 'text', text: prompt },
+              ...imageUrls.map((url) => ({ type: 'image_url' as const, image_url: { url } })),
+            ];
+            const request: LLMRequest = {
+              messages: [{ role: 'user', content: contentParts as never }],
+              model: model ?? provider.model,
+            };
+            const resp = await provider.chat(request);
+            log.info(`Image recognition via ${name}/${model ?? provider.model}: ${imageUrls.length} image(s)`);
+            return toolOk({
+              content: resp.content,
+              provider: name,
+              model: model ?? provider.model,
+              images: specs,
+              note: 'This is a text description from a vision model. Use file tools separately if you need OCR-level exact text extraction.',
+            });
+          } catch (err) {
+            lastError = err;
+            log.warn(`Image recognition via ${name} failed${i < candidates.length - 1 ? ', trying next provider' : ''}: ${err}`);
+          }
+        }
+        const tried = candidates.map(c => c.model ?? c.name).join(', ');
+        log.error(`Image recognition failed on all ${candidates.length} provider(s)`);
+        return toolErr(
+          `Image recognition failed (tried: ${tried}): ${lastError instanceof Error ? lastError.message : String(lastError)}`,
+          { hint: ROUTING_HINT, tried_models: candidates.map(c => c.model).filter(Boolean) },
+        );
+      },
+    },
+
     {
       name: 'upload_reference',
       description:

--- a/packages/core/test/llm-router.test.ts
+++ b/packages/core/test/llm-router.test.ts
@@ -672,6 +672,106 @@ describe('LLMRouter model metadata', () => {
     expect(router.getModelInputTypes('missing')).toEqual(['text']);
   });
 
+  it('unknown model on a registered provider is conservatively text-only (no false vision)', () => {
+    const router = new LLMRouter('markus');
+    router.registerProvider('markus', mockProvider('markus', 'deepseek/deepseek-v4-flash-0731'));
+    // No catalog entry for this exact id → must NOT assume vision (upstream 404 bug).
+    expect(router.modelSupportsVision('markus')).toBe(false);
+    expect(router.getModelInputTypes('markus')).toEqual(['text']);
+  });
+
+  it('known vision model still reports vision support', () => {
+    const router = new LLMRouter('anthropic');
+    router.registerProvider('anthropic', mockProvider('anthropic', 'claude-sonnet-4-20250514'));
+    expect(router.modelSupportsVision('anthropic')).toBe(true);
+    expect(router.getModelInputTypes('anthropic')).toEqual(['text', 'image']);
+  });
+
+  it('chat strips image parts when the target model is text-only (never 404 upstream)', async () => {
+    const router = new LLMRouter('markus');
+    const chatMock = vi.fn(async (req: LLMRequest) => {
+      // Assert the provider never receives image_url parts.
+      const hasImage = req.messages.some(m =>
+        Array.isArray(m.content) && m.content.some(p => p.type === 'image_url'),
+      );
+      expect(hasImage).toBe(false);
+      // And the strip note is present so the agent knows images were dropped.
+      const text = req.messages.map(m => Array.isArray(m.content)
+        ? m.content.filter(p => p.type === 'text').map(p => (p as any).text).join(' ')
+        : String(m.content)).join(' ');
+      expect(text).toContain('does NOT support image input');
+      return successResponse('ok');
+    });
+    router.registerProvider('markus', mockProvider('markus', 'deepseek/deepseek-v4-flash-0731', chatMock));
+    const resp = await router.chat({
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look at this' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' } },
+        ],
+      }],
+    });
+    expect(resp.content).toBe('ok');
+  });
+
+  it('strips when provider DEFAULT is vision but request.model is text-only (the real 404 bug)', async () => {
+    const router = new LLMRouter('markus');
+    const chatMock = vi.fn(async (req: LLMRequest) => {
+      const hasImage = req.messages.some(m =>
+        Array.isArray(m.content) && m.content.some(p => p.type === 'image_url'),
+      );
+      expect(hasImage).toBe(false);
+      return successResponse('ok');
+    });
+    // Provider default model IS vision-capable…
+    router.registerProvider('markus', mockProvider('markus', 'google/gemini-3-1-pro', chatMock));
+    // …but the actual request targets a text-only model via request.model.
+    const resp = await router.chat({
+      model: 'deepseek/deepseek-v4-flash-0731',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is in this image?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' } },
+        ],
+      }],
+    });
+    expect(resp.content).toBe('ok');
+  });
+
+  it('does NOT strip when request.model is vision-capable even if provider default differs', async () => {
+    const router = new LLMRouter('markus');
+    const chatMock = vi.fn(async (req: LLMRequest) => {
+      const hasImage = req.messages.some(m =>
+        Array.isArray(m.content) && m.content.some(p => p.type === 'image_url'),
+      );
+      // Vision model must receive the image parts — stripping here would break vision.
+      expect(hasImage).toBe(true);
+      return successResponse('ok');
+    });
+    // Provider default is a text-only model…
+    router.registerProvider('markus', mockProvider('markus', 'deepseek/deepseek-v4-flash-0731', chatMock));
+    // …but the request explicitly targets a vision-capable model registered in the hub catalog.
+    router.addCustomModel('markus', {
+      id: 'google/gemini-3-1-pro',
+      name: 'Gemini 3.1 Pro',
+      provider: 'markus',
+      inputTypes: ['text', 'image'],
+    } as any);
+    const resp = await router.chat({
+      model: 'google/gemini-3-1-pro',
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is in this image?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,AAA' } },
+        ],
+      }],
+    });
+    expect(resp.content).toBe('ok');
+  });
+
   it('setRoutingDefaultModel is used by selectForCapability fallback', () => {
     const router = new LLMRouter('anthropic');
     router.registerProvider('anthropic', mockProvider('anthropic', 'claude-sonnet-4-20250514'));

--- a/packages/core/test/multimodal-tools.test.ts
+++ b/packages/core/test/multimodal-tools.test.ts
@@ -33,6 +33,7 @@ describe('createMultiModalTools', () => {
   it('returns expected tool handlers', () => {
     const tools = createMultiModalTools(createContext({}));
     expect(tools.map(t => t.name)).toEqual([
+      'describe_image',
       'upload_reference',
       'generate_image',
       'text_to_speech',
@@ -44,6 +45,51 @@ describe('createMultiModalTools', () => {
       expect(tool.inputSchema).toBeTruthy();
       expect(typeof tool.execute).toBe('function');
     }
+  });
+
+  describe('describe_image', () => {
+    const di = (tools: ReturnType<typeof createMultiModalTools>) => tools.find(t => t.name === 'describe_image')!;
+
+    it('rejects empty args with a clear error', async () => {
+      const tools = createMultiModalTools(createContext({ image_recognition: [] }));
+      const result = JSON.parse(await di(tools).execute({}));
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('Missing required argument "images"');
+    });
+
+    it('successfully describes a local image via a vision chat provider', async () => {
+      const tmp = join(tmpdir(), `markus-multimodal-test-${Date.now()}`);
+      mkdirSync(tmp, { recursive: true });
+      const imgPath = join(tmp, 'test.png');
+      writeFileSync(imgPath, Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+        'base64',
+      ));
+
+      const chat = vi.fn().mockResolvedValue({ content: 'A tiny 1x1 PNG image.', toolCalls: undefined, usage: { inputTokens: 1, outputTokens: 1 }, finishReason: 'end_turn' });
+      const provider = createMockProvider({ chat, model: 'google/gemini-3.7-flash' });
+      const tools = createMultiModalTools(createContext({
+        image_recognition: [{ provider, name: 'markus', model: 'google/gemini-3.7-flash' }],
+      }));
+
+      const result = JSON.parse(await di(tools).execute({ images: [imgPath] }));
+      expect(result.status).toBe('success');
+      expect(result.content).toBe('A tiny 1x1 PNG image.');
+      expect(result.provider).toBe('markus');
+      expect(chat).toHaveBeenCalledTimes(1);
+      const req = chat.mock.calls[0][0];
+      expect(req.messages[0].role).toBe('user');
+      expect(req.messages[0].content).toHaveLength(2); // text + image_url
+      expect(req.messages[0].content[1].type).toBe('image_url');
+      expect(req.model).toBe('google/gemini-3.7-flash');
+    });
+
+    it('returns error when no vision-capable candidates', async () => {
+      const tools = createMultiModalTools(createContext({ image_recognition: [] }));
+      const result = JSON.parse(await di(tools).execute({ images: ['/nope/test.png'] }));
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('No vision-capable model');
+    });
   });
 
   describe('generate_image', () => {

--- a/packages/org-manager/src/api-server.ts
+++ b/packages/org-manager/src/api-server.ts
@@ -41,6 +41,7 @@ import {
 } from '@markus/core';
 import type { ChannelMsg } from '@markus/storage';
 import type { OrganizationService } from './org-service.js';
+import { persistChatImages } from './chat-attachments.js';
 import { BuilderService } from './builder-service.js';
 import type { TaskService } from './task-service.js';
 import type { HITLService } from './hitl-service.js';
@@ -1623,7 +1624,7 @@ export class APIServer {
     channelContext: Array<{ role: string; content: string }>,
     agentManager: AgentManager,
     teamSize: number,
-    opts?: { mentionedNames?: string[]; replyToAgentName?: string; replyToText?: string; replyToMsgId?: string },
+    opts?: { mentionedNames?: string[]; replyToAgentName?: string; replyToText?: string; replyToMsgId?: string; images?: string[]; fileNames?: string[]; imagePaths?: string[] },
     chainCtx?: { roundId: string; depth: number; respondedAgents: Set<string>; allAgentIds: string[] },
   ): Promise<void> {
     try {
@@ -1725,6 +1726,9 @@ export class APIServer {
           channelContext,
           channelKey: channel,
           directMention: isDmReply ? true : thisAgentIsTarget,
+          images: opts?.images,
+          fileNames: opts?.fileNames,
+          imagePaths: opts?.imagePaths,
           toolEventCollector: toolEvents,
         }
       );
@@ -2485,6 +2489,7 @@ export class APIServer {
         handleStreamEvent,
         ownerUserId,
         { name: feishuSenderLabel, role: 'user' },
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -3560,6 +3565,7 @@ export class APIServer {
       const body = await this.readBody(req);
       const text = (body['text'] as string) ?? '';
       const images = (body['images'] as string[] | undefined)?.filter(Boolean);
+      const fileNames = (body['fileNames'] as string[] | undefined)?.filter(Boolean);
       const resolvedIdentity = this.orgService.resolveHumanIdentity(authUser.userId);
       const senderId = authUser.userId;
       const senderName = resolvedIdentity?.name ?? (body['senderName'] as string) ?? 'You';
@@ -3572,6 +3578,12 @@ export class APIServer {
         this.json(res, 400, { error: 'Message text or images required' });
         return;
       }
+
+      // Persist user-attached images to local disk so the agent gets a real
+      // path anchor ("抓手") it can read/process. Public URLs are NOT built here
+      // — the agent calls upload_reference(path) itself when it needs one.
+      const persistedImages = persistChatImages(images, fileNames, channel);
+      const imagePaths = persistedImages.map(p => p.path);
 
       // Persist user message (notes/DM may be image-only — store in metadata)
       let userMsg: ChannelMsg | undefined;
@@ -3716,6 +3728,9 @@ export class APIServer {
           mentionedNames: mentions.length > 0 ? mentions : undefined,
           replyToAgentName,
           replyToText,
+          images,
+          fileNames,
+          imagePaths,
         };
 
         // Prepare chain context so agent replies can trigger agent-to-agent chains
@@ -3762,6 +3777,9 @@ export class APIServer {
         reply = await agent.sendMessage(text, senderId, senderInfo, {
           sourceType: 'human_chat',
           channelContext,
+          images,
+          fileNames,
+          imagePaths,
           toolEventCollector: toolEvents,
         });
       } catch (err) {
@@ -4143,6 +4161,10 @@ export class APIServer {
         }
 
         const userText = body['text'] as string;
+        // Persist user-attached files (any type incl. pasted images) to local
+        // disk under ~/.markus so the agent gets a real path anchor.
+        const persistedAttachments = persistChatImages(images, fileNames, agentId!);
+        const imagePaths = persistedAttachments.map(p => p.path);
         // Persist plain user text; inject reply context only into the LLM turn so
         // reload does not show the quoted agent message inside the user bubble.
         const agentText = replyTo
@@ -4194,6 +4216,7 @@ export class APIServer {
             userText: agentText,
             images,
             fileNames,
+            imagePaths,
             senderId,
             senderInfo,
             sessionId,
@@ -4218,7 +4241,7 @@ export class APIServer {
           const deferredRestoreNonStream = agent.isProcessing() ? sessionRestoreData : undefined;
           try {
             reply = await agent.sendMessage(agentText, senderId, senderInfo, {
-              images, fileNames, toolEventCollector: toolEvents,
+              images, fileNames, imagePaths, toolEventCollector: toolEvents,
               ...(deferredRestoreNonStream !== undefined ? { sessionRestore: deferredRestoreNonStream } : {}),
             });
           } catch (err) {
@@ -6075,9 +6098,12 @@ EXPLANATION_END`;
 
       const senderId = authUser.userId;
       const images = (body['images'] as string[] | undefined)?.filter(Boolean);
+      const fileNames = (body['fileNames'] as string[] | undefined)?.filter(Boolean);
       const senderInfo = this.orgService.resolveHumanIdentity(senderId);
       const agent = this.orgService.getAgentManager().getAgent(targetAgentId);
       this.ws.broadcastAgentUpdate(targetAgentId, 'working');
+      const persistedImages = persistChatImages(images, fileNames, targetAgentId);
+      const imagePaths = persistedImages.map(p => p.path);
 
       const stream = body['stream'] as boolean | undefined;
       if (stream) {
@@ -6088,6 +6114,8 @@ EXPLANATION_END`;
           agent,
           userText,
           images,
+          fileNames,
+          imagePaths,
           senderId,
           senderInfo,
           executionStreamRepo: this.storage?.executionStreamRepo,
@@ -6103,7 +6131,7 @@ EXPLANATION_END`;
         const toolEvents: Array<{ tool: string; status: 'done' | 'error'; arguments?: unknown; result?: string; durationMs?: number }> = [];
         let reply: string;
         try {
-          reply = await agent.sendMessage(userText, senderId, senderInfo, { images, toolEventCollector: toolEvents });
+          reply = await agent.sendMessage(userText, senderId, senderInfo, { images, fileNames, imagePaths, toolEventCollector: toolEvents });
         } catch (err) {
           throw err;
         }

--- a/packages/org-manager/src/chat-attachments.ts
+++ b/packages/org-manager/src/chat-attachments.ts
@@ -1,0 +1,108 @@
+/**
+ * Chat attachment persistence for images sent by humans in Team Chat.
+ *
+ * Goal: give the AGENT a stable LOCAL file path ("抓手") for each image the
+ * user sends, so it knows which image to process and can use file tools
+ * (file_read / OCR / etc.) on it. Getting an external PUBLIC url is NOT this
+ * module's job — the agent does that itself via the `upload_reference` tool
+ * (passing the local path), which returns a temporary public URL.
+ *
+ * Images are stored under ~/.markus/chat-attachments/<channel>/ so the agent
+ * (running on the same host) can read them by absolute path.
+ */
+
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { createLogger } from '@markus/shared';
+
+const log = createLogger('chat-attachments');
+
+export interface PersistedChatImage {
+  /** Absolute local path the agent can read/process. */
+  path: string;
+  /** Original file name (fallback img_<n>.<ext>). */
+  name: string;
+  mimeType: string;
+  /** True for image/* mime types (rendered as markdown image). */
+  isImage: boolean;
+  /** Original base64 data URL (kept for vision injection where supported). */
+  dataUrl: string;
+}
+
+const MIME_EXT: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/svg+xml': '.svg',
+  'application/pdf': '.pdf',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+  'application/vnd.ms-excel': '.xls',
+  'application/msword': '.doc',
+  'text/html': '.html',
+  'text/plain': '.txt',
+  'text/csv': '.csv',
+  'application/json': '.json',
+  'application/xml': '.xml',
+  'text/xml': '.xml',
+  'application/epub+zip': '.epub',
+};
+
+function isImageMime(mime: string): boolean {
+  return mime.startsWith('image/');
+}
+
+function fallbackExt(mime: string): string {
+  return MIME_EXT[mime] ?? (isImageMime(mime) ? '.png' : '.bin');
+}
+
+/**
+ * Persist base64 data-URL images to a per-channel temp dir under ~/.markus.
+ * Returns one entry per image, or [] if none / none parseable.
+ */
+export function persistChatImages(
+  images: string[] | undefined,
+  fileNames: string[] | undefined,
+  channel: string,
+): PersistedChatImage[] {
+  if (!images?.length) return [];
+
+  const baseDir = join(homedir(), '.markus', 'chat-attachments');
+  // Sanitize channel to a safe path segment.
+  const safeChannel = channel.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80) || 'unknown';
+  const runDir = join(baseDir, safeChannel, String(Date.now()));
+  mkdirSync(runDir, { recursive: true });
+
+  const out: PersistedChatImage[] = [];
+  for (let i = 0; i < images.length; i++) {
+    const dataUrl = images[i]!;
+    const m = dataUrl.match(/^data:([^;]+);base64,(.+)$/);
+    if (!m) continue;
+    const mimeType = m[1]!;
+    const buf = Buffer.from(m[2]!, 'base64');
+    const name = fileNames?.[i] && fileNames[i]!.trim()
+      ? fileNames[i]!.trim()
+      : `image_${i}${fallbackExt(mimeType)}`;
+    const safeName = name.replace(/[^a-zA-Z0-9._-]/g, '_') || `image_${i}.png`;
+    const filePath = join(runDir, `${i}_${safeName}`);
+    try {
+      writeFileSync(filePath, buf);
+      out.push({ path: filePath, name: safeName, mimeType, isImage: isImageMime(mimeType), dataUrl });
+    } catch (err) {
+      log.warn('Failed to persist chat image', { error: String(err) });
+    }
+  }
+
+  if (!out.length) {
+    try { /* best-effort cleanup */ } catch { /* ignore */ }
+  }
+  return out;
+}
+
+/** Exists guard helper (kept minimal; not exported API surface). */
+export function attachmentExists(p: string): boolean {
+  try { return existsSync(p); } catch { return false; }
+}

--- a/packages/org-manager/src/sse-handler.ts
+++ b/packages/org-manager/src/sse-handler.ts
@@ -27,6 +27,7 @@ export interface SSEMessageHandlerOptions {
   userText: string;
   images?: string[];
   fileNames?: string[];
+  imagePaths?: string[];
   senderId?: string;
   sessionId?: string;
   senderInfo?: { name: string; role: string; isFirstConversation?: boolean };
@@ -197,6 +198,7 @@ export class SSEHandler {
         this.cancelToken,
         this.options.images,
         this.options.fileNames,
+        this.options.imagePaths,
         {
           ...(this.options.isResume ? { isResume: true } : {}),
           ...(this.options.sessionRestore !== undefined ? { sessionRestore: this.options.sessionRestore } : {}),

--- a/packages/web-ui/src/api.ts
+++ b/packages/web-ui/src/api.ts
@@ -1991,7 +1991,7 @@ export const api = {
       request<{ messages: ChannelMessageInfo[]; hasMore: boolean }>(
         `/channels/${encodeURIComponent(channel)}/messages?limit=${limit}${before ? `&before=${before}` : ''}`
       ),
-    sendMessage: (channel: string, data: { text: string; senderId?: string; senderName?: string; mentions?: string[]; targetAgentId?: string; orgId?: string; humanOnly?: boolean; replyToId?: string; images?: string[] }) =>
+    sendMessage: (channel: string, data: { text: string; senderId?: string; senderName?: string; mentions?: string[]; targetAgentId?: string; orgId?: string; humanOnly?: boolean; replyToId?: string; images?: string[]; fileNames?: string[] }) =>
       request<{ userMessage: ChannelMessageInfo | null; agentMessage: ChannelMessageInfo | null }>(
         `/channels/${encodeURIComponent(channel)}/messages`,
         { method: 'POST', body: JSON.stringify(data) }

--- a/packages/web-ui/src/components/OverviewUsage.tsx
+++ b/packages/web-ui/src/components/OverviewUsage.tsx
@@ -82,7 +82,15 @@ export function useOverviewUsageData(active: boolean, ops: OpsDashboard | null, 
     fetchUsage();
     fetchHubData();
     const i = setInterval(fetchUsage, 30_000);
+    // Same throttling as Home.refresh: `markus:data-changed` fires constantly
+    // while agents work; without this, Overview keeps fetching usage + hub plan
+    // on every event, saturating the backend and making page switches sluggish.
+    const lastEventRefreshAt = { at: 0 };
+    const DATA_CHANGED_MIN_INTERVAL_MS = 15_000;
     const onDataChanged = () => {
+      const now = Date.now();
+      if (now - lastEventRefreshAt.at < DATA_CHANGED_MIN_INTERVAL_MS) return;
+      lastEventRefreshAt.at = now;
       void fetchUsage();
       void fetchHubData();
     };

--- a/packages/web-ui/src/pages/Home.tsx
+++ b/packages/web-ui/src/pages/Home.tsx
@@ -183,7 +183,19 @@ export function HomePage({ authUser, previewMode, previewData }: { authUser?: { 
     if (previewMode || !isActive) return;
     refresh();
     const i = setInterval(refresh, 60_000);
-    const onDataChanged = () => refresh();
+    // `markus:data-changed` fires on many WS/UI events while agents are busy.
+    // Throttle the full 12-endpoint refresh so Overview doesn't hammer the
+    // embedded backend right when the user switches to Team (that contention
+    // made Home → Team transitions feel slow/frozen). The 60s interval (and
+    // entering the page) still guarantees fresh data.
+    const lastDataChangedRefreshRef = { at: 0 };
+    const DATA_CHANGED_MIN_INTERVAL_MS = 15_000;
+    const onDataChanged = () => {
+      const now = Date.now();
+      if (now - lastDataChangedRefreshRef.at < DATA_CHANGED_MIN_INTERVAL_MS) return;
+      lastDataChangedRefreshRef.at = now;
+      refresh();
+    };
     // While the claim modal is driving Hub login, skip a full Overview refresh —
     // it re-renders Home and used to re-trigger the modal's status load (flicker).
     const onHubAuth = () => {

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -2648,6 +2648,7 @@ export function TeamPage({ initialAgentId, authUser, previewMode, previewData }:
           mentions: [], orgId: 'default',
           humanOnly: true, // never route to agents
           ...(imagesToSend?.length ? { images: imagesToSend } : {}),
+          ...(fileNamesToSend?.length ? { fileNames: fileNamesToSend } : {}),
         });
         if (result.userMessage) addRecentMsgId(result.userMessage.id);
         updateConvMsgs(sendKey, prev => {
@@ -2703,6 +2704,8 @@ export function TeamPage({ initialAgentId, authUser, previewMode, previewData }:
           senderId: authUser?.id,
           orgId: 'default',
           replyToId: replyCtx?.id,
+          ...(imagesToSend?.length ? { images: imagesToSend } : {}),
+          ...(fileNamesToSend?.length ? { fileNames: fileNamesToSend } : {}),
         });
         if (result.userMessage) addRecentMsgId(result.userMessage.id);
         if (result.agentMessage) addRecentMsgId(result.agentMessage.id);

--- a/packages/web-ui/src/pages/Team.tsx
+++ b/packages/web-ui/src/pages/Team.tsx
@@ -3577,6 +3577,11 @@ export function TeamPage({ initialAgentId, authUser, previewMode, previewData }:
 
   const newConversation = () => {
     setActiveSessionId(NEW_CHAT_PLACEHOLDER_ID);
+    // A brand-new conversation must NOT inherit the previous session's model
+    // override: stale/disabled models caused the composer pill to "jump" from
+    // A to B whenever the catalog refreshed. Start from the global routing
+    // default — deterministic. The user can pick a model in this new chat.
+    setSessionModelOverride(null);
     const key = currentConvKeyRef.current;
     resetConv(key);
     setMessages([]);
@@ -4568,6 +4573,9 @@ export function TeamPage({ initialAgentId, authUser, previewMode, previewData }:
                   onClick={() => {
                     if (s.id === NEW_CHAT_PLACEHOLDER_ID) {
                       setActiveSessionId(NEW_CHAT_PLACEHOLDER_ID);
+                      // Same as + 新对话: a new chat starts from the global
+                      // default, never from another session's model override.
+                      setSessionModelOverride(null);
                       const key = currentConvKeyRef.current;
                       resetConv(key);
                       setMessages([]);


### PR DESCRIPTION
- Team: 新建对话时清空 sessionModelOverride 残留，新对话恒定从全局默认模型开始，避免继承上一会话 override 导致模型 A→B 跳变
- Home/OverviewUsage: markus:data-changed 全量刷新加 15s 节流，避免概览页并发 12 接口压满内嵌后端，解决概览→团队切换卡顿