### PR TITLE
release v0.9.7-rc.5: fix(publish): Trusted Publishing 升级 npm CLI>=11.5.1 + provenance + repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,9 +5,13 @@ on:
     tags:
       - 'v*'
 
+# Trusted publishing (npm): id-token: write lets GitHub Actions mint an OIDC
+# token that npm CLI auto-exchanges for a short-lived publish token, so we no
+# longer rely on a long-lived NPM_TOKEN. See https://docs.npmjs.com/trusted-publishers
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 jobs:
   publish-npm:
@@ -64,10 +68,8 @@ jobs:
           # npm pack dry-run must include the zip
           cd packages/cli && npm pack --dry-run 2>&1 | grep -F 'markus-browser-extension.zip'
 
-      - name: Publish to npm
+      - name: Publish to npm (Trusted Publishing)
         run: cd packages/cli && npm publish --access public --tag ${{ steps.meta.outputs.npm_tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   build-server-binary:
     needs: publish-npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,8 +68,11 @@ jobs:
           # npm pack dry-run must include the zip
           cd packages/cli && npm pack --dry-run 2>&1 | grep -F 'markus-browser-extension.zip'
 
+      - name: Upgrade npm CLI (Trusted Publishing needs >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Publish to npm (Trusted Publishing)
-        run: cd packages/cli && npm publish --access public --tag ${{ steps.meta.outputs.npm_tag }}
+        run: cd packages/cli && npm publish --access public --provenance --tag ${{ steps.meta.outputs.npm_tag }}
 
   build-server-binary:
     needs: publish-npm

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/package.json
+++ b/package.json
@@ -53,5 +53,5 @@
       "node-pty"
     ]
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/a2a/package.json
+++ b/packages/a2a/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -13,5 +13,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -13,5 +13,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/chrome-extension/package.json
+++ b/packages/chrome-extension/package.json
@@ -13,5 +13,5 @@
     "esbuild": "^0.25.0",
     "typescript": "^5.6.0"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -41,5 +41,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,13 @@
   "description": "Markus — AI Digital Workforce Platform",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/markus-global/markus.git"
+  },
+  "publishConfig": {
+    "provenance": true
+  },
   "bin": {
     "markus": "dist/markus.mjs"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,5 +48,5 @@
     "commander": "^14.0.3",
     "esbuild": "^0.27.4"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/comms/package.json
+++ b/packages/comms/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/core/data/model-catalog-baseline.json
+++ b/packages/core/data/model-catalog-baseline.json
@@ -10052,6 +10052,21 @@
         "output_cost_per_second": 0.0066027,
         "supports_tool_choice": true
     },
+    "bedrock/guardrails": {
+        "guardrail_cost_per_unit": {
+            "automatedReasoningPolicyUnits": 0.00017,
+            "contentPolicyImageUnits": 0.00075,
+            "contentPolicyUnits": 0.00015,
+            "contextualGroundingPolicyUnits": 0.0001,
+            "sensitiveInformationPolicyFreeUnits": 0.0,
+            "sensitiveInformationPolicyUnits": 0.0001,
+            "topicPolicyUnits": 0.00015,
+            "wordPolicyUnits": 0.0
+        },
+        "litellm_provider": "bedrock",
+        "mode": "guardrail",
+        "source": "https://aws.amazon.com/bedrock/pricing/"
+    },
     "bedrock/ap-northeast-1/1-month-commitment/anthropic.claude-instant-v1": {
         "input_cost_per_second": 0.01475,
         "litellm_provider": "bedrock",
@@ -14441,6 +14456,25 @@
         "supports_tool_choice": true,
         "supports_output_config": true
     },
+    "databricks/databricks-claude-opus-4-6": {
+        "input_cost_per_token": 5.00003e-06,
+        "input_dbu_cost_per_token": 7.1429e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 2.5000010000000002e-05,
+        "output_dbu_cost_per_token": 0.000357143,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "databricks/databricks-claude-sonnet-4": {
         "input_cost_per_token": 2.9999900000000002e-06,
         "input_dbu_cost_per_token": 4.2857e-05,
@@ -14498,6 +14532,25 @@
         "supports_reasoning": true,
         "supports_tool_choice": true
     },
+    "databricks/databricks-claude-sonnet-4-6": {
+        "input_cost_per_token": 2.9999900000000002e-06,
+        "input_dbu_cost_per_token": 4.2857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1000000,
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_assistant_prefill": true,
+        "supports_function_calling": true,
+        "supports_reasoning": true,
+        "supports_tool_choice": true
+    },
     "databricks/databricks-gemini-2-5-flash": {
         "input_cost_per_token": 3.0001999999999996e-07,
         "input_dbu_cost_per_token": 4.285999999999999e-06,
@@ -14528,6 +14581,74 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-1-flash-lite": {
+        "input_cost_per_token": 3.1248e-07,
+        "input_dbu_cost_per_token": 4.464e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.87502e-06,
+        "output_dbu_cost_per_token": 2.6786e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-1-pro": {
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-flash": {
+        "input_cost_per_token": 6.2503e-07,
+        "input_dbu_cost_per_token": 8.929e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 3.74997e-06,
+        "output_dbu_cost_per_token": 5.3571e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
+        "supports_function_calling": true,
+        "supports_tool_choice": true
+    },
+    "databricks/databricks-gemini-3-pro": {
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 1048576,
+        "max_output_tokens": 65536,
+        "max_tokens": 65536,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving",
         "supports_function_calling": true,
         "supports_tool_choice": true
@@ -14575,6 +14696,126 @@
         "mode": "chat",
         "output_cost_per_token": 9.999990000000002e-06,
         "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-1-codex-max": {
+        "input_cost_per_token": 1.24999e-06,
+        "input_dbu_cost_per_token": 1.7857e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 9.999990000000002e-06,
+        "output_dbu_cost_per_token": 0.000142857,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-1-codex-mini": {
+        "input_cost_per_token": 2.4997e-07,
+        "input_dbu_cost_per_token": 3.571e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.99997e-06,
+        "output_dbu_cost_per_token": 2.8571e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-2": {
+        "input_cost_per_token": 1.75e-06,
+        "input_dbu_cost_per_token": 2.5e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_dbu_cost_per_token": 0.0002,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-2-codex": {
+        "input_cost_per_token": 1.75e-06,
+        "input_dbu_cost_per_token": 2.5e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_dbu_cost_per_token": 0.0002,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-3-codex": {
+        "input_cost_per_token": 1.75e-06,
+        "input_dbu_cost_per_token": 2.5e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.4e-05,
+        "output_dbu_cost_per_token": 0.0002,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-4": {
+        "input_cost_per_token": 2.49998e-06,
+        "input_dbu_cost_per_token": 3.5714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.5000020000000002e-05,
+        "output_dbu_cost_per_token": 0.000214286,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-4-mini": {
+        "input_cost_per_token": 7.4998e-07,
+        "input_dbu_cost_per_token": 1.0714e-05,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 4.50002e-06,
+        "output_dbu_cost_per_token": 6.4286e-05,
+        "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
+    },
+    "databricks/databricks-gpt-5-4-nano": {
+        "input_cost_per_token": 1.9999e-07,
+        "input_dbu_cost_per_token": 2.857e-06,
+        "litellm_provider": "databricks",
+        "max_input_tokens": 272000,
+        "max_output_tokens": 128000,
+        "max_tokens": 128000,
+        "metadata": {
+            "notes": "Input/output cost per token is dbu cost * $0.070. Number provided for reference, '*_dbu_cost_per_token' used in actual calculation."
+        },
+        "mode": "chat",
+        "output_cost_per_token": 1.24999e-06,
+        "output_dbu_cost_per_token": 1.7857e-05,
         "source": "https://www.databricks.com/product/pricing/proprietary-foundation-model-serving"
     },
     "databricks/databricks-gpt-5-mini": {
@@ -19424,20 +19665,20 @@
         "web_search_billing_unit": "per_query"
     },
     "vertex_ai/gemini-3.6-flash": {
-        "cache_read_input_token_cost": 1.5e-07,
-        "cache_read_input_token_cost_flex": 7.5e-08,
-        "input_cost_per_token": 1.5e-06,
-        "input_cost_per_token_batches": 7.5e-07,
-        "input_cost_per_token_flex": 7.5e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
         "litellm_provider": "vertex_ai",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_reasoning_token": 7.5e-06,
-        "output_cost_per_token": 7.5e-06,
-        "output_cost_per_token_batches": 3.75e-06,
-        "output_cost_per_token_flex": 3.75e-06,
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -19467,9 +19708,9 @@
         "supports_vision": true,
         "supports_web_search": true,
         "supports_native_streaming": true,
-        "input_cost_per_token_priority": 2.7e-06,
-        "output_cost_per_token_priority": 1.35e-05,
-        "cache_read_input_token_cost_priority": 2.7e-07,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.014,
@@ -21150,20 +21391,20 @@
         "web_search_billing_unit": "per_query"
     },
     "gemini/gemini-3.6-flash": {
-        "cache_read_input_token_cost": 1.5e-07,
-        "cache_read_input_token_cost_flex": 7.5e-08,
-        "input_cost_per_token": 1.5e-06,
-        "input_cost_per_token_batches": 7.5e-07,
-        "input_cost_per_token_flex": 7.5e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
         "litellm_provider": "gemini",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_reasoning_token": 7.5e-06,
-        "output_cost_per_token": 7.5e-06,
-        "output_cost_per_token_batches": 3.75e-06,
-        "output_cost_per_token_flex": 3.75e-06,
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
         "rpm": 2000,
         "source": "https://ai.google.dev/pricing/gemini-3",
         "supported_endpoints": [
@@ -21196,9 +21437,9 @@
         "supports_web_search": true,
         "supports_native_streaming": true,
         "tpm": 800000,
-        "input_cost_per_token_priority": 2.7e-06,
-        "output_cost_per_token_priority": 1.35e-05,
-        "cache_read_input_token_cost_priority": 2.7e-07,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.014,
@@ -21544,20 +21785,20 @@
         "web_search_billing_unit": "per_query"
     },
     "gemini-3.6-flash": {
-        "cache_read_input_token_cost": 1.5e-07,
-        "cache_read_input_token_cost_flex": 7.5e-08,
-        "input_cost_per_token": 1.5e-06,
-        "input_cost_per_token_batches": 7.5e-07,
-        "input_cost_per_token_flex": 7.5e-07,
+        "cache_read_input_token_cost": 7.5e-08,
+        "cache_read_input_token_cost_flex": 3.75e-08,
+        "input_cost_per_token": 7.5e-07,
+        "input_cost_per_token_batches": 3.75e-07,
+        "input_cost_per_token_flex": 3.75e-07,
         "litellm_provider": "vertex_ai-language-models",
         "max_input_tokens": 1048576,
         "max_output_tokens": 65536,
         "max_tokens": 65536,
         "mode": "chat",
-        "output_cost_per_reasoning_token": 7.5e-06,
-        "output_cost_per_token": 7.5e-06,
-        "output_cost_per_token_batches": 3.75e-06,
-        "output_cost_per_token_flex": 3.75e-06,
+        "output_cost_per_reasoning_token": 3.75e-06,
+        "output_cost_per_token": 3.75e-06,
+        "output_cost_per_token_batches": 1.875e-06,
+        "output_cost_per_token_flex": 1.875e-06,
         "source": "https://ai.google.dev/pricing/gemini-3",
         "supported_endpoints": [
             "/v1/chat/completions",
@@ -21588,9 +21829,9 @@
         "supports_vision": true,
         "supports_web_search": true,
         "supports_native_streaming": true,
-        "input_cost_per_token_priority": 2.7e-06,
-        "output_cost_per_token_priority": 1.35e-05,
-        "cache_read_input_token_cost_priority": 2.7e-07,
+        "input_cost_per_token_priority": 1.35e-06,
+        "output_cost_per_token_priority": 6.75e-06,
+        "cache_read_input_token_cost_priority": 1.35e-07,
         "search_context_cost_per_query": {
             "search_context_size_low": 0.014,
             "search_context_size_medium": 0.014,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,5 +26,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,5 +26,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,5 +26,5 @@
     "@types/turndown": "^5.0.6",
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -37,5 +37,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -37,5 +37,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -37,5 +37,5 @@
     "esbuild": "^0.27.4",
     "typescript": "^5.9.3"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/gui/package.json
+++ b/packages/gui/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/sharp": "^0.32.0"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -22,5 +22,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -22,5 +22,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/org-manager/package.json
+++ b/packages/org-manager/package.json
@@ -22,5 +22,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/remote/package.json
+++ b/packages/remote/package.json
@@ -18,5 +18,5 @@
   "devDependencies": {
     "@types/ws": "^8.18.1"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,5 +10,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,5 +10,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,5 +10,5 @@
     "dev": "tsc -b --watch",
     "clean": "rm -rf dist *.tsbuildinfo"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -13,5 +13,5 @@
   "dependencies": {
     "@markus/shared": "workspace:*"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -62,5 +62,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.7-rc.4"
+  "version": "0.9.7-rc.5"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -62,5 +62,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.7-rc.3"
+  "version": "0.9.7-rc.4"
 }

--- a/packages/web-ui/package.json
+++ b/packages/web-ui/package.json
@@ -62,5 +62,5 @@
     "typescript": "^5.9.3",
     "vite": "^7.3.1"
   },
-  "version": "0.9.7-rc.1"
+  "version": "0.9.7-rc.3"
 }


### PR DESCRIPTION
Version bump v0.9.7-rc.4 → v0.9.7-rc.5